### PR TITLE
Let cloud deploy and the SDKs scope a machine's outbound egress to specific hostnames and CIDR ranges

### DIFF
--- a/sdk/node/generated/smolfleet.ts
+++ b/sdk/node/generated/smolfleet.ts
@@ -798,6 +798,7 @@ export interface components {
             mode: "open";
         } | {
             cidrs: string[];
+            hosts?: string[];
             /** @enum {string} */
             mode: "allowCidrs";
         };

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -719,9 +719,18 @@ export async function makeTransport(
           : {}),
         diskGb: config.resources?.storageGb ?? null,
       },
-      ...(config.resources?.network
-        ? { network: { mode: "open" as const } }
-        : {}),
+      ...(config.resources?.allowCidrs?.length ||
+      config.resources?.allowHosts?.length
+        ? {
+            network: {
+              mode: "allowCidrs" as const,
+              cidrs: config.resources.allowCidrs ?? [],
+              hosts: config.resources.allowHosts ?? [],
+            },
+          }
+        : config.resources?.network
+          ? { network: { mode: "open" as const } }
+          : {}),
       // Publish ports: supply only the guest port; the control plane allocates
       // the node host port (read it back from the machine info after start).
       // Publishing a port implies the virtio-net backend on the node.

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -12,6 +12,17 @@ export interface ResourceSpec {
   memoryMb?: number;
   /** Enable outbound network access (TSI). Default: false. */
   network?: boolean;
+  /**
+   * Scope egress to these CIDR ranges. Setting this (or `allowHosts`) enables
+   * networking and restricts it to the listed CIDRs. Cloud target only.
+   */
+  allowCidrs?: string[];
+  /**
+   * Scope egress to these hostnames and their subdomains (e.g.
+   * `api.anthropic.com`). Setting this (or `allowCidrs`) enables networking and
+   * restricts it to the listed hosts. Cloud target only.
+   */
+  allowHosts?: string[];
   /** Storage disk size in GB (default: 20). */
   storageGb?: number;
   /** Overlay disk size in GB (default: 10). */

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -531,7 +531,13 @@ def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None)
             "autoStopSeconds": config.auto_stop_seconds,
             "ttlSeconds": config.ttl_seconds,
         }
-        if r and r.network:
+        if r and (r.allow_cidrs or r.allow_hosts):
+            body["network"] = {
+                "mode": "allowCidrs",
+                "cidrs": r.allow_cidrs or [],
+                "hosts": r.allow_hosts or [],
+            }
+        elif r and r.network:
             body["network"] = {"mode": "open"}
         # Publish ports: supply only the guest port; the control plane allocates
         # the node host port (read the allocated hostPort back from the machine

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -28,6 +28,13 @@ class ResourceSpec:
     """Memory in MB."""
     network: Optional[bool] = None
     """Enable outbound network access (TSI). Default: False."""
+    allow_cidrs: Optional[list[str]] = None
+    """Scope egress to these CIDR ranges. Setting this (or allow_hosts) enables
+    networking and restricts it to the listed CIDRs. Cloud target only."""
+    allow_hosts: Optional[list[str]] = None
+    """Scope egress to these hostnames and their subdomains (e.g.
+    api.anthropic.com). Setting this (or allow_cidrs) enables networking and
+    restricts it to the listed hosts. Cloud target only."""
     storage_gb: Optional[int] = None
     """Storage disk size in GB."""
     overlay_gb: Optional[int] = None

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -37,6 +37,17 @@ pub struct DeployCmd {
     #[arg(long)]
     pub network: bool,
 
+    /// Scope egress to these CIDR ranges (repeatable). Implies `--network`;
+    /// the machine can reach only the listed CIDRs (plus any `--allow-host`).
+    #[arg(long = "allow-cidr", value_name = "CIDR")]
+    pub allow_cidr: Vec<String>,
+
+    /// Scope egress to these hostnames and their subdomains (repeatable).
+    /// Implies `--network`; the machine can reach only the listed hosts
+    /// (plus any `--allow-cidr`). Example: `--allow-host api.anthropic.com`.
+    #[arg(long = "allow-host", value_name = "HOSTNAME")]
+    pub allow_host: Vec<String>,
+
     /// Let ANY signed-in smolmachines user reach the app's URL. Without
     /// `--public` the URL works only for you, the owner. Either way the app sits
     /// behind a smolmachines login — it is never reachable anonymously.
@@ -118,7 +129,9 @@ impl DeployCmd {
         if name.is_empty() {
             anyhow::bail!("invalid reference: name cannot be empty");
         }
-        let network = if self.network {
+        let network = if !self.allow_cidr.is_empty() || !self.allow_host.is_empty() {
+            serde_json::json!({"mode": "allowCidrs", "cidrs": self.allow_cidr, "hosts": self.allow_host})
+        } else if self.network {
             serde_json::json!({"mode": "open"})
         } else {
             serde_json::json!({"mode": "blocked"})


### PR DESCRIPTION
Adds `smol deploy --allow-host`/`--allow-cidr` and the equivalent `allowHosts`/`allowCidrs` fields on the Node and Python SDK resource spec, so a cloud machine can be scoped to reach only named hosts and CIDR ranges instead of fully open or blocked networking.