### PR TITLE
Build and ship the smol CLI for Windows (x86_64)

### DIFF
--- a/.github/workflows/release-smol.yml
+++ b/.github/workflows/release-smol.yml
@@ -135,9 +135,79 @@ jobs:
             dist/smol-*-${{ matrix.platform }}.tar.gz.sha256
           if-no-files-found: error
 
+  # Windows is a CROSS build (mingw-w64 on Linux) with a different asset shape
+  # (a .zip with the DLLs beside smol.exe + agent-rootfs.tar.gz), so it lives in
+  # its own job rather than the tar.gz matrix. It reuses the runtime assets from
+  # the matching smolvm Windows release zip.
+  build-windows:
+    name: build · windows-x86_64
+    runs-on: ubuntu-latest
+    env:
+      ENGINE_VERSION: ${{ github.event.inputs.engine_version || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assert Cargo.toml version matches the release/engine version
+        shell: bash
+        run: |
+          cargo_ver="$(grep -m1 -E '^version[[:space:]]*=' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [ "v$cargo_ver" != "$ENGINE_VERSION" ]; then
+            echo "::error::Cargo.toml version (v$cargo_ver) != release/engine version ($ENGINE_VERSION)."
+            exit 1
+          fi
+
+      - name: Check out engine source at ${{ env.ENGINE_VERSION }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ vars.SMOLVM_ENGINE_REPO }}
+          ref: ${{ env.ENGINE_VERSION }}
+          path: __engine__
+      - name: Repoint smol path deps at the engine checkout
+        shell: bash
+        run: |
+          perl -i -pe 's{path = "\.\./crates/}{path = "__engine__/crates/}g' Cargo.toml
+          perl -i -pe 's{path = "\.\."}{path = "__engine__"}g' Cargo.toml
+          if grep -nE 'path = "\.\.' Cargo.toml; then
+            echo "::error::a path dep was not repointed at __engine__"; exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-gnu
+
+      - name: Install mingw-w64 + zip
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64 zip unzip
+
+      - name: Download engine Windows zip
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENGINE_REPO: ${{ vars.SMOLVM_ENGINE_REPO }}
+        run: |
+          mkdir -p engine-asset
+          asset="smolvm-${ENGINE_VERSION#v}-windows-x86_64.zip"
+          gh release download "$ENGINE_VERSION" --repo "$ENGINE_REPO" --pattern "$asset" --dir engine-asset --clobber
+          [ -f "engine-asset/$asset" ] || { echo "::error::engine Windows asset $asset not found in $ENGINE_VERSION"; exit 1; }
+          echo "ENGINE_ZIP=$PWD/engine-asset/$asset" >> "$GITHUB_ENV"
+
+      - name: Build self-contained Windows bundle
+        env:
+          SMOLVM_ENGINE_VERSION: ${{ env.ENGINE_VERSION }}
+        run: bash scripts/build-smol-dist-windows.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: smol-windows-x86_64
+          path: |
+            dist/smol-*-windows-x86_64.zip
+            dist/smol-*-windows-x86_64.zip.sha256
+          if-no-files-found: error
+
   publish:
     name: publish release
-    needs: build
+    needs: [build, build-windows]
     # Publish ONLY for tag pushes or an explicit dispatch publish:true. (Guarding
     # on the tag ref, not just event==push, so a future branch trigger can't ship.)
     if: ${{ startsWith(github.ref, 'refs/tags/') || inputs.publish }}
@@ -158,6 +228,7 @@ jobs:
           for p in darwin-arm64 linux-x86_64 linux-arm64; do
             ls dist/smol-*-"$p".tar.gz >/dev/null 2>&1 || { echo "::error::missing $p tarball — refusing to publish a partial release"; exit 1; }
           done
+          ls dist/smol-*-windows-x86_64.zip >/dev/null 2>&1 || { echo "::error::missing windows-x86_64 zip — refusing to publish a partial release"; exit 1; }
       - name: Verify checksums
         shell: bash
         run: |
@@ -170,10 +241,10 @@ jobs:
         run: |
           notes="Self-contained \`smol\` CLI — bundles its own libkrun runtime + guest agent (smolvm $TAG). Install: \`curl -sSL https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$TAG/scripts/install.sh | bash\`"
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber dist/smol-*.tar.gz dist/checksums.sha256
+            gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber dist/smol-*.tar.gz dist/smol-*.zip dist/checksums.sha256
           else
             # --target pins the tag to THIS run's commit when the tag doesn't exist yet
             # (the dispatch case); on a tag push the tag already exists and is used as-is.
             gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --target "$GITHUB_SHA" \
-              --title "smol $TAG" --notes "$notes" dist/smol-*.tar.gz dist/checksums.sha256
+              --title "smol $TAG" --notes "$notes" dist/smol-*.tar.gz dist/smol-*.zip dist/checksums.sha256
           fi

--- a/build.rs
+++ b/build.rs
@@ -73,6 +73,16 @@ fn link_krun() {
 }
 
 fn main() {
+    // Build scripts run on the HOST, so `cfg!(target_os)` here describes the
+    // build machine, not the artifact. A Linux/macOS → Windows cross build must
+    // NOT emit the Unix libkrun link args: on Windows, libkrun (krun.dll) is
+    // loaded at runtime via libloading, with no link-time dependency. Gate on
+    // the actual compile target (mirrors the engine build.rs) so the Unix link
+    // path below is skipped when producing a Windows binary.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        return;
+    }
+
     // On macOS, create a placeholder __SMOLVM,__smolvm Mach-O section.
     // This section is replaced with real data by `smolvm pack --single-file`.
     // The placeholder marker is NOT the SMOLSECT magic, so detect.rs won't

--- a/scripts/build-smol-dist-windows.sh
+++ b/scripts/build-smol-dist-windows.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# build-smol-dist-windows.sh — assemble a self-contained `smol` CLI for Windows.
+#
+# CROSS build: runs on Linux/macOS, cross-compiles smol.exe with the mingw-w64
+# toolchain, and reuses the runtime assets (krun.dll + libkrunfw.dll +
+# agent-rootfs.tar.gz + pre-formatted ext4 templates) straight from the matching
+# smolvm Windows release zip — the same "reuse the engine release" contract as
+# build-smol-dist.sh, so the host CLI and guest agent share one wire protocol.
+#
+# Windows resolves krun.dll (+ its libkrunfw.dll dependency) and the disk
+# templates from smol.exe's OWN directory, and extracts agent-rootfs.tar.gz on
+# first run — so there is NO wrapper script here (unlike the Unix bundle);
+# everything sits beside smol.exe and the folder is relocatable.
+#
+# Output: dist/smol-<version>-windows-x86_64.zip (+ .sha256)
+#
+# Env (all optional):
+#   SMOLVM_ENGINE_VERSION  engine release tag for the runtime assets (default v<Cargo version>)
+#   ENGINE_REPO            repo holding that release (default smol-machines/smolvm)
+#   ENGINE_ZIP             path to an already-downloaded smolvm-<ver>-windows-x86_64.zip;
+#                          when set, skip `gh release download`
+#   OUT_DIR                zip destination (default <smol>/dist)
+#   GH_TOKEN               token for `gh release download`
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SMOL_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLATFORM="windows-x86_64"
+TARGET="x86_64-pc-windows-gnu"
+
+VERSION="$(grep -m1 -E '^version[[:space:]]*=' "$SMOL_ROOT/Cargo.toml" | sed -E 's/.*"([^"]+)".*/\1/')"
+[ -n "$VERSION" ] || { echo "error: could not parse version from Cargo.toml" >&2; exit 1; }
+ENGINE_VERSION="${SMOLVM_ENGINE_VERSION:-v$VERSION}"
+ENGINE_REPO="${ENGINE_REPO:-smol-machines/smolvm}"
+OUT_DIR="${OUT_DIR:-$SMOL_ROOT/dist}"
+DIST_NAME="smol-${VERSION}-${PLATFORM}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo ">> building $DIST_NAME (engine Windows assets from $ENGINE_REPO@$ENGINE_VERSION)"
+
+# ── 1. obtain the engine Windows zip (krun.dll + libkrunfw.dll + rootfs + templates)
+ASSET="smolvm-${ENGINE_VERSION#v}-${PLATFORM}.zip"
+if [ -n "${ENGINE_ZIP:-}" ]; then
+  SRC="$ENGINE_ZIP"
+else
+  echo ">> downloading $ASSET"
+  gh release download "$ENGINE_VERSION" --repo "$ENGINE_REPO" --pattern "$ASSET" --dir "$WORK" --clobber
+  SRC="$WORK/$ASSET"
+fi
+[ -f "$SRC" ] || { echo "error: engine Windows zip not found: $SRC" >&2; exit 1; }
+unzip -q "$SRC" -d "$WORK/engine"
+ENGINE_EXTRACT="$WORK/engine/smolvm-${ENGINE_VERSION#v}-${PLATFORM}"
+for f in krun.dll libkrunfw.dll agent-rootfs.tar.gz; do
+  [ -f "$ENGINE_EXTRACT/$f" ] || { echo "error: engine zip missing $f" >&2; exit 1; }
+done
+
+# ── 2. cross-compile smol.exe (no link-time libkrun — Windows dlopens krun.dll)
+LINKER="${CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER:-x86_64-w64-mingw32-gcc}"
+command -v "$LINKER" >/dev/null 2>&1 || {
+  echo "error: mingw linker $LINKER not found (apt: gcc-mingw-w64-x86-64; brew: mingw-w64)" >&2; exit 1; }
+export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$LINKER"
+rustup target list --installed 2>/dev/null | grep -q "$TARGET" || rustup target add "$TARGET"
+echo ">> cross-compiling smol.exe ($TARGET)"
+( cd "$SMOL_ROOT" && cargo build --release --bin smol --target "$TARGET" )
+EXE="$SMOL_ROOT/target/$TARGET/release/smol.exe"
+[ -f "$EXE" ] || { echo "error: cross build did not produce $EXE" >&2; exit 1; }
+
+# ── 3. assemble the dist — everything beside smol.exe, no wrapper on Windows
+DIST="$WORK/$DIST_NAME"
+mkdir -p "$DIST"
+cp "$EXE" "$DIST/smol.exe"
+cp "$ENGINE_EXTRACT/krun.dll" "$DIST/krun.dll"
+cp "$ENGINE_EXTRACT/libkrunfw.dll" "$DIST/libkrunfw.dll"
+cp "$ENGINE_EXTRACT/agent-rootfs.tar.gz" "$DIST/agent-rootfs.tar.gz"
+for t in storage-template.ext4 overlay-template.ext4; do
+  [ -f "$ENGINE_EXTRACT/$t" ] && cp "$ENGINE_EXTRACT/$t" "$DIST/"
+done
+
+cat > "$DIST/README.txt" <<EOF
+smol ${VERSION} — self-contained CLI for Smol Machines (Windows x86_64)
+
+This bundle is fully self-contained: it ships its own libkrun runtime and guest
+agent (smolvm ${ENGINE_VERSION}). No separate smolvm install is required.
+
+REQUIREMENTS
+  Windows 10/11 x86_64 with the Windows Hypervisor Platform (WHP) feature enabled:
+    dism /online /enable-feature /featurename:HypervisorPlatform /all   (then reboot)
+  or Settings > Optional features > More Windows features > Windows Hypervisor Platform.
+
+INSTALL
+  Unzip anywhere and keep all files together — krun.dll, libkrunfw.dll, the ext4
+  disk templates, and agent-rootfs.tar.gz must stay beside smol.exe. Optionally add
+  the folder to PATH. Or install with PowerShell:
+    irm https://raw.githubusercontent.com/smol-machines/smol/${ENGINE_VERSION}/scripts/install.ps1 | iex
+
+USAGE
+  smol.exe run -I alpine --net -- echo "Hello from Windows"
+  smol.exe --help
+
+NOT YET SUPPORTED ON WINDOWS: GPU acceleration; machine fork / snapshot.
+Networking is TSI-only (outbound TCP/UDP + inbound -p; no virtio-net).
+EOF
+
+# ── 4. checksums + zip (Windows ships a .zip, not a tarball)
+sha() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$@"; else shasum -a 256 "$@"; fi; }
+( cd "$DIST" && sha smol.exe krun.dll libkrunfw.dll agent-rootfs.tar.gz > checksums.txt )
+mkdir -p "$OUT_DIR"
+rm -f "$OUT_DIR/${DIST_NAME}.zip"
+( cd "$WORK" && zip -qr "$OUT_DIR/${DIST_NAME}.zip" "$DIST_NAME" )
+( cd "$OUT_DIR" && sha "${DIST_NAME}.zip" > "${DIST_NAME}.zip.sha256" )
+echo ">> done: $OUT_DIR/${DIST_NAME}.zip ($(du -h "$OUT_DIR/${DIST_NAME}.zip" | cut -f1))"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,106 @@
+<#
+.SYNOPSIS
+  Install the self-contained `smol` CLI on Windows (x86_64).
+
+.DESCRIPTION
+  Downloads the smol-<version>-windows-x86_64.zip release bundle (smol.exe +
+  bundled libkrun runtime + guest agent), verifies its checksum, extracts it to
+  a prefix, and adds that prefix to the user PATH. No separate smolvm install is
+  required — the bundle is self-contained.
+
+  Run:
+    irm https://raw.githubusercontent.com/smol-machines/smol/main/scripts/install.ps1 | iex
+
+.NOTES
+  Environment overrides:
+    SMOL_VERSION                 install a specific tag (default: latest release)
+    SMOL_PREFIX                  install location (default: %LOCALAPPDATA%\Programs\smol)
+    SMOL_INSECURE_SKIP_CHECKSUM  =1 to install without verifying the checksum (NOT recommended)
+#>
+
+$ErrorActionPreference = "Stop"
+$Repo = "smol-machines/smol"
+$Platform = "windows-x86_64"
+
+function Info($m) { Write-Host ">> $m" }
+
+if ([Environment]::Is64BitOperatingSystem -eq $false) {
+    throw "smol requires 64-bit Windows (x86_64)."
+}
+
+# ── resolve version ─────────────────────────────────────────────────────────
+$Version = $env:SMOL_VERSION
+if (-not $Version) {
+    Info "resolving latest release of $Repo"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" `
+        -Headers @{ "User-Agent" = "smol-install" }
+    $Version = $rel.tag_name
+}
+$Ver  = $Version.TrimStart("v")
+$Dist = "smol-$Ver-$Platform"
+$Zip  = "$Dist.zip"
+$Base = "https://github.com/$Repo/releases/download/$Version"
+
+$Tmp = Join-Path $env:TEMP ("smol-install-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $Tmp | Out-Null
+try {
+    Info "installing smol $Version ($Platform)"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Info "downloading $Zip"
+    Invoke-WebRequest -Uri "$Base/$Zip" -OutFile "$Tmp\$Zip" -UseBasicParsing
+
+    # ── verify checksum (combined checksums.sha256; fall back to per-asset) ──
+    $want = $null
+    try {
+        Invoke-WebRequest -Uri "$Base/checksums.sha256" -OutFile "$Tmp\checksums.sha256" -UseBasicParsing
+        $line = Get-Content "$Tmp\checksums.sha256" |
+            Where-Object { $_ -match [regex]::Escape($Zip) } | Select-Object -First 1
+        if ($line) { $want = ($line -split '\s+')[0] }
+    } catch {}
+    if (-not $want) {
+        try {
+            Invoke-WebRequest -Uri "$Base/$Zip.sha256" -OutFile "$Tmp\$Zip.sha256" -UseBasicParsing
+            $want = ((Get-Content "$Tmp\$Zip.sha256") -split '\s+')[0]
+        } catch {}
+    }
+    if ($want) {
+        Info "verifying checksum"
+        $got = (Get-FileHash "$Tmp\$Zip" -Algorithm SHA256).Hash.ToLower()
+        if ($got -ne $want.ToLower()) { throw "checksum mismatch (want '$want', got '$got')" }
+    } elseif ($env:SMOL_INSECURE_SKIP_CHECKSUM -eq "1") {
+        Info "WARNING: checksum unavailable; SMOL_INSECURE_SKIP_CHECKSUM=1 — installing unverified"
+    } else {
+        throw "checksum not found for $Zip (set SMOL_INSECURE_SKIP_CHECKSUM=1 to override)"
+    }
+
+    # ── install ─────────────────────────────────────────────────────────────
+    $Prefix = $env:SMOL_PREFIX
+    if (-not $Prefix) { $Prefix = Join-Path $env:LOCALAPPDATA "Programs\smol" }
+    if (Test-Path $Prefix) { Remove-Item -Recurse -Force $Prefix }
+    New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
+
+    Info "installing to $Prefix"
+    Expand-Archive -Path "$Tmp\$Zip" -DestinationPath $Tmp -Force
+    # The zip holds a top-level "$Dist\" folder — move its contents into $Prefix
+    # so smol.exe (and its DLLs/templates) land directly in the prefix.
+    Copy-Item -Path (Join-Path $Tmp "$Dist\*") -Destination $Prefix -Recurse -Force
+
+    # ── add to the user PATH ────────────────────────────────────────────────
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if (($userPath -split ';') -notcontains $Prefix) {
+        [Environment]::SetEnvironmentVariable("Path", ($userPath.TrimEnd(';') + ";$Prefix"), "User")
+        Info "added $Prefix to your PATH (open a new terminal to pick it up)"
+    }
+    $env:Path = "$env:Path;$Prefix"
+
+    $installed = & "$Prefix\smol.exe" --version
+    Info "installed: $installed"
+    Write-Host ""
+    Write-Host "smol needs the Windows Hypervisor Platform to boot VMs. If it's not enabled:"
+    Write-Host "  dism /online /enable-feature /featurename:HypervisorPlatform /all   (admin, then reboot)"
+    Write-Host "Then try:  smol run -I alpine --net -- cat /etc/os-release"
+}
+finally {
+    Remove-Item -Recurse -Force $Tmp -ErrorAction SilentlyContinue
+}

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -57,7 +57,7 @@ from .types import (
     ResourceSpec,
 )
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 
 __all__ = [
     "Machine",

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -6,6 +6,17 @@ use smolvm::agent::{AgentManager, ExecEvent, RunConfig};
 use smolvm::db::SmolvmDb;
 use std::time::Duration;
 
+/// Windows stand-in for a SIGWINCH stream: `recv()` never completes, so the
+/// terminal-resize select arm stays inert (Windows has no resize signal).
+#[cfg(not(unix))]
+struct WinchStub;
+#[cfg(not(unix))]
+impl WinchStub {
+    async fn recv(&mut self) -> Option<()> {
+        std::future::pending::<Option<()>>().await
+    }
+}
+
 #[derive(Args, Debug)]
 pub struct ExecCmd {
     /// Machine name (default: "default")
@@ -342,8 +353,13 @@ impl ExecCmd {
             let mut stdout = tokio::io::stdout();
             let mut buf = vec![0u8; 8192];
             let mut stdin_open = true;
+            // Terminal-resize (SIGWINCH) forwarding is Unix-only; on Windows use a
+            // never-ready stub so the resize select arm below simply never fires.
+            #[cfg(unix)]
             let mut winch =
                 tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())?;
+            #[cfg(not(unix))]
+            let mut winch = WinchStub;
             let mut exit_code = 0i32;
 
             loop {

--- a/src/commands/fork.rs
+++ b/src/commands/fork.rs
@@ -12,7 +12,7 @@ use smolvm::config::RecordState;
 use smolvm::data::network::PortMapping;
 use smolvm::db::SmolvmDb;
 use std::io::{Read, Write};
-use std::os::unix::net::UnixStream;
+use smolvm::platform::uds::UdsStream;
 use std::path::Path;
 use std::time::Duration;
 
@@ -383,7 +383,7 @@ fn host_random_hex(hex_len: usize) -> String {
 /// Send one line to a VM control socket and return its reply line.
 fn control_socket_cmd(sock: &Path, cmd: &str) -> anyhow::Result<String> {
     let mut stream =
-        UnixStream::connect(sock).map_err(|e| anyhow::anyhow!("connect control socket: {e}"))?;
+        UdsStream::connect(sock).map_err(|e| anyhow::anyhow!("connect control socket: {e}"))?;
     stream.set_read_timeout(Some(Duration::from_secs(60))).ok();
     stream
         .write_all(format!("{cmd}\n").as_bytes())

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,7 +172,9 @@ fn boot_vm(config_path: std::path::PathBuf) -> smolvm::Result<()> {
     use smolvm::agent::boot_config::BootConfig;
     use smolvm::agent::{launch_agent_vm, LaunchConfig, VmDisks};
 
-    // Become a session leader (detach from parent's terminal session)
+    // Become a session leader (detach from parent's terminal session).
+    // POSIX-only; Windows has no process sessions.
+    #[cfg(unix)]
     unsafe {
         libc::setsid();
     }
@@ -195,7 +197,10 @@ fn boot_vm(config_path: std::path::PathBuf) -> smolvm::Result<()> {
         smolvm::process::exit_child(1);
     }
 
-    // Close ALL inherited file descriptors from the parent
+    // Close ALL inherited file descriptors from the parent. POSIX-only — fd
+    // numbers and getdtablesize are a Unix concept; on Windows inherited handles
+    // are managed differently and this loop does not apply.
+    #[cfg(unix)]
     unsafe {
         let max_fd = libc::getdtablesize();
         for fd in 3..max_fd {


### PR DESCRIPTION
The `smol` CLI was never built for Windows — the release matrix only produced darwin-arm64/linux-x86_64/linux-arm64, and install.sh is bash-only, so Windows users couldn't install it at all (the #1 source of "smolvm doesn't work on Windows" reports). The engine already ships a Windows build; this does the same for the CLI.

- build.rs: gate the Unix libkrun link path on the real compile target (CARGO_CFG_TARGET_OS), so a Linux→Windows cross build skips it — on Windows libkrun (krun.dll) is loaded at runtime via libloading, no link-time dep.
- main.rs / exec.rs / fork.rs: cfg-gate the Unix-only paths (setsid, getdtablesize, SIGWINCH) and use the engine's cross-platform UDS instead of std::os::unix UnixStream.
- scripts/build-smol-dist-windows.sh: cross-compile smol.exe with mingw-w64 and assemble a self-contained zip, reusing the runtime assets (krun.dll + libkrunfw.dll + agent-rootfs + ext4 templates) from the matching smolvm Windows release.
- scripts/install.ps1: PowerShell installer (irm ... | iex).
- release-smol.yml: a build-windows job + publish now ships smol-<ver>-windows-x86_64.zip.

Validated locally: smol.exe cross-compiles to a valid PE32+ (imports KERNEL32/ws2_32, no link-time krun). Runtime VM boot needs the Windows Hypervisor Platform on real hardware (GCP nested virt can't host WHP).