### PR TITLE
Add non-interactive smol cloud exec and env/secret injection to smol cloud deploy

### DIFF
--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -476,6 +476,39 @@ pub enum CloudSubcommand {
         #[arg(short = 'n', long, value_name = "NAME")]
         name: Option<String>,
     },
+
+    /// Run a command non-interactively on a deployed cloud machine.
+    ///
+    /// Prints the command's stdout to stdout and stderr to stderr, and exits
+    /// with the command's exit code — suitable for scripts and CI. Unlike
+    /// `shell` this does not allocate a PTY, so output is clean.
+    ///
+    ///   smol cloud exec -n myapp -- sh -c 'echo hi'
+    Exec(CloudExecArgs),
+}
+
+/// Arguments for `smol cloud exec` (non-interactive cloud command execution).
+#[derive(Args, Debug)]
+pub struct CloudExecArgs {
+    /// Machine name (default: "default")
+    #[arg(short = 'n', long, value_name = "NAME")]
+    pub name: Option<String>,
+
+    /// Command to run (everything after `--`)
+    #[arg(trailing_var_arg = true, required = true, value_name = "COMMAND")]
+    pub command: Vec<String>,
+
+    /// Set an environment variable for this command (repeatable)
+    #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
+    pub env: Vec<String>,
+
+    /// Working directory for the command
+    #[arg(short = 'w', long, value_name = "DIR")]
+    pub workdir: Option<String>,
+
+    /// Command timeout in seconds (default 600)
+    #[arg(long, value_name = "SECONDS")]
+    pub timeout: Option<u64>,
 }
 
 impl CloudCmd {
@@ -496,6 +529,21 @@ impl CloudCmd {
                 secret_env: vec![],
                 secret_file: vec![],
                 timeout: None,
+                cloud: true,
+                local: false,
+            }
+            .run(),
+            CloudSubcommand::Exec(a) => crate::commands::exec::ExecCmd {
+                name: a.name,
+                command: a.command,
+                interactive: false,
+                tty: false,
+                stream: false,
+                env: a.env,
+                workdir: a.workdir,
+                secret_env: vec![],
+                secret_file: vec![],
+                timeout: a.timeout,
                 cloud: true,
                 local: false,
             }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -57,6 +57,21 @@ pub struct DeployCmd {
     /// Push a local .smolmachine file before deploying
     #[arg(short = 'f', long, value_name = "PATH")]
     pub file: Option<PathBuf>,
+
+    /// Set an environment variable in the deployed machine (KEY=VALUE, repeatable)
+    #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
+    pub env: Vec<String>,
+
+    /// Inject a secret from a host env var (GUEST_VAR=HOST_VAR), resolved on the
+    /// host at deploy time; the value is set in the machine, never persisted to
+    /// disk on the host (repeatable)
+    #[arg(long = "secret-env", value_name = "GUEST_VAR=HOST_VAR")]
+    pub secret_env: Vec<String>,
+
+    /// Inject a secret from a host file (GUEST_VAR=/abs/path), resolved on the
+    /// host at deploy time (repeatable)
+    #[arg(long = "secret-file", value_name = "GUEST_VAR=/abs/path")]
+    pub secret_file: Vec<String>,
 }
 
 /// Sync-resolved inputs for the push step. Resolved outside the runtime so
@@ -181,6 +196,16 @@ impl DeployCmd {
             })
         };
 
+        // Machine env: plain --env plus host-resolved --secret-env/--secret-file.
+        // Resolved on the host at deploy time; secret values are set in the
+        // machine but never written to the host disk.
+        let mut env_pairs = smolvm::util::parse_env_list(&self.env);
+        env_pairs.extend(crate::commands::common::resolve_cli_secrets(
+            &self.secret_env,
+            &self.secret_file,
+        )?);
+        let env: std::collections::BTreeMap<String, String> = env_pairs.into_iter().collect();
+
         let body = serde_json::json!({
             "name": name,
             "source": source,
@@ -189,6 +214,7 @@ impl DeployCmd {
                 "memoryMb": self.memory,
             },
             "network": network,
+            "env": env,
             // Publish the service port. Send only the guest port; the control
             // plane allocates the node host port. The app's URL always requires a
             // smolmachines login: owner-only by default, any signed-in user when


### PR DESCRIPTION
Adds a `smol cloud exec` subcommand that runs a command on a deployed cloud machine and prints clean stdout/stderr with the exit code propagated (no PTY), suitable for scripts and CI, and adds --env/--secret-env/--secret-file to `smol cloud deploy` so a deployment can receive configuration and secrets; both reuse the existing exec and create paths that already support these on the API.