### PR TITLE
Bump the smol CLI and SDKs to 1.3.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,7 +2183,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol-cli"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "anyhow",
  "base64",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.3.6"
+version = "1.3.4"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.3.6"
+version = "1.3.4"
 dependencies = [
  "async-stream",
  "axum",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.3.6"
+version = "1.3.4"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.3.6"
+version = "1.3.4"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2328,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.3.6"
+version = "1.3.4"
 dependencies = [
  "base64",
  "serde",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.3.6"
+version = "1.3.4"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk", "__engine__"]
 name = "smol-cli"
 # Tracks the bundled smolvm engine release: a `smol` vX.Y.Z ships smolvm vX.Y.Z's
 # libkrun + agent-rootfs, so the host CLI and guest agent can never drift.
-version = "1.3.7"
+version = "1.3.8"
 edition = "2021"
 description = "Ship and run software with isolation by default"
 license = "Apache-2.0"

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "smol-node"
-version = "1.3.7"
+version = "1.3.8"
 edition = "2021"
 description = "Native NAPI core for the smol SDK — embed microVMs directly in Node.js"
 license = "Apache-2.0"

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smolmachines",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Embed isolated microVM sandboxes directly in your code — no server to run.",
   "license": "Apache-2.0",
   "author": "smol-machines",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol-py"
-version = "1.3.7"
+version = "1.3.8"
 edition = "2021"
 description = "Native (pyo3) core for the smol Python SDK — embeds the smolvm engine in-process."
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smolmachines"
-version = "1.3.7"
+version = "1.3.8"
 description = "Embed isolated microVM sandboxes directly in your Python code — local (embedded) or smolfleet cloud."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -57,7 +57,7 @@ from .types import (
     ResourceSpec,
 )
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 __all__ = [
     "Machine",


### PR DESCRIPTION
Bumps the smol CLI and the Node and Python SDKs to 1.3.8 to track the smolvm 1.3.8 engine release; tagging v1.3.8 builds against and bundles the matching engine assets and publishes the CLI and SDKs.