### PR TITLE
Bump the smol CLI and SDKs to 1.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,7 +2183,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol-cli"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk", "__engine__"]
 name = "smol-cli"
 # Tracks the bundled smolvm engine release: a `smol` vX.Y.Z ships smolvm vX.Y.Z's
 # libkrun + agent-rootfs, so the host CLI and guest agent can never drift.
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 description = "Ship and run software with isolation by default"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ curl -sSL https://raw.githubusercontent.com/smol-machines/smol/main/scripts/inst
 The script auto-detects your platform, downloads the matching release bundle
 (which carries its own `libkrun` runtime + guest agent), verifies its checksum,
 extracts it to `~/.smol`, and symlinks `smol` onto your `PATH` (`~/.local/bin`).
-Pin a release with `SMOL_VERSION=v1.3.2`; override locations with `PREFIX` /
+Pin a release with `SMOL_VERSION=v1.3.3`; override locations with `PREFIX` /
 `BIN_DIR`. Supports macOS Apple Silicon and Linux x86_64/arm64.
 
 ## Components

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "smol-node"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 description = "Native NAPI core for the smol SDK — embed microVMs directly in Node.js"
 license = "Apache-2.0"

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smolmachines",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Embed isolated microVM sandboxes directly in your code — no server to run.",
   "license": "Apache-2.0",
   "author": "smol-machines",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol-py"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 description = "Native (pyo3) core for the smol Python SDK — embeds the smolvm engine in-process."
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smolmachines"
-version = "1.3.2"
+version = "1.3.3"
 description = "Embed isolated microVM sandboxes directly in your Python code — local (embedded) or smolfleet cloud."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -57,7 +57,7 @@ from .types import (
     ResourceSpec,
 )
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 __all__ = [
     "Machine",


### PR DESCRIPTION
Bring the smol CLI and the Node and Python SDKs to 1.3.3, matching the current smolvm engine release.