### PR TITLE
Wire a --cuda flag through smol run and machine create

### DIFF
--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -44,6 +44,10 @@ pub struct CreateCmd {
     #[arg(long, value_name = "MiB")]
     pub gpu_vram: Option<u32>,
 
+    /// Remote guest CUDA Driver-API calls to the host NVIDIA GPU over vsock
+    #[arg(long, help_heading = "Hardware")]
+    pub cuda: bool,
+
     /// Mount host directory (HOST:GUEST[:ro])
     #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
     pub volume: Vec<String>,
@@ -168,6 +172,7 @@ impl CreateCmd {
         record.gpu = if self.gpu { Some(true) } else { None };
         record.gpu_vram_mib = smolvm::data::resources::validate_gpu_vram_mib(self.gpu_vram)
             .map_err(|e| anyhow::anyhow!("--gpu-vram: {}", e))?;
+        record.cuda = self.cuda;
 
         let mut config = SmolvmConfig::load()?;
         config.insert_vm(name.clone(), record)?;

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -144,7 +144,6 @@ impl PackCreateCmd {
                 cpus: 2,
                 memory_mib: 512,
                 network: true,
-                cuda: false,
                 storage_gib: None,
                 overlay_gib: None,
                 allowed_cidrs: None,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -110,9 +110,8 @@ impl RunCmd {
             network_backend: None,
             gpu: self.gpu,
             gpu_vram_mib: self.gpu_vram,
-            cuda: self.cuda,
             rosetta: false,
-            cuda: false,
+            cuda: self.cuda,
             dns: None,
         };
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -100,7 +100,6 @@ impl UpCmd {
             cpus,
             memory_mib: mem,
             network: net,
-            cuda: false,
             storage_gib: sf.storage,
             overlay_gib: sf.overlay,
             allowed_cidrs: if allowed_cidrs.is_empty() {


### PR DESCRIPTION
Adds --cuda to smol run and smol machine create so the engine's CUDA-over-vsock remoting is reachable from the CLI (sets VmResources.cuda / record.cuda). Stacked on #61; retarget to main once that merges.