### PR TITLE
Vendor libkrun's GPU dylibs into the Node addon so it boots on macOS without Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,12 @@ jobs:
         with:
           name: rootfs-${{ matrix.rootfs_arch }}
           path: ${{ github.workspace }}/rootfs
+      # libkrun.dylib load-links Homebrew libepoxy/virglrenderer; bundle-native.sh
+      # vendors them next to the addon (repointed to @loader_path) so it's
+      # self-contained on a Mac without those formulae. Source must exist here.
+      - name: Install GPU dylibs to vendor (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libepoxy virglrenderer
       - name: Bundle native libs + boot helper next to the addon
         env:
           SMOLVM_LIB_DIR: ${{ matrix.engine_lib }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,6 +372,13 @@ jobs:
         with:
           name: rootfs-${{ matrix.rootfs_arch }}
           path: ${{ github.workspace }}/rootfs
+      # libkrun.dylib is built GPU-enabled and load-links Homebrew
+      # libepoxy/virglrenderer by absolute path; bundle-native.sh vendors them
+      # into the wheel (repointed to @loader_path) so it's self-contained on a
+      # Mac without those formulae. The vendor source must exist on THIS runner.
+      - name: Install GPU dylibs to vendor (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libepoxy virglrenderer
       - name: Stage native libs + boot helper into the wheel
         working-directory: sdk/python
         env:

--- a/sdk/node/scripts/bundle-native.sh
+++ b/sdk/node/scripts/bundle-native.sh
@@ -48,20 +48,70 @@ else
   echo "bundle-native: WARNING — SMOLVM_ROOTFS_TAR not set/found; package ships no guest rootfs (boot needs one already on the host)" >&2
 fi
 
+# macOS: a GPU-enabled libkrun.dylib load-links Homebrew libepoxy/virglrenderer
+# by ABSOLUTE path. GPU is unused by the SDK, but those load commands must
+# resolve or `dlopen` fails on any Mac without those formulae ("Library not
+# loaded"). Vendor each dep next to libkrun repointed to @loader_path, recursively
+# (virglrenderer pulls in libepoxy + libMoltenVK). A missing dep is FATAL: shipping
+# a repoint-without-vendor addon would hard-fail at VM boot on a clean Mac.
+_vendor_macho_deps() {
+  local target="$1" dep dbase src cand pfx
+  # Process substitution (not a pipe) so the loop runs in this shell and a fatal
+  # `exit 1` propagates instead of dying in a subshell.
+  while read -r dep; do
+    dbase="$(basename "$dep")"
+    case "$dep" in
+      /opt/homebrew/*|/usr/local/*|/opt/local/*) ;;
+      @loader_path/*|@rpath/*)
+        [ "$dbase" = "$(basename "$target")" ] && continue ;;
+      *) continue ;;
+    esac
+    if [ ! -e "$DEST/$dbase" ]; then
+      src=""
+      if [ -e "$dep" ]; then src="$dep"
+      elif [ -e "$LIB_DIR/$dbase" ]; then src="$LIB_DIR/$dbase"
+      else
+        for pfx in "${HOMEBREW_PREFIX:-}" /opt/homebrew /usr/local /opt/local; do
+          [ -n "$pfx" ] && [ -d "$pfx" ] || continue
+          cand="$(find "$pfx/opt" "$pfx/lib" -name "$dbase" 2>/dev/null | head -1)"
+          [ -n "$cand" ] && { src="$cand"; break; }
+        done
+      fi
+      if [ -z "$src" ]; then
+        echo "bundle-native: FATAL — GPU dep '$dbase' (referenced by $(basename "$target")) not found on this builder; the addon would not be self-contained and would fail to boot. Install it first: brew install libepoxy virglrenderer" >&2
+        exit 1
+      fi
+      cp -f "$src" "$DEST/$dbase"; chmod u+w "$DEST/$dbase"
+      install_name_tool -id "@rpath/$dbase" "$DEST/$dbase" 2>/dev/null || true
+      _vendor_macho_deps "$DEST/$dbase"
+      codesign --force --sign - "$DEST/$dbase" 2>/dev/null || true
+      echo "vendored dep $dbase"
+    fi
+    case "$dep" in
+      /opt/homebrew/*|/usr/local/*|/opt/local/*)
+        install_name_tool -change "$dep" "@loader_path/$dbase" "$target" 2>/dev/null || true ;;
+    esac
+  done < <(otool -L "$target" 2>/dev/null | awk 'NR>1{print $1}')
+}
+
 if [ "$OS" = "Darwin" ]; then
-  # Copy the libs VERBATIM — they already resolve each other at runtime
-  # (libkrun dlopens libkrunfw by name from the lib dir). Do NOT run
-  # install_name_tool: it needlessly invalidates the working signatures.
   cp -p "$LIB_DIR/libkrun.dylib" "$DEST/"
   cp -p "$LIB_DIR/libkrunfw.5.dylib" "$DEST/"
+  chmod u+w "$DEST/libkrun.dylib"
+  # Vendor libkrun's absolute Homebrew GPU deps → @loader_path siblings, so the
+  # addon boots on a Mac without libepoxy/virglrenderer installed.
+  _vendor_macho_deps "$DEST/libkrun.dylib"
+  # install_name_tool invalidated libkrun's signature — re-sign (ad-hoc) or macOS
+  # dlopen SIGKILLs it. libkrunfw is untouched and keeps its original signature.
+  codesign --force --sign - "$DEST/libkrun.dylib" 2>/dev/null || true
   # Versioned soname symlinks — REQUIRED. libkrun is resolved as `libkrun.1.dylib`;
   # without it the VM exits 0 instantly ("boot subprocess exited during startup").
   ( cd "$DEST" \
       && ln -sf libkrunfw.5.dylib libkrunfw.dylib \
       && ln -sf libkrun.dylib libkrun.1.dylib )
 
-  # Only the helper needs (re)signing — with the hypervisor entitlement, so the
-  # user's `node` needs none. The copied dylibs keep their original signatures.
+  # The helper needs (re)signing with the hypervisor entitlement, so the user's
+  # `node` needs none.
   codesign --force --sign - --entitlements "${SMOLVM_ENTITLEMENTS:-$REPO_ROOT/smolvm.entitlements}" "$DEST/smol-vmm"
   # VERIFY the entitlement actually stuck — without it, krun_start_enter fails
   # with -22 and the VM never boots. (This silently regressed once; assert it.)

--- a/sdk/python/scripts/bundle-native.sh
+++ b/sdk/python/scripts/bundle-native.sh
@@ -30,14 +30,15 @@ copied=0
 # each absolute dep next to the bundled lib and repoint it to @loader_path,
 # recursively (virglrenderer itself pulls in libepoxy + libMoltenVK).
 _vendor_macho_deps() {
-  local target="$1" dep dbase
-  otool -L "$target" 2>/dev/null | awk 'NR>1{print $1}' | while read -r dep; do
+  local target="$1" dep dbase src cand pfx
+  # Read via process substitution (NOT a pipe) so this runs in the current shell:
+  # a pipeline would put the loop in a subshell where a fatal `exit 1` — a wheel
+  # that isn't self-contained must never publish — would be swallowed.
+  while read -r dep; do
     dbase="$(basename "$dep")"
     case "$dep" in
       # Absolute Homebrew/MacPorts path: repoint to @loader_path AND vendor.
-      /opt/homebrew/*|/usr/local/*|/opt/local/*)
-        install_name_tool -change "$dep" "@loader_path/$dbase" "$target" 2>/dev/null || true
-        ;;
+      /opt/homebrew/*|/usr/local/*|/opt/local/*) ;;
       # Already relative to its loader (e.g. virglrenderer -> @loader_path/
       # libMoltenVK): no repoint, but the sibling must still be vendored.
       @loader_path/*|@rpath/*)
@@ -45,20 +46,42 @@ _vendor_macho_deps() {
         ;;
       *) continue ;;  # system lib / framework — leave it
     esac
+    # Locate the actual dylib to vendor BEFORE repointing. The load command may
+    # name an absolute Homebrew path that doesn't exist verbatim on this builder
+    # (a different Homebrew prefix, or `brew install`ed after libkrun was built),
+    # so fall back to searching every known Homebrew prefix.
     if [ ! -e "$DEST/$dbase" ]; then
-      if [ -e "$dep" ]; then cp -f "$dep" "$DEST/$dbase"
-      elif [ -e "$LIB_DIR/$dbase" ]; then cp -f "$LIB_DIR/$dbase" "$DEST/$dbase"
+      src=""
+      if [ -e "$dep" ]; then src="$dep"
+      elif [ -e "$LIB_DIR/$dbase" ]; then src="$LIB_DIR/$dbase"
       else
-        echo "bundle-native: WARNING — missing dep $dbase (wheel not self-contained)" >&2
-        continue
+        for pfx in "${HOMEBREW_PREFIX:-}" /opt/homebrew /usr/local /opt/local; do
+          [ -n "$pfx" ] && [ -d "$pfx" ] || continue
+          cand="$(find "$pfx/opt" "$pfx/lib" -name "$dbase" 2>/dev/null | head -1)"
+          [ -n "$cand" ] && { src="$cand"; break; }
+        done
       fi
+      if [ -z "$src" ]; then
+        # FATAL, not a warning: a repoint-without-vendor ships a wheel whose
+        # libkrun dlopens @loader_path/<missing> and hard-fails at VM boot on any
+        # Mac lacking the Homebrew formula. Fail the build so it can't slip out.
+        echo "bundle-native: FATAL — GPU dep '$dbase' (referenced by $(basename "$target")) not found on this builder; the wheel would not be self-contained and would fail to boot. Install it first: brew install libepoxy virglrenderer" >&2
+        exit 1
+      fi
+      cp -f "$src" "$DEST/$dbase"
       chmod u+w "$DEST/$dbase"
       install_name_tool -id "@rpath/$dbase" "$DEST/$dbase" 2>/dev/null || true
       _vendor_macho_deps "$DEST/$dbase"
       codesign --force --sign - "$DEST/$dbase" 2>/dev/null || true
       echo "vendored dep $dbase"
     fi
-  done
+    # Repoint the parent to the now-guaranteed-present sibling (absolute paths only).
+    case "$dep" in
+      /opt/homebrew/*|/usr/local/*|/opt/local/*)
+        install_name_tool -change "$dep" "@loader_path/$dbase" "$target" 2>/dev/null || true
+        ;;
+    esac
+  done < <(otool -L "$target" 2>/dev/null | awk 'NR>1{print $1}')
 }
 
 case "$(uname -s)" in


### PR DESCRIPTION
The macOS Node addon copied libkrun verbatim, keeping its absolute Homebrew load paths for libepoxy and libvirglrenderer, so it only booted on a Mac that happened to have those formulae installed and failed with a dlopen 'Library not loaded' error everywhere else — the same latent gap the Python wheel had. This vendors each GPU dylib next to libkrun repointed to @loader_path (recursively, and re-signs since install_name_tool invalidates the signature), turns a missing dependency into a hard build failure, and installs the formulae on the macOS addon runner so the source exists to vendor. Validated: the fixed script vendors libepoxy, virglrenderer, and libMoltenVK and repoints libkrun; the Node and Python SDKs both boot and persist processes across execs on Linux/KVM.