### PR TITLE
Match python SDK __version__ to 1.4.4

### DIFF
--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -57,7 +57,7 @@ from .types import (
     ResourceSpec,
 )
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"
 
 __all__ = [
     "Machine",


### PR DESCRIPTION
The python package __version__ was left at 1.4.3, tripping the version-consistency check; bump it to 1.4.4 to match the CLI and other SDK manifests.