### PR TITLE
Degrade cloud enumeration to local when unavailable; stream cloud cp; unify auth errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,6 +2205,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -2212,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.2.5"
+version = "1.3.6"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2237,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.2.5"
+version = "1.3.6"
 dependencies = [
  "async-stream",
  "axum",
@@ -2266,6 +2267,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "smolfile",
+ "smolvm-cuda",
  "smolvm-network",
  "smolvm-pack",
  "smolvm-protocol",
@@ -2287,8 +2289,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smolvm-cuda"
+version = "1.3.1"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "smolvm-network"
-version = "1.2.5"
+version = "1.3.6"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2300,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.2.5"
+version = "1.3.6"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2319,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.2.5"
+version = "1.3.6"
 dependencies = [
  "base64",
  "serde",
@@ -2329,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.2.5"
+version = "1.3.6"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,10 @@ smolvm-registry = { path = "../crates/smolvm-registry" }
 # rustls (not native-tls) so the build pulls no openssl-sys — which keeps the
 # Linux zigbuild cross-compile pure-Rust (no system OpenSSL headers). Matches the
 # engine's smolvm-registry, so reqwest's features unify on rustls across the tree.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
+# Adapts a tokio file reader into a byte stream for streamed cloud `cp` uploads
+# (so a large file is never read wholly into RAM). `io` feature = ReaderStream.
+tokio-util = { version = "0.7", features = ["io"] }
 # WebSocket client for interactive cloud exec/shell (rustls so the cross-compile
 # stays openssl-free, matching reqwest above).
 tokio-tungstenite = { version = "0.28", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -199,6 +199,50 @@ pub async fn check_response(resp: reqwest::Response, context: &str) -> Result<re
     }
 }
 
+/// Whether a stored api_key counts as "logged in" (present and non-empty).
+fn api_key_is_present(api_key: Option<&str>) -> bool {
+    api_key.is_some_and(|k| !k.is_empty())
+}
+
+/// True when a cloud API key is configured (i.e. the user has logged in).
+///
+/// The best-effort machine enumeration checks this BEFORE firing a request:
+/// with no key the control plane would just answer 401, so we skip the round
+/// trip and degrade to local instead. Explicit cloud verbs don't use this —
+/// they go through [`cloud_client`] and surface auth failures directly.
+pub fn cloud_is_authenticated() -> bool {
+    SmolSettings::load()
+        .map(|s| api_key_is_present(s.cloud.api_key.as_deref()))
+        .unwrap_or(false)
+}
+
+/// Best-effort variant of [`list_machines`] for the unified resolver.
+///
+/// Returns `Ok(None)` for every "cloud unavailable" condition — an unreachable
+/// control plane (connect/timeout, after retries) or rejected/forbidden
+/// credentials (401/403) — so `smol machine ls` and bare-name resolution degrade
+/// to local-only instead of surfacing a network or auth error. A genuine server
+/// error (5xx after retry) or a protocol/decode error still surfaces as `Err`.
+pub async fn list_machines_best_effort(
+    http: &reqwest::Client,
+    endpoint: &str,
+) -> Result<Option<Vec<CloudMachine>>> {
+    let resp =
+        match super::common::send_with_retry(http.get(format!("{}/v1/machines", endpoint))).await {
+            Ok(resp) => resp,
+            // Connection refused / timed out / DNS failure → control plane
+            // unreachable (offline). Degrade to local rather than error.
+            Err(_) => return Ok(None),
+        };
+    // Not authenticated / forbidden → treat as "cloud not available to this user"
+    // (logged out, or a stale/rejected token). Degrade to local.
+    if matches!(resp.status().as_u16(), 401 | 403) {
+        return Ok(None);
+    }
+    let resp = check_response(resp, "list machines").await?;
+    Ok(Some(resp.json().await?))
+}
+
 /// Fetch the list of all cloud machines.
 pub async fn list_machines(http: &reqwest::Client, endpoint: &str) -> Result<Vec<CloudMachine>> {
     // Log method + path only; the Authorization header is never logged.
@@ -297,6 +341,15 @@ mod tests {
     }
 
     #[test]
+    fn api_key_present_predicate() {
+        // Logged-out (None) and an empty key both count as "not authenticated";
+        // any non-empty key is present. This is the GAP1 degrade-to-local gate.
+        assert!(!api_key_is_present(None));
+        assert!(!api_key_is_present(Some("")));
+        assert!(api_key_is_present(Some("smk_live_xxx")));
+    }
+
+    #[test]
     fn cloud_machine_list_deserializes() {
         let json = r#"[
             {"id": "mach-1", "name": "a", "state": "started"},
@@ -308,6 +361,85 @@ mod tests {
         assert_eq!(
             machines[1].source.as_ref().unwrap().source_type,
             "smolmachine"
+        );
+    }
+}
+
+/// GAP1 regression: the best-effort enumeration must degrade to `Ok(None)` (not
+/// error) whenever the cloud is unavailable — logged out, unreachable, or the
+/// credentials are rejected — so `smol machine ls` and bare-name resolution fall
+/// back to local. A reachable, authenticated control plane still returns rows.
+#[cfg(test)]
+mod best_effort_tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    /// Spawn a one-shot HTTP/1.1 server that answers the first request with
+    /// `status_line` + `body`, then closes. Returns its base URL.
+    fn spawn_once(status_line: &'static str, body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                // Drain the request line/headers; we don't need to parse them.
+                let mut buf = [0u8; 2048];
+                let _ = stream.read(&mut buf);
+                let resp = format!(
+                    "{status_line}\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(resp.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    fn client() -> reqwest::Client {
+        super::super::common::http_client_builder().build().unwrap()
+    }
+
+    #[tokio::test]
+    async fn best_effort_401_degrades_to_none() {
+        let base = spawn_once("HTTP/1.1 401 Unauthorized", r#"{"error":"unauthorized"}"#);
+        let out = list_machines_best_effort(&client(), &base).await.unwrap();
+        assert!(out.is_none(), "a 401 must degrade to Ok(None), got {out:?}");
+    }
+
+    #[tokio::test]
+    async fn best_effort_403_degrades_to_none() {
+        let base = spawn_once("HTTP/1.1 403 Forbidden", r#"{"error":"forbidden"}"#);
+        let out = list_machines_best_effort(&client(), &base).await.unwrap();
+        assert!(out.is_none(), "a 403 must degrade to Ok(None), got {out:?}");
+    }
+
+    #[tokio::test]
+    async fn best_effort_200_returns_machines() {
+        let base = spawn_once(
+            "HTTP/1.1 200 OK",
+            r#"[{"id":"mach-1","name":"a","state":"started"}]"#,
+        );
+        let machines = list_machines_best_effort(&client(), &base)
+            .await
+            .unwrap()
+            .expect("a reachable, authenticated cloud returns Some(rows)");
+        assert_eq!(machines.len(), 1);
+        assert_eq!(machines[0].id, "mach-1");
+    }
+
+    #[tokio::test]
+    async fn best_effort_offline_degrades_to_none() {
+        // Bind then immediately drop to obtain a port nothing is listening on, so
+        // the connect is refused → the control plane is "unreachable" (offline).
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let base = format!("http://{addr}");
+        let out = list_machines_best_effort(&client(), &base).await.unwrap();
+        assert!(
+            out.is_none(),
+            "an unreachable cloud must degrade to Ok(None)"
         );
     }
 }

--- a/src/commands/cp.rs
+++ b/src/commands/cp.rs
@@ -109,22 +109,135 @@ fn cp_cloud(
                 rel
             );
             if is_upload {
-                let bytes = std::fs::read(&local_path)
+                // Stream the file straight from disk into the request body so a
+                // large upload is never read wholly into RAM (mirrors the local
+                // path's chunked `write_file_from_reader`).
+                let meta = tokio::fs::metadata(&local_path)
+                    .await
                     .map_err(|e| anyhow::anyhow!("{}: {}", local_path, e))?;
-                let size = bytes.len();
-                let resp = http.put(&url).body(bytes).send().await?;
+                if meta.is_dir() {
+                    anyhow::bail!("{}: is a directory (cp copies a single file)", local_path);
+                }
+                let size = meta.len();
+                let file = tokio::fs::File::open(&local_path)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}: {}", local_path, e))?;
+                let body = reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(file));
+                // Set Content-Length explicitly (a streamed body has unknown length
+                // and would otherwise be chunked) to preserve the prior semantics.
+                let resp = http
+                    .put(&url)
+                    .header(reqwest::header::CONTENT_LENGTH, size)
+                    .body(body)
+                    .send()
+                    .await?;
                 cloud::check_response(resp, "upload file to machine").await?;
                 eprintln!("Uploaded {local_path} ({size} bytes) -> {label}:{guest_path}");
             } else {
+                // Refuse to clobber a directory target, mirroring local `cp`.
+                if std::path::Path::new(&local_path).is_dir() {
+                    anyhow::bail!(
+                        "{}: is a directory (specify a destination file path)",
+                        local_path
+                    );
+                }
                 let resp = http.get(&url).send().await?;
                 let resp = cloud::check_response(resp, "download file from machine").await?;
-                let bytes = resp.bytes().await?;
-                let size = bytes.len();
-                std::fs::write(&local_path, &bytes)
+                // Stream the response body chunk-by-chunk to disk so a large
+                // download is never buffered entirely in memory.
+                let size = write_chunks_to_file(resp.bytes_stream(), &local_path)
+                    .await
                     .map_err(|e| anyhow::anyhow!("{}: {}", local_path, e))?;
                 eprintln!("Downloaded {label}:{guest_path} ({size} bytes) -> {local_path}");
             }
             Ok(())
         },
     )
+}
+
+/// Drain a byte stream to `path`, returning the number of bytes written.
+///
+/// Writes each chunk straight to the file as it arrives so a large download is
+/// never held wholly in memory. Generic over the chunk/error type so it works
+/// with `reqwest::Response::bytes_stream()` (chunks are `bytes::Bytes`, errors
+/// `reqwest::Error`) and is unit-testable with an in-memory stream.
+async fn write_chunks_to_file<S, B, E>(mut stream: S, path: &str) -> anyhow::Result<u64>
+where
+    S: futures_util::Stream<Item = Result<B, E>> + Unpin,
+    B: AsRef<[u8]>,
+    E: Into<anyhow::Error>,
+{
+    use futures_util::StreamExt;
+    use tokio::io::AsyncWriteExt;
+
+    let mut file = tokio::fs::File::create(path).await?;
+    let mut written: u64 = 0;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(Into::into)?;
+        let bytes = chunk.as_ref();
+        file.write_all(bytes).await?;
+        written += bytes.len() as u64;
+    }
+    file.flush().await?;
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The streamed-download path round-trips a multi-chunk body to disk without
+    /// buffering it whole (the R2-C4 fix). Exercises the exact helper the cloud
+    /// download uses, fed an in-memory chunk stream standing in for `bytes_stream`.
+    #[tokio::test]
+    async fn write_chunks_round_trips_multi_chunk_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.bin").to_string_lossy().into_owned();
+
+        let chunks: Vec<Result<Vec<u8>, std::io::Error>> = vec![
+            Ok(b"hello ".to_vec()),
+            Ok(b"streamed ".to_vec()),
+            Ok(b"world".to_vec()),
+        ];
+        let stream = futures_util::stream::iter(chunks);
+
+        let written = write_chunks_to_file(stream, &path).await.unwrap();
+        assert_eq!(written, 20);
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello streamed world");
+    }
+
+    /// A mid-stream error propagates instead of leaving a silently-truncated file
+    /// look like success.
+    #[tokio::test]
+    async fn write_chunks_propagates_stream_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("err.bin").to_string_lossy().into_owned();
+
+        let chunks: Vec<Result<Vec<u8>, std::io::Error>> =
+            vec![Ok(b"partial".to_vec()), Err(std::io::Error::other("boom"))];
+        let stream = futures_util::stream::iter(chunks);
+
+        let err = write_chunks_to_file(stream, &path).await.unwrap_err();
+        assert!(err.to_string().contains("boom"));
+    }
+
+    /// The upload side streams from a tokio file reader; confirm the reader-stream
+    /// reassembles to the original bytes (i.e. nothing is dropped/duplicated).
+    #[tokio::test]
+    async fn reader_stream_reassembles_file() {
+        use futures_util::StreamExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("in.bin");
+        let payload: Vec<u8> = (0..10_000u32).map(|i| (i % 256) as u8).collect();
+        std::fs::write(&path, &payload).unwrap();
+
+        let file = tokio::fs::File::open(&path).await.unwrap();
+        let mut stream = tokio_util::io::ReaderStream::new(file);
+        let mut collected = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            collected.extend_from_slice(&chunk.unwrap());
+        }
+        assert_eq!(collected, payload);
+    }
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -205,11 +205,7 @@ impl DeployCmd {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            anyhow::bail!("deploy failed ({}): {}", status, text);
-        }
+        let resp = cloud::check_response(resp, "deploy").await?;
 
         let machine: cloud::CloudMachine = resp.json().await?;
 

--- a/src/commands/destroy.rs
+++ b/src/commands/destroy.rs
@@ -23,9 +23,8 @@ impl DestroyCmd {
             match resp.status().as_u16() {
                 200 | 204 => eprintln!("Destroyed: {}", display_name),
                 404 => anyhow::bail!("machine '{}' not found", display_name),
-                status => {
-                    let text = resp.text().await.unwrap_or_default();
-                    anyhow::bail!("destroy failed ({}): {}", status, text);
+                _ => {
+                    super::cloud::check_response(resp, "destroy").await?;
                 }
             }
 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -229,11 +229,7 @@ impl ExecCmd {
                 .send()
                 .await?;
 
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let text = resp.text().await.unwrap_or_default();
-                anyhow::bail!("exec failed ({}): {}", status, text);
-            }
+            let resp = super::cloud::check_response(resp, "exec").await?;
 
             let result: serde_json::Value = resp.json().await?;
             let stdout = result.get("stdout").and_then(|v| v.as_str()).unwrap_or("");

--- a/src/commands/fork.rs
+++ b/src/commands/fork.rs
@@ -260,9 +260,8 @@ impl ForkCmd {
                         let text = resp.text().await.unwrap_or_default();
                         anyhow::bail!("cannot fork golden '{}': {}", golden_id, text);
                     }
-                    status => {
-                        let text = resp.text().await.unwrap_or_default();
-                        anyhow::bail!("fork failed ({}): {}", status, text);
+                    _ => {
+                        super::cloud::check_response(resp, "fork golden").await?;
                     }
                 }
                 Ok(())

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -125,9 +125,8 @@ impl LogsCmd {
                     }
                 }
                 404 => anyhow::bail!("machine '{}' not found", id),
-                status => {
-                    let text = resp.text().await.unwrap_or_default();
-                    anyhow::bail!("events failed ({}): {}", status, text);
+                _ => {
+                    super::cloud::check_response(resp, "list events").await?;
                 }
             }
             Ok(())

--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -132,9 +132,16 @@ fn list_local() -> Result<Vec<MachineRef>> {
 /// the user is not logged in / the endpoint is unset, so callers can degrade to
 /// local-only cleanly. Real network/auth failures after a valid login DO surface.
 fn list_cloud() -> Result<Option<Vec<MachineRef>>> {
-    // `cloud_client()` fails cleanly when unconfigured/logged out — treat that as
-    // "cloud unavailable", not a hard error. It also does a `block_on` refresh
-    // internally, so it must run before we build our own runtime.
+    // Not logged in → skip the cloud entirely rather than fire an unauthenticated
+    // request that would 401 and hard-error. This is the fresh-install and
+    // post-`smol logout` default, and the whole point of best-effort enumeration.
+    if !cloud::cloud_is_authenticated() {
+        return Ok(None);
+    }
+    // `cloud_client()` can still fail cleanly (expired token + refresh failed);
+    // for a best-effort listing treat that as "cloud unavailable", not a hard
+    // error. It also does a `block_on` refresh internally, so it must run before
+    // we build our own runtime.
     let (http, cloud_config) = match cloud::cloud_client() {
         Ok(v) => v,
         Err(_) => return Ok(None),
@@ -142,7 +149,12 @@ fn list_cloud() -> Result<Option<Vec<MachineRef>>> {
     let endpoint = cloud_config.endpoint()?.to_string();
 
     let rt = tokio::runtime::Runtime::new()?;
-    let machines = rt.block_on(cloud::list_machines(&http, &endpoint))?;
+    // Unreachable control plane (offline) or rejected credentials (401/403) →
+    // degrade to local; only genuine server/protocol errors surface here.
+    let machines = match rt.block_on(cloud::list_machines_best_effort(&http, &endpoint))? {
+        Some(machines) => machines,
+        None => return Ok(None),
+    };
     Ok(Some(
         machines
             .into_iter()

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -105,9 +105,8 @@ fn run_cloud(name: String) -> anyhow::Result<()> {
         match resp.status().as_u16() {
             200 | 204 => println!("Deleted machine: {}", display_name),
             404 => anyhow::bail!("machine '{}' not found", display_name),
-            status => {
-                let text = resp.text().await.unwrap_or_default();
-                anyhow::bail!("delete failed ({}): {}", status, text);
+            _ => {
+                super::cloud::check_response(resp, "delete machine").await?;
             }
         }
         Ok(())

--- a/src/commands/scale.rs
+++ b/src/commands/scale.rs
@@ -34,9 +34,8 @@ impl ScaleCmd {
             match resp.status().as_u16() {
                 200..=299 => eprintln!("Scaled group '{}' to {} replicas", self.name, self.count),
                 404 => anyhow::bail!("group '{}' not found", self.name),
-                status => {
-                    let text = resp.text().await.unwrap_or_default();
-                    anyhow::bail!("scale failed ({}): {}", status, text);
+                _ => {
+                    super::cloud::check_response(resp, "scale group").await?;
                 }
             }
 

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -233,9 +233,8 @@ impl StartCmd {
                     }
                 }
                 404 => anyhow::bail!("machine '{}' not found", id),
-                status => {
-                    let text = resp.text().await.unwrap_or_default();
-                    anyhow::bail!("start failed ({}): {}", status, text);
+                _ => {
+                    super::cloud::check_response(resp, "start machine").await?;
                 }
             }
             Ok(())

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -127,9 +127,8 @@ impl StatusCmd {
                     }
                 }
                 404 => anyhow::bail!("machine '{}' not found", id),
-                status => {
-                    let text = resp.text().await.unwrap_or_default();
-                    anyhow::bail!("status failed ({}): {}", status, text);
+                _ => {
+                    super::cloud::check_response(resp, "get machine status").await?;
                 }
             }
             Ok(())

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -90,9 +90,8 @@ impl StopCmd {
                     eprintln!("Machine {}: {}", id, machine.state);
                 }
                 404 => anyhow::bail!("machine '{}' not found", id),
-                status => {
-                    let text = resp.text().await.unwrap_or_default();
-                    anyhow::bail!("stop failed ({}): {}", status, text);
+                _ => {
+                    super::cloud::check_response(resp, "stop machine").await?;
                 }
             }
             Ok(())


### PR DESCRIPTION
Make logged-out/offline machine enumeration degrade to local instead of hard-erroring, stream cloud `cp` instead of buffering whole files in RAM, and route cloud non-success responses through `check_response` for consistent auth errors.