### PR TITLE
Bundle libkrun's macOS GPU sibling dylibs in the Python wheel so local machines boot

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -51,6 +51,11 @@ include = [
     "python/smol/libkrunfw*.dylib",
     "python/smol/libkrun*.so*",
     "python/smol/libkrunfw*.so*",
+    # A GPU-enabled libkrun.dylib load-links libepoxy/virglrenderer/MoltenVK via
+    # @loader_path; bundle-native.sh vendors them next to libkrun, so they must be
+    # packaged too or the wheel's libkrun dangles and the VM boot process exits 1
+    # (dyld: "Library not loaded: @loader_path/libepoxy.0.dylib").
+    "python/smol/*.dylib",
     # The virgl weak-symbol stub bundle-native.sh compiles next to libkrun so it
     # loads under RTLD_NOW; without this glob the stub is dropped and libkrun's
     # NEEDED dangles (auditwheel repair then fails to locate it).

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,6 +285,7 @@ fn boot_vm(config_path: std::path::PathBuf) -> smolvm::Result<()> {
         ssh_agent_socket: config.ssh_agent_socket.as_deref(),
         dns_filter_socket: dns_filter_socket_path.as_deref(),
         cuda_socket: None,
+        docker_socket: None,
         packed_layers_dir: config.packed_layers_dir.as_deref(),
         extra_disks: &config.extra_disks,
         dns_filter_enabled: config


### PR DESCRIPTION
Package libkrun's macOS GPU sibling dylibs (libepoxy/virglrenderer/MoltenVK) in the Python wheel and set the engine's new LaunchConfig.docker_socket field, so local Machine.create boots on macOS and the CLI builds against the current engine.