### PR TITLE
Make machine exec reuse the machine's persistent overlay so changes survive across execs and restarts

### DIFF
--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -150,7 +150,8 @@ impl ExecCmd {
                     .with_env(env)
                     .with_workdir(self.workdir.clone())
                     .with_timeout(timeout)
-                    .with_tty(self.tty);
+                    .with_tty(self.tty)
+                    .with_persistent_overlay(Some(name.clone()));
                 let exit_code = client.run_interactive(config)?;
                 manager.detach();
                 std::process::exit(exit_code);
@@ -159,7 +160,8 @@ impl ExecCmd {
             let config = RunConfig::new(image, command.clone())
                 .with_env(env)
                 .with_workdir(self.workdir.clone())
-                .with_timeout(timeout);
+                .with_timeout(timeout)
+                .with_persistent_overlay(Some(name.clone()));
             let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
             print_and_exit(
                 &manager,


### PR DESCRIPTION
Exec on image machines previously ran each command in a fresh ephemeral container overlay, so installed packages vanished between execs; passing the machine name as the persistent overlay id matches the engine CLI's behavior.