### PR TITLE
Send the machine size to the catalog as sizeBytes so pushed machines register their real size

### DIFF
--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -128,7 +128,9 @@ fn register_in_catalog(
         "repo": repo,
         "tag": tag,
         "digest": digest,
-        "size_bytes": result.layer_size,
+        // The control-plane RegisterMachineRequest is camelCase — the field is
+        // `sizeBytes`; `size_bytes` is silently ignored (registers size 0).
+        "sizeBytes": result.layer_size,
         "platforms": platforms,
         "manifest": manifest,
     });


### PR DESCRIPTION
The catalog register request is camelCase, so the size field is sizeBytes; push was sending size_bytes which the control plane ignored, registering every pushed machine with size 0 (shown as 0 B in the console and registry); it now sends sizeBytes so the real artifact size is recorded.