### PR TITLE
Bump smol CLI and SDKs to 1.5.0 to track the smolvm 1.5.0 engine release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,7 +2272,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol-cli"
-version = "1.4.5"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.4.5"
+version = "1.5.0"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.4.5"
+version = "1.5.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -2380,14 +2380,14 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.3.1"
+version = "1.5.0"
 dependencies = [
  "libloading",
 ]
 
 [[package]]
 name = "smolvm-network"
-version = "1.4.5"
+version = "1.5.0"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.4.5"
+version = "1.5.0"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.4.5"
+version = "1.5.0"
 dependencies = [
  "base64",
  "serde",
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.4.5"
+version = "1.5.0"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk", "__engine__"]
 name = "smol-cli"
 # Tracks the bundled smolvm engine release: a `smol` vX.Y.Z ships smolvm vX.Y.Z's
 # libkrun + agent-rootfs, so the host CLI and guest agent can never drift.
-version = "1.4.5"
+version = "1.5.0"
 edition = "2021"
 description = "Ship and run software with isolation by default"
 license = "Apache-2.0"

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "smol-node"
-version = "1.4.5"
+version = "1.5.0"
 edition = "2021"
 description = "Native NAPI core for the smol SDK — embed microVMs directly in Node.js"
 license = "Apache-2.0"

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smolmachines",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "Embed isolated microVM sandboxes directly in your code — no server to run.",
   "license": "Apache-2.0",
   "author": "smol-machines",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol-py"
-version = "1.4.5"
+version = "1.5.0"
 edition = "2021"
 description = "Native (pyo3) core for the smol Python SDK — embeds the smolvm engine in-process."
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smolmachines"
-version = "1.4.5"
+version = "1.5.0"
 description = "Embed isolated microVM sandboxes directly in your Python code — local (embedded) or smolfleet cloud."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -57,7 +57,7 @@ from .types import (
     ResourceSpec,
 )
 
-__version__ = "1.4.5"
+__version__ = "1.5.0"
 
 __all__ = [
     "Machine",

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -150,6 +150,7 @@ impl PackCreateCmd {
                 network_backend: None,
                 gpu: false,
                 gpu_vram_mib: None,
+                rosetta: false,
                 dns: None,
             },
         )?;

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -58,6 +58,7 @@ impl PullCmd {
             tag_or_digest,
             self.output.as_deref(),
             &cache,
+            &[],
         ))?;
 
         tracing::debug!(digest = %result.digest, size = result.size, cached = result.cached, "pull completed");

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -104,6 +104,7 @@ impl RunCmd {
             network_backend: None,
             gpu: self.gpu,
             gpu_vram_mib: self.gpu_vram,
+            rosetta: false,
             dns: None,
         };
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -110,6 +110,7 @@ impl UpCmd {
             network_backend: None,
             gpu,
             gpu_vram_mib,
+            rosetta: false,
             dns: None,
         };
 


### PR DESCRIPTION
Bumps the CLI, Node SDK, and Python SDK to 1.5.0 (with matching Cargo.lock entries) so smol bundles the smolvm 1.5.0 runtime and guest agent.