### PR TITLE
Trust the libkrun/krun tap before installing virglrenderer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,8 @@ jobs:
         run: |
           brew install libepoxy
           brew tap libkrun/krun
-          HOMEBREW_NO_INSTALL_FROM_API=1 brew install virglrenderer
+          brew trust libkrun/krun
+          brew install libkrun/krun/virglrenderer
       - name: Bundle native libs + boot helper next to the addon
         env:
           SMOLVM_LIB_DIR: ${{ matrix.engine_lib }}
@@ -396,7 +397,8 @@ jobs:
         run: |
           brew install libepoxy
           brew tap libkrun/krun
-          HOMEBREW_NO_INSTALL_FROM_API=1 brew install virglrenderer
+          brew trust libkrun/krun
+          brew install libkrun/krun/virglrenderer
       - name: Stage native libs + boot helper into the wheel
         working-directory: sdk/python
         env:


### PR DESCRIPTION
The runner sets HOMEBREW_REQUIRE_TAP_TRUST, so brew refuses the third-party libkrun/krun formula. Run brew trust libkrun/krun and install the fully-qualified formula.