### PR TITLE
Non-interactive machine rm (-y/--yes, no hang on non-tty) + fix VmResources.cuda drift

### DIFF
--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -151,6 +151,7 @@ impl PackCreateCmd {
                 gpu: false,
                 gpu_vram_mib: None,
                 rosetta: false,
+                cuda: false,
                 dns: None,
             },
         )?;

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -10,8 +10,8 @@ pub struct RmCmd {
     #[arg(short = 'n', long, value_name = "NAME")]
     pub name: String,
 
-    /// Skip confirmation prompt
-    #[arg(long)]
+    /// Skip the confirmation prompt (non-interactive). Alias: --force
+    #[arg(short = 'y', long = "yes", visible_alias = "force")]
     pub force: bool,
 
     /// Delete a cloud machine (by name or ID). Usually unnecessary — a machine's
@@ -47,7 +47,18 @@ impl RmCmd {
 }
 
 /// Prompt on stderr for a delete; returns true if the user confirmed.
+///
+/// In a non-interactive context (a pipe, CI, a background job) there is no one
+/// to answer the prompt, and blocking on stdin would hang forever. Detect that
+/// and fail with an actionable message instead — the caller should pass `--yes`.
 fn confirm_delete(name: &str) -> anyhow::Result<bool> {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "refusing to delete '{}' without confirmation in a non-interactive context; pass --yes",
+            name
+        );
+    }
     eprint!("Delete machine '{}'? [y/N] ", name);
     let mut input = String::new();
     if std::io::stdin().read_line(&mut input).is_ok() {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -105,6 +105,7 @@ impl RunCmd {
             gpu: self.gpu,
             gpu_vram_mib: self.gpu_vram,
             rosetta: false,
+            cuda: false,
             dns: None,
         };
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -111,6 +111,7 @@ impl UpCmd {
             gpu,
             gpu_vram_mib,
             rosetta: false,
+            cuda: false,
             dns: None,
         };
 


### PR DESCRIPTION
Adds -y/--yes for machine rm (aliasing --force) and makes the confirmation refuse to run on a non-tty instead of blocking on stdin forever; also sets the engine's new VmResources.cuda field, which smol main was missing (CI was red before this).