### PR TITLE
fix(exec): run image exec in the machine's persistent overlay

### DIFF
--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -129,7 +129,12 @@ impl ExecCmd {
                     .with_env(env)
                     .with_workdir(self.workdir.clone())
                     .with_timeout(timeout)
-                    .with_tty(self.tty);
+                    .with_tty(self.tty)
+                    // Run in the machine's persistent overlay so filesystem
+                    // changes survive across execs (and join the running main
+                    // container when started detached). Without this each exec
+                    // gets a fresh overlay and writes to `/` vanish.
+                    .with_persistent_overlay(Some(name.clone()));
                 let exit_code = client.run_interactive(config)?;
                 manager.detach();
                 std::process::exit(exit_code);
@@ -138,7 +143,8 @@ impl ExecCmd {
             let config = RunConfig::new(image, command.clone())
                 .with_env(env)
                 .with_workdir(self.workdir.clone())
-                .with_timeout(timeout);
+                .with_timeout(timeout)
+                .with_persistent_overlay(Some(name.clone()));
             let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
             print_and_exit(
                 &manager,


### PR DESCRIPTION
Image-based `smol exec` ran in a fresh overlay each call, so filesystem changes never persisted across execs; this runs it in the machine's persistent overlay to match the smolvm engine's own `machine exec`.