### PR TITLE
Make SDK host mounts writable by default with an idiomatic readOnly flag, matching the CLI

### DIFF
--- a/sdk/node/src/types.rs
+++ b/sdk/node/src/types.rs
@@ -36,7 +36,7 @@ pub struct HostMountConfig {
     pub source: String,
     /// Absolute path inside the guest.
     pub target: String,
-    /// Mount as read-only (default: true).
+    /// Mount as read-only (default: false — writable, matching the CLI).
     pub read_only: Option<bool>,
 }
 
@@ -152,7 +152,10 @@ impl TryFrom<&HostMountConfig> for HostMount {
     type Error = smolvm::error::Error;
 
     fn try_from(m: &HostMountConfig) -> Result<Self, Self::Error> {
-        HostMount::new(&m.source, &m.target, m.read_only.unwrap_or(true))
+        // Default writable, matching the engine's own `HostMount::parse`
+        // (host:guest[:ro|:rw] defaults to writable) and the `smol -v` CLI. A
+        // read-only mount is opt-in via read_only: true.
+        HostMount::new(&m.source, &m.target, m.read_only.unwrap_or(false))
     }
 }
 

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -94,7 +94,10 @@ export function toNativeConfig(
     mounts: config.mounts?.map((m) => ({
       source: m.source,
       target: m.target,
-      readOnly: m.readonly,
+      // Prefer the canonical camelCase `readOnly`; fall back to the deprecated
+      // lowercase `readonly` for backwards compatibility. Undefined → engine
+      // default (writable).
+      readOnly: m.readOnly ?? m.readonly,
     })),
     ports: config.ports?.map((p) => ({ host: p.host, guest: p.guest })),
     resources: config.resources && {

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -39,7 +39,9 @@ export interface MountSpec {
   source: string;
   /** Absolute path inside the machine. */
   target: string;
-  /** Mount read-only (default: true). */
+  /** Mount read-only. Default: false (writable), matching the `smol -v` CLI. */
+  readOnly?: boolean;
+  /** @deprecated Use `readOnly`. Kept for backwards compatibility. */
   readonly?: boolean;
 }
 

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -90,7 +90,8 @@ def _native_config(name: str, config: MachineConfig) -> dict:
     cfg: dict[str, Any] = {"name": name, "persistent": config.persistent}
     if config.mounts:
         cfg["mounts"] = [
-            {"source": m.source, "target": m.target, "read_only": m.readonly} for m in config.mounts
+            {"source": m.source, "target": m.target, "read_only": m.effective_read_only}
+            for m in config.mounts
         ]
     if config.ports:
         cfg["ports"] = [{"host": p.host, "guest": p.guest} for p in config.ports]

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -51,7 +51,16 @@ class MountSpec:
     """Absolute path on the host."""
     target: str
     """Absolute path inside the machine."""
-    readonly: bool = True
+    read_only: bool = False
+    """Mount read-only. Default: False (writable), matching the ``smol -v`` CLI."""
+    readonly: Optional[bool] = None
+    """Deprecated alias for :attr:`read_only`; kept for backwards compatibility."""
+
+    @property
+    def effective_read_only(self) -> bool:
+        """Resolve the read-only flag, preferring the deprecated ``readonly``
+        alias when explicitly set, else ``read_only``."""
+        return self.readonly if self.readonly is not None else self.read_only
 
 
 @dataclass


### PR DESCRIPTION
The engine and the smol -v CLI default host mounts to writable (host:guest[:ro|:rw]), but both SDKs silently forced them read-only: the field was the non-idiomatic all-lowercase readonly (a TypeScript reserved word) so the natural readOnly / read_only was dropped, and the native default was read-only. A user passing readOnly:false got a read-only mount and writes failed with EROFS. This renames the field to the idiomatic readOnly (Node) and read_only (Python), keeps the old readonly as a deprecated alias, and defaults to writable to match the CLI, engine, and Docker; read-only is now opt-in. Verified on Linux/KVM: readOnly:false is writable and the host sees guest writes, readOnly:true is read-only.