### PR TITLE
Bump smol CLI + SDKs to 1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +703,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1152,6 +1170,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1256,26 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -1410,6 +1468,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -1417,6 +1487,25 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2183,7 +2272,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol-cli"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -2213,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.3.4"
+version = "1.4.2"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2238,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.3.4"
+version = "1.4.2"
 dependencies = [
  "async-stream",
  "axum",
@@ -2255,6 +2344,7 @@ dependencies = [
  "libloading",
  "metrics",
  "metrics-exporter-prometheus",
+ "notify",
  "parking_lot",
  "pkg-config",
  "rusqlite",
@@ -2297,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.3.4"
+version = "1.4.2"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2309,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.3.4"
+version = "1.4.2"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2328,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.3.4"
+version = "1.4.2"
 dependencies = [
  "base64",
  "serde",
@@ -2338,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.3.4"
+version = "1.4.2"
 dependencies = [
  "bytes",
  "dirs",
@@ -2552,7 +2642,7 @@ checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk", "__engine__"]
 name = "smol-cli"
 # Tracks the bundled smolvm engine release: a `smol` vX.Y.Z ships smolvm vX.Y.Z's
 # libkrun + agent-rootfs, so the host CLI and guest agent can never drift.
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 description = "Ship and run software with isolation by default"
 license = "Apache-2.0"

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "smol-node"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 description = "Native NAPI core for the smol SDK — embed microVMs directly in Node.js"
 license = "Apache-2.0"

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smolmachines",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Embed isolated microVM sandboxes directly in your code — no server to run.",
   "license": "Apache-2.0",
   "author": "smol-machines",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol-py"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 description = "Native (pyo3) core for the smol Python SDK — embeds the smolvm engine in-process."
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smolmachines"
-version = "1.4.1"
+version = "1.4.2"
 description = "Embed isolated microVM sandboxes directly in your Python code — local (embedded) or smolfleet cloud."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -57,7 +57,7 @@ from .types import (
     ResourceSpec,
 )
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 __all__ = [
     "Machine",


### PR DESCRIPTION
Release 1.4.2, tracking smolvm 1.4.2: host→guest inotify hot-reload for -v mounts, the qcow2 boot-disk fix, and -v mounts reaching the container.