### PR TITLE
fix(macos): add allow-jit entitlement so forkable VMs can boot

### DIFF
--- a/smolvm.entitlements
+++ b/smolvm.entitlements
@@ -6,5 +6,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Forkable golden VMs map guest RAM from a file-backed region HVF executes guest code from, which the macOS hardened runtime blocks (`krun_start_enter -22`) without a JIT entitlement; this adds `com.apple.security.cs.allow-jit` to the entitlements the release/SDK signing scripts use.