### PR TITLE
Bundle the virgl stub into the Python wheel and make npm publish idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,16 @@ jobs:
         # OIDC trusted publishing: no NPM_TOKEN. npm ≥11.5.1 exchanges the GitHub
         # OIDC token (id-token: write) for a short-lived registry credential, and
         # attaches provenance (the repo is public, so provenance is accepted).
-        run: npm publish --access public --provenance
+        # Skip if this exact version is already on npm so a re-run (e.g. to finish
+        # a half-published release) stays green instead of 403-ing on the duplicate
+        # and blocking the gated PyPI publish.
+        run: |
+          VER="$(node -p "require('./package.json').version")"
+          if npm view "smolmachines@$VER" version >/dev/null 2>&1; then
+            echo "smolmachines@$VER already published to npm — skipping"
+          else
+            npm publish --access public --provenance
+          fi
 
   # ─── Python: abi3 wheels (one per platform, Py3.9+) ────────────────────────
   python-wheels:
@@ -409,6 +418,7 @@ jobs:
             auditwheel repair \
               --exclude libkrun.so.1 --exclude libkrunfw.so.5 \
               --exclude libkrun.so --exclude libkrunfw.so \
+              --exclude smol_virgl_stub.so \
               -w dist_manylinux "$whl"
           done
           rm -f dist/*.whl && mv dist_manylinux/*.whl dist/

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -51,6 +51,10 @@ include = [
     "python/smol/libkrunfw*.dylib",
     "python/smol/libkrun*.so*",
     "python/smol/libkrunfw*.so*",
+    # The virgl weak-symbol stub bundle-native.sh compiles next to libkrun so it
+    # loads under RTLD_NOW; without this glob the stub is dropped and libkrun's
+    # NEEDED dangles (auditwheel repair then fails to locate it).
+    "python/smol/smol_virgl_stub.so",
     "python/smol/smol-vmm",
     "python/smol/agent-rootfs.tar",
 ]


### PR DESCRIPTION
Ships the virgl weak-symbol stub inside the Python wheel so libkrun loads under RTLD_NOW and auditwheel can relabel to manylinux, and skips npm publish when the version already exists so a re-run can finish a half-published release without blocking PyPI.