### PR TITLE
feat(cloud deploy): add --auto-stop <SECONDS> for opt-in scale-to-zero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.4.5"
+version = "1.4.7"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.4.5"
+version = "1.4.7"
 dependencies = [
  "async-stream",
  "axum",
@@ -2367,6 +2367,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tower-http",
  "tracing",
@@ -2387,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.4.5"
+version = "1.4.7"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2399,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.4.5"
+version = "1.4.7"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2418,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.4.5"
+version = "1.4.7"
 dependencies = [
  "base64",
  "serde",
@@ -2428,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.4.5"
+version = "1.4.7"
 dependencies = [
  "bytes",
  "dirs",

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -77,6 +77,11 @@ pub struct DeployCmd {
     /// host at deploy time (repeatable)
     #[arg(long = "secret-file", value_name = "GUEST_VAR=/abs/path")]
     pub secret_file: Vec<String>,
+
+    /// Sleep the app after N seconds idle; a request wakes it (scale-to-zero).
+    /// Omit to keep the app always-on.
+    #[arg(long = "auto-stop", value_name = "SECONDS")]
+    pub auto_stop: Option<u64>,
 }
 
 /// Sync-resolved inputs for the push step. Resolved outside the runtime so
@@ -85,6 +90,18 @@ pub struct DeployCmd {
 struct PushInputs {
     client: smolvm_registry::RegistryClient,
     reference: smolvm::registry::Reference,
+}
+
+/// Apply the optional scale-to-zero setting to a create-request body.
+///
+/// `Some(seconds)` sets `autoStopSeconds` (the camelCase wire name the control
+/// plane expects) so the machine sleeps after that many idle seconds and wakes
+/// on the next request. `None` leaves the body untouched — the field is absent,
+/// so the request is identical to an always-on deploy (the server default).
+fn apply_auto_stop(body: &mut serde_json::Value, auto_stop: Option<u64>) {
+    if let Some(seconds) = auto_stop {
+        body["autoStopSeconds"] = serde_json::json!(seconds);
+    }
 }
 
 impl DeployCmd {
@@ -214,7 +231,7 @@ impl DeployCmd {
         )?);
         let env: std::collections::BTreeMap<String, String> = env_pairs.into_iter().collect();
 
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "name": name,
             "source": source,
             "resources": {
@@ -230,6 +247,10 @@ impl DeployCmd {
             "ports": [{ "port": self.port }],
             "public": self.public,
         });
+        // Opt into scale-to-zero only when `--auto-stop` was given. Omitting the
+        // flag omits the field, keeping the request byte-for-byte identical to
+        // the always-on default the control plane already applies.
+        apply_auto_stop(&mut body, self.auto_stop);
 
         eprintln!("Deploying {} to {}...", reference, endpoint);
 
@@ -312,5 +333,57 @@ impl DeployCmd {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    // `DeployCmd` derives `Args`, not `Parser`, so flatten it into a throwaway
+    // `Parser` to exercise it through clap exactly as `smol cloud deploy` would.
+    #[derive(Parser, Debug)]
+    struct Wrap {
+        #[command(flatten)]
+        inner: DeployCmd,
+    }
+
+    fn parse(args: &[&str]) -> Result<DeployCmd, clap::Error> {
+        Wrap::try_parse_from(args).map(|w| w.inner)
+    }
+
+    #[test]
+    fn auto_stop_flag_parses_to_optional_u64() {
+        let cmd = parse(&["smol", "myapp:v1", "--auto-stop", "300"]).unwrap();
+        assert_eq!(cmd.auto_stop, Some(300));
+    }
+
+    #[test]
+    fn auto_stop_flag_absent_is_none() {
+        let cmd = parse(&["smol", "myapp:v1"]).unwrap();
+        assert_eq!(cmd.auto_stop, None, "no flag ⇒ None ⇒ always-on");
+    }
+
+    #[test]
+    fn auto_stop_flag_rejects_non_integer() {
+        assert!(parse(&["smol", "myapp:v1", "--auto-stop", "soon"]).is_err());
+    }
+
+    #[test]
+    fn body_carries_auto_stop_seconds_when_set() {
+        let mut body = serde_json::json!({ "name": "myapp" });
+        apply_auto_stop(&mut body, Some(300));
+        assert_eq!(body["autoStopSeconds"], serde_json::json!(300));
+    }
+
+    #[test]
+    fn body_omits_auto_stop_seconds_when_unset() {
+        let mut body = serde_json::json!({ "name": "myapp" });
+        apply_auto_stop(&mut body, None);
+        assert!(
+            body.get("autoStopSeconds").is_none(),
+            "an always-on deploy must omit the field entirely (byte-identical to today)"
+        );
     }
 }

--- a/src/commands/machines.rs
+++ b/src/commands/machines.rs
@@ -28,8 +28,8 @@ impl MachinesCmd {
         }
 
         println!(
-            "{:<36} {:<20} {:<25} {:<12} {:<20}",
-            "ID", "NAME", "SOURCE", "STATE", "UPDATED"
+            "{:<36} {:<20} {:<25} {:<12} {:<12} {:<20}",
+            "ID", "NAME", "SOURCE", "STATE", "AUTO-STOP", "UPDATED"
         );
 
         for m in &machines {
@@ -40,13 +40,18 @@ impl MachinesCmd {
                 .unwrap_or("-");
             let updated = m.updated_at.as_deref().unwrap_or("-");
             let updated_short = updated.split('T').next().unwrap_or(updated);
+            let auto_stop = m
+                .auto_stop_seconds
+                .map(|s| format!("{s}s"))
+                .unwrap_or_else(|| "always-on".to_string());
 
             println!(
-                "{:<36} {:<20} {:<25} {:<12} {:<20}",
+                "{:<36} {:<20} {:<25} {:<12} {:<12} {:<20}",
                 m.id,
                 m.name.as_deref().unwrap_or("-"),
                 source,
                 m.state,
+                auto_stop,
                 updated_short
             );
         }

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -58,6 +58,7 @@ impl PullCmd {
             tag_or_digest,
             self.output.as_deref(),
             &cache,
+            &[], // no brokered P2P peers for a CLI pull
         ))?;
 
         tracing::debug!(digest = %result.digest, size = result.size, cached = result.cached, "pull completed");

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -112,6 +112,10 @@ impl StatusCmd {
                             .unwrap_or(0);
                         let created = machine.created_at.as_deref().unwrap_or("-");
                         let updated = machine.updated_at.as_deref().unwrap_or("-");
+                        let auto_stop = machine
+                            .auto_stop_seconds
+                            .map(|s| format!("{s}s idle (scale-to-zero)"))
+                            .unwrap_or_else(|| "always-on".to_string());
 
                         println!(
                             "Machine '{}' ({}): {}",
@@ -122,6 +126,7 @@ impl StatusCmd {
                         println!("  Source:  {}", source);
                         println!("  CPUs:    {}", cpus);
                         println!("  Memory:  {} MiB", mem);
+                        println!("  Auto-stop: {}", auto_stop);
                         println!("  Created: {}", created);
                         println!("  Updated: {}", updated);
                     }


### PR DESCRIPTION
Adds a `--auto-stop <SECONDS>` flag to the cloud create/deploy path that opts an app into scale-to-zero by sending `autoStopSeconds`, with the flag omitted keeping today's always-on default unchanged.