### PR TITLE
Add --cuda / resources.cuda for CUDA-over-vsock GPU remoting

### DIFF
--- a/sdk/node/binding.d.ts
+++ b/sdk/node/binding.d.ts
@@ -48,6 +48,8 @@ export interface VmResourcesConfig {
   gpu?: boolean
   /** GPU VRAM in MiB (default: engine default when GPU is enabled). */
   gpuVramMib?: number
+  /** Run the guest's unmodified CUDA/PyTorch code on the host's NVIDIA GPU by remoting CUDA calls over vsock (distinct from `gpu`, which is Vulkan). Local target only (default: false). */
+  cuda?: boolean
 }
 /** Options for executing a command. */
 export interface ExecOptions {

--- a/sdk/node/src/types.rs
+++ b/sdk/node/src/types.rs
@@ -68,6 +68,10 @@ pub struct VmResourcesConfig {
     pub gpu: Option<bool>,
     /// GPU VRAM in MiB (default: engine default when GPU is enabled).
     pub gpu_vram_mib: Option<u32>,
+    /// Run the guest's unmodified CUDA/PyTorch code on the host's NVIDIA GPU by
+    /// remoting CUDA calls over vsock (distinct from `gpu`, which is Vulkan; no
+    /// CUDA toolkit needed in the image). Local target only (default: false).
+    pub cuda: Option<bool>,
 }
 
 /// Options for executing a command.
@@ -177,6 +181,7 @@ impl VmResourcesConfig {
             allowed_cidrs: None,
             gpu: self.gpu.unwrap_or(false),
             gpu_vram_mib: self.gpu_vram_mib,
+            cuda: self.cuda.unwrap_or(false),
             rosetta: false,
             dns: None,
         }

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -112,6 +112,8 @@ def _native_config(name: str, config: MachineConfig) -> dict:
             res["gpu"] = r.gpu
         if r.gpu_vram_mib is not None:
             res["gpu_vram_mib"] = r.gpu_vram_mib
+        if r.cuda is not None:
+            res["cuda"] = r.cuda
         cfg["resources"] = res
     return cfg
 

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -43,6 +43,10 @@ class ResourceSpec:
     """Enable GPU acceleration (virtio-gpu/venus). Local target only. Default: False."""
     gpu_vram_mib: Optional[int] = None
     """GPU VRAM in MiB (default: engine default when GPU is enabled). Local target only."""
+    cuda: Optional[bool] = None
+    """Run the guest's unmodified CUDA/PyTorch code on the host's NVIDIA GPU by
+    remoting CUDA Driver-API calls to the host over vsock (distinct from ``gpu``,
+    which is Vulkan; no CUDA toolkit needed in the image). Local target only."""
 
 
 @dataclass

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -285,6 +285,11 @@ impl Machine {
                         resources.gpu_vram_mib = Some(v.extract()?);
                     }
                 }
+                if let Some(v) = rd.get_item("cuda")? {
+                    if !v.is_none() {
+                        resources.cuda = v.extract()?;
+                    }
+                }
             }
         }
         // Map the Python `mounts` list (dicts of {source, target, read_only})

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -144,6 +144,7 @@ impl PackCreateCmd {
                 cpus: 2,
                 memory_mib: 512,
                 network: true,
+                cuda: false,
                 storage_gib: None,
                 overlay_gib: None,
                 allowed_cidrs: None,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -59,6 +59,12 @@ pub struct RunCmd {
     /// GPU VRAM in MiB (requires --gpu)
     #[arg(long, value_name = "MiB")]
     pub gpu_vram: Option<u32>,
+
+    /// Run unmodified CUDA/PyTorch code on the host's NVIDIA GPU by remoting the
+    /// guest's CUDA calls to the host over vsock (distinct from --gpu, which is
+    /// Vulkan). No CUDA toolkit needed in the image.
+    #[arg(long)]
+    pub cuda: bool,
 }
 
 impl RunCmd {
@@ -104,6 +110,7 @@ impl RunCmd {
             network_backend: None,
             gpu: self.gpu,
             gpu_vram_mib: self.gpu_vram,
+            cuda: self.cuda,
             rosetta: false,
             dns: None,
         };

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -100,6 +100,7 @@ impl UpCmd {
             cpus,
             memory_mib: mem,
             network: net,
+            cuda: false,
             storage_gib: sf.storage,
             overlay_gib: sf.overlay,
             allowed_cidrs: if allowed_cidrs.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,6 +262,26 @@ fn boot_vm(config_path: std::path::PathBuf) -> smolvm::Result<()> {
         None
     };
 
+    // Start the per-VM CUDA-over-vsock host server when requested (mirrors the
+    // engine's internal_boot). With it, unmodified CUDA/PyTorch code in the guest
+    // runs on the host GPU — the launcher bridges vsock port CUDA to this socket.
+    let cuda_socket_path = if config.cuda || config.resources.cuda {
+        let path = config
+            .vsock_socket
+            .parent()
+            .unwrap_or(std::path::Path::new("/tmp"))
+            .join("cuda.sock");
+        match smolvm::cuda_host::start(&path) {
+            Ok(()) => Some(path),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to start CUDA host server — CUDA disabled");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // Launch the VM (blocks until exit)
     let disks = VmDisks {
         storage: &storage_disk,
@@ -284,7 +304,7 @@ fn boot_vm(config_path: std::path::PathBuf) -> smolvm::Result<()> {
         resources: config.resources,
         ssh_agent_socket: config.ssh_agent_socket.as_deref(),
         dns_filter_socket: dns_filter_socket_path.as_deref(),
-        cuda_socket: None,
+        cuda_socket: cuda_socket_path.as_deref(),
         docker_socket: None,
         pod_net: None,
         packed_layers_dir: config.packed_layers_dir.as_deref(),


### PR DESCRIPTION
Adds `smol run --cuda` and `cuda` to the Python/Node SDK resources, wiring the guest's unmodified CUDA/PyTorch calls to the host NVIDIA GPU via the embedded engine and composing with the existing `fork()`. Depends on smolvm PR #628 (adds `VmResources.cuda`); merge that + cut an engine release first.