### PR TITLE
Pin npm to the 11.x line in the SDK publish job so it stays Node 20 compatible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,8 +261,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: npm
           cache-dependency-path: sdk/node/package-lock.json
-      # OIDC trusted publishing needs npm ≥ 11.5.1; node 20 ships npm 10.x.
-      - run: npm install -g npm@latest
+      # OIDC trusted publishing needs npm ≥ 11.5.1; node 20 ships npm 10.x. Pin
+      # the 11.x line rather than @latest — npm 12 dropped Node 20 support and
+      # fails this step with EBADENGINE on the node-20 runner.
+      - run: npm install -g npm@11
       - run: npm ci
       - run: npm run build:ts
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
npm@latest is now npm@12, which dropped Node 20 support and fails the SDK publish job with EBADENGINE on the node-20 runner; pinning the 11.x line keeps npm at the version OIDC trusted publishing needs (>= 11.5.1) while staying Node 20 compatible. The 1.5.0 SDK was already published to npm and PyPI via a dispatch off this branch, so this just lands the fix on main so future tag-triggered releases don't hit it.