### PR TITLE
Add the rosetta field to the Node SDK VmResources binding for the smolvm 1.5.0 API

### DIFF
--- a/sdk/node/src/types.rs
+++ b/sdk/node/src/types.rs
@@ -177,6 +177,7 @@ impl VmResourcesConfig {
             allowed_cidrs: None,
             gpu: self.gpu.unwrap_or(false),
             gpu_vram_mib: self.gpu_vram_mib,
+            rosetta: false,
             dns: None,
         }
     }


### PR DESCRIPTION
The smolvm 1.5.0 VmResources gained a rosetta field and the Node SDK native binding constructed VmResources without it, which failed the SDK release build; this adds rosetta: false to match, verified by a build-only SDK release dispatch that compiles the node and python addons across all targets. npm and PyPI 1.5.0 were never published (the failed build skipped the publish steps), so this unblocks the SDK half of the 1.5.0 release.