### PR TITLE
Bump the CLI and SDKs to 1.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk", "__engine__"]
 name = "smol-cli"
 # Tracks the bundled smolvm engine release: a `smol` vX.Y.Z ships smolvm vX.Y.Z's
 # libkrun + agent-rootfs, so the host CLI and guest agent can never drift.
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Ship and run software with isolation by default"
 license = "Apache-2.0"

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "smol-node"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Native NAPI core for the smol SDK — embed microVMs directly in Node.js"
 license = "Apache-2.0"

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smolmachines",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Embed isolated microVM sandboxes directly in your code — no server to run.",
   "license": "Apache-2.0",
   "author": "smol-machines",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol-py"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Native (pyo3) core for the smol Python SDK — embeds the smolvm engine in-process."
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smolmachines"
-version = "1.6.0"
+version = "1.6.1"
 description = "Embed isolated microVM sandboxes directly in your Python code — local (embedded) or smolfleet cloud."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -57,7 +57,7 @@ from .types import (
     ResourceSpec,
 )
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 __all__ = [
     "Machine",


### PR DESCRIPTION
Version bump to track the smolvm 1.6.1 engine release; ships the --cuda flag, the Node SDK cuda field, and non-interactive machine rm.