### PR TITLE
Update the CLI reference so lifecycle verbs live under machine and document the file and registry command groups

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,51 +9,49 @@ Global behavior:
   the file is created `0600`. Secrets (cloud API keys) are masked by `config show`.
 - Logging is controlled by `RUST_LOG` (default `warn`); set `RUST_LOG=debug` for
   verbose output.
-- Related commands are grouped under nouns: `smol pack …` (artifacts),
-  `smol cloud …` (smolfleet), `smol auth …` (login), `smol machine …` (per-machine
-  maintenance). The daily-driver lifecycle verbs stay top-level.
-- `--cloud` on `exec`/`start`/`stop`/`status`/`logs` targets the configured
-  smolfleet cluster instead of the local engine.
+- Commands are grouped under nouns: `smol machine …` (a machine's whole
+  lifecycle), `smol file …` (Smolfile), `smol pack …` (artifacts),
+  `smol registry …` (registries), `smol auth …` (login), `smol cloud …`
+  (smolfleet). `smol run` (ephemeral one-shot) stays top-level.
+- **Local or cloud is resolved automatically.** `smol machine …` commands find a
+  machine wherever it lives — local engine or smolfleet — so `smol machine ls`
+  shows both. Force one side with `--local` / `--cloud`, or with a `local/<name>`
+  / `cloud/<name>` prefix (a `mach-…` id is always cloud).
 
-## Local machine lifecycle
-
-| Command | Description |
-|---------|-------------|
-| `smol run <image> -- <cmd…>` | Boot an **ephemeral** machine, run a command, stream output, exit with its code. |
-| `smol create <name> --image <ref>` | Create a **persistent** machine (does not run a command). Use `--from <path.smolmachine>` to create from a packed artifact (uses its layers, no pull). Restrict egress with `--allow-cidr`/`--allow-host`/`--outbound-localhost-only` (imply `--net`). |
-| `smol start <name>` / `smol stop <name>` | Start / stop a persistent machine. Add `--forkable` to `start` to make it a fork base. |
-| `smol fork --golden <name> --name <clone>` | Clone a running, forkable machine (copy-on-write RAM + disks). The golden must have been started `--forkable`; it then stays frozen as the shared base. `-p HOST:GUEST` pins the clone's ports (otherwise they're remapped to free host ports). |
-| `smol ls` | List machines (`--json` for machine-readable output). |
-| `smol status <name>` | Show one machine's status (`--json`). |
-| `smol rm <name>` | Delete a machine (`--force` to skip the confirmation prompt). |
-
-## Exec, shell & files
+## Ephemeral one-shot — `smol run`
 
 | Command | Description |
 |---------|-------------|
-| `smol exec --name <name> -- <cmd…>` | Run a command in a machine (`--stream` for live output; `-e KEY=VALUE`, `-w DIR`, `-i/-t`). Inject secrets host-side for the call with `--secret-env GUEST=HOST_VAR` / `--secret-file GUEST=/path` (never persisted). |
-| `smol shell --name <name>` | Interactive shell into a local machine (cloud: `smol cloud shell`). |
-| `smol cp <src> <dst>` | Copy files host↔guest (`name:/path` denotes a guest path). |
-| `smol logs <name>` | Fetch machine logs (`--tail N`). |
+| `smol run <image> -- <cmd…>` | Boot an **ephemeral** machine, run a command, stream output, exit with its code, then discard the machine. |
 
-## Machine maintenance — `smol machine …`
+## Machine lifecycle — `smol machine …`
 
 | Command | Description |
 |---------|-------------|
+| `smol machine create <name> --image <ref>` | Create a **persistent** machine (does not run a command). Use `--from <path.smolmachine>` to create from a packed artifact (uses its layers, no pull). Restrict egress with `--allow-cidr`/`--allow-host`/`--outbound-localhost-only` (imply `--net`). |
+| `smol machine start <name>` / `smol machine stop <name>` | Start / stop a persistent machine. Add `--forkable` to `start` to make it a fork base. |
+| `smol machine ls` | List machines, local **and** cloud (`--json`; `--local`/`--cloud` to scope). Alias: `list`. |
+| `smol machine status <name>` | Show one machine's status (`--json`). |
+| `smol machine rm <name>` | Delete a machine (`--force` to skip the confirmation prompt). Alias: `delete`. |
+| `smol machine exec --name <name> -- <cmd…>` | Run a command in a machine (`--stream` for live output; `-e KEY=VALUE`, `-w DIR`, `-i/-t`). Inject secrets host-side for the call with `--secret-env GUEST=HOST_VAR` / `--secret-file GUEST=/path` (never persisted). |
+| `smol machine shell --name <name>` | Interactive shell into a machine. Alias: `sh`. |
+| `smol machine cp <src> <dst>` | Copy files host↔guest (`name:/path` denotes a guest path). |
+| `smol machine logs <name>` | Fetch machine logs (`--tail N`). |
+| `smol machine fork --golden <name> --name <clone>` | Clone a running, forkable machine (copy-on-write RAM + disks). The golden must have been started `--forkable`; it then stays frozen as the shared base. `-p HOST:GUEST` pins the clone's ports (otherwise they're remapped to free host ports). |
 | `smol machine images --name <name>` | List a machine's cached images and storage usage (`--json`). |
 | `smol machine prune --name <name>` | Reclaim a machine's disk: free unreferenced layers, or `--all` to purge the cache (`--dry-run` to preview; `--all` requires the machine stopped). |
 | `smol machine update --name <name> …` | Modify a **stopped** machine: add/remove volumes/ports/env, set `--cpus`/`--mem`/`--workdir`, toggle `--net`/`--gpu`, expand `--storage`/`--overlay` (expand-only). |
 | `smol machine monitor --name <name>` | Supervise a machine in the foreground with health checks (`--health-cmd`, `--interval`, `--health-retries`) and a restart policy (`--restart never\|always\|on-failure\|unless-stopped`). |
 | `smol machine data-dir --name <name>` | Print the machine's on-disk data directory (scripting/debugging). |
 
-## Smolfile (declarative)
+## Smolfile (declarative) — `smol file …`
 
 | Command | Description |
 |---------|-------------|
-| `smol init` | Scaffold a `Smolfile` in the current directory. |
-| `smol up` / `smol down` | Bring the `Smolfile`-defined machine up / down. |
+| `smol file init` | Scaffold a `Smolfile` in the current directory. |
+| `smol file up` / `smol file down` | Bring the `Smolfile`-defined machine up / down. |
 
-## Artifacts & registry — `smol pack …`
+## Artifacts — `smol pack …`
 
 | Command | Description |
 |---------|-------------|
@@ -61,29 +59,40 @@ Global behavior:
 | `smol pack push <ref>` / `smol pack pull <ref>` | Push / pull artifacts to/from a registry. |
 | `smol pack inspect <ref>` | Inspect an artifact in a registry. |
 
+## Registries — `smol registry …`
+
+| Command | Description |
+|---------|-------------|
+| `smol registry ls` | List the registries you have stored credentials for. |
+| `smol registry catalog [host]` | List repositories in a registry (`GET /v2/_catalog`; `--json`). Not every registry exposes the catalog endpoint. |
+| `smol registry tags <reference>` | List the tags of a repository (`--json`). |
+| `smol registry login` / `smol registry logout` | Authenticate to / forget a registry (aliases of `smol auth login` / `logout`). |
+
 ## Authentication — `smol auth …`
 
 | Command | Description |
 |---------|-------------|
-| `smol auth login` / `smol auth logout` | Authenticate to the registry / cloud (OAuth device flow). |
+| `smol auth login` / `smol auth logout` | Authenticate to the registry and cloud (OAuth device flow) — one token covers both the artifact registry and the smolfleet API. |
 
 ## Cloud (smolfleet) — `smol cloud …`
 
+Cloud machines are also reachable through `smol machine …` with `--cloud` (or a
+`cloud/<name>` prefix); this group holds the cloud-only operations.
+
 | Command | Description |
 |---------|-------------|
-| `smol cloud deploy --image <ref>` | Create + start a machine on the cloud cluster. |
+| `smol cloud deploy --image <ref>` | Create + start a machine on the cloud cluster. Scope egress with `--allow-host`/`--allow-cidr`. |
 | `smol cloud ls` | List cloud machines. |
 | `smol cloud rm <id>` | Delete a cloud machine. |
 | `smol cloud scale …` | Scale a cloud deployment. |
-| `smol cloud shell --name <name>` | Interactive shell into a cloud machine. |
-| `smol exec\|start\|stop\|status\|logs --cloud …` | Operate on cloud machines with the flat lifecycle verbs. |
+| `smol cloud shell --name <name>` | Interactive shell into a cloud machine. Alias: `sh`. |
 
-## Config
+## Config — `smol config …`
 
 | Command | Description |
 |---------|-------------|
 | `smol config set <key> <value>` | Set a config value (e.g. cloud endpoint, API key). Plain-HTTP endpoints are rejected for non-loopback hosts. |
 | `smol config show` | Show config (secrets masked). |
 
-> This reference is generated from the command surface; for authoritative flags
-> and defaults always use `smol <command> --help`.
+> This reference is a map of the command surface; for authoritative flags and
+> defaults always use `smol <command> --help`.


### PR DESCRIPTION
Rewrites docs/cli.md to match the noun-group CLI: every per-machine verb is shown under `smol machine …` with its aliases, Smolfile commands move under `smol file …`, and the new `smol registry …` browsing group (catalog/tags) plus automatic local-or-cloud resolution are documented.