### PR TITLE
Start the host→guest file watcher for the run's lifetime so hot-reload works

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -143,6 +143,17 @@ impl RunCmd {
 
         let mut client = AgentClient::connect_with_retry(manager.vsock_socket())?;
 
+        // Propagate host edits under -v mounts into the guest as fsnotify events
+        // so inotify-based hot-reload (Vite, webpack, nodemon) fires when a file
+        // is changed on the host. Held for the command's lifetime; dropped (which
+        // stops the watcher) when this scope exits. No-op without mounts or on a
+        // guest kernel that lacks the /proc/smolvm-fsnotify interface.
+        let _fs_watcher = if mounts.is_empty() {
+            None
+        } else {
+            smolvm::agent::FsNotifyWatcher::start(manager.vsock_socket().to_path_buf(), &mounts)
+        };
+
         // Registry images pull in-guest; a local image is already staged on the
         // host (mounted via packed_layers_dir), so skip the pull for it.
         if let Some(ref img) = resolved_image {


### PR DESCRIPTION
When `smol run` mounts a host directory with `-v`, start a host filesystem watcher that propagates host edits into the guest as fsnotify events, so inotify-based hot-reload (Vite, webpack, nodemon) fires when you edit a file on the host. The watcher is held for the command's lifetime and stops when it exits; it is a no-op without mounts, when SMOL_NO_HOT_RELOAD is set, or on a guest kernel without the /proc/smolvm-fsnotify interface.

Depends on the engine change that adds the watcher and the FsNotify agent request, plus the libkrunfw kernel interface. Validated on macOS end to end: editing a mounted file on the host fires the event inside the container.