### PR TITLE
Expose the cuda resource flag through the Node SDK's TypeScript surface

### DIFF
--- a/sdk/node/native.ts
+++ b/sdk/node/native.ts
@@ -38,6 +38,7 @@ export interface NativeResources {
   overlayGib?: number | undefined;
   gpu?: boolean | undefined;
   gpuVramMib?: number | undefined;
+  cuda?: boolean | undefined;
 }
 
 export interface NativeMachineConfig {

--- a/sdk/node/test/unit.ts
+++ b/sdk/node/test/unit.ts
@@ -70,6 +70,14 @@ check('omits gpu fields when unset (engine defaults apply)', () => {
   assert.strictEqual(cfg.resources?.gpu, undefined);
   assert.strictEqual(cfg.resources?.gpuVramMib, undefined);
 });
+check('forwards cuda to native resources', () => {
+  const cfg = toNativeConfig('m', { resources: { cuda: true } });
+  assert.strictEqual(cfg.resources?.cuda, true);
+});
+check('omits cuda when unset (engine default applies)', () => {
+  const cfg = toNativeConfig('m', { resources: { cpus: 2 } });
+  assert.strictEqual(cfg.resources?.cuda, undefined);
+});
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -108,6 +108,7 @@ export function toNativeConfig(
       overlayGib: config.resources.overlayGb,
       gpu: config.resources.gpu,
       gpuVramMib: config.resources.gpuVramMib,
+      cuda: config.resources.cuda,
     },
   };
 }

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -31,6 +31,13 @@ export interface ResourceSpec {
   gpu?: boolean;
   /** GPU VRAM in MiB (default: engine default when GPU is enabled). Local target only. */
   gpuVramMib?: number;
+  /**
+   * Run the guest's unmodified CUDA/PyTorch code on the host's NVIDIA GPU by
+   * remoting CUDA Driver-API calls over vsock (distinct from `gpu`, which is
+   * Vulkan). On a host without an NVIDIA GPU this falls back to a CPU-emulation
+   * backend. Local target only. Default: false.
+   */
+  cuda?: boolean;
 }
 
 /** Host directory mounted into the machine. */


### PR DESCRIPTION
The napi binding and the Python SDK already accept a cuda resource flag, but the Node SDK's public ResourceSpec, native interface, and transport mapping stopped at gpu, so cuda was unreachable from the ergonomic TypeScript API.