### PR TITLE
Route smolmachine pack image references through the from-smolmachine flow in create and reject them in ephemeral run, and bump to 1.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk", "__engine__"]
 name = "smol-cli"
 # Tracks the bundled smolvm engine release: a `smol` vX.Y.Z ships smolvm vX.Y.Z's
 # libkrun + agent-rootfs, so the host CLI and guest agent can never drift.
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 description = "Ship and run software with isolation by default"
 license = "Apache-2.0"

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "smol-node"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 description = "Native NAPI core for the smol SDK — embed microVMs directly in Node.js"
 license = "Apache-2.0"

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smolmachines",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Embed isolated microVM sandboxes directly in your code — no server to run.",
   "license": "Apache-2.0",
   "author": "smol-machines",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol-py"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 description = "Native (pyo3) core for the smol Python SDK — embeds the smolvm engine in-process."
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smolmachines"
-version = "1.6.2"
+version = "1.6.3"
 description = "Embed isolated microVM sandboxes directly in your Python code — local (embedded) or smolfleet cloud."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -57,7 +57,7 @@ from .types import (
     ResourceSpec,
 )
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 __all__ = [
     "Machine",

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -110,6 +110,21 @@ impl CreateCmd {
             return self.create_from_smolmachine(&from);
         }
 
+        // A registry `--image` can name a smolmachine PACK artifact (e.g.
+        // registry.smolmachines.com/library/enforra-node:0.1.0) whose single
+        // "layer" is a complete .smolmachine sidecar, not an OCI filesystem
+        // layer. The in-guest OCI puller would tar-unpack its multi-GiB
+        // storage.ext4 into the guest disk and fill it before boot, so probe
+        // the manifest on the host and, when it is a pack, reroute through the
+        // proven from-.smolmachine flow (the same path as `--from`). The probe
+        // fails open — a non-pack ref or any probe error returns None and falls
+        // through to the normal registry pull, so ordinary images are untouched.
+        if let Some(img) = self.image.clone() {
+            if let Some(sidecar) = smolvm::data::pack_ref::resolve_pack_ref_blocking(&img)? {
+                return self.create_from_smolmachine(&sidecar);
+            }
+        }
+
         let name = self
             .name
             .unwrap_or_else(smolvm::util::generate_machine_name);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -123,6 +123,29 @@ impl RunCmd {
         // exposed through `smol`.
         let (resolved_image, packed_layers_dir) = match self.image.as_deref() {
             Some(img) => {
+                // A registry `--image` can name a smolmachine PACK artifact
+                // (e.g. registry.smolmachines.com/library/enforra-node:0.1.0)
+                // whose single "layer" is a complete .smolmachine sidecar, not
+                // an OCI filesystem layer. The in-guest OCI puller would unpack
+                // its multi-GiB storage.ext4 into the guest disk and stall the
+                // boot. Unlike `machine create`, `run` is ephemeral and has no
+                // packed-layers cache to route a sidecar through, so probe the
+                // manifest on the host and refuse rather than start a doomed
+                // run — directing the user to the persistent pack flow. The
+                // probe fails open: a non-pack ref (or any probe error) returns
+                // None and falls through to normal resolution, so ordinary
+                // registry/local images are untouched.
+                if smolvm::data::pack_ref::resolve_pack_ref_blocking(img)?.is_some() {
+                    anyhow::bail!(
+                        "'{img}' is a smolmachine pack artifact, which `smol run` \
+                         cannot execute ephemerally.\n\
+                         Create a persistent machine from it instead:\n  \
+                         smol machine create --image {img}\n  \
+                         smol machine start\n\
+                         Or deploy it to the cloud:\n  \
+                         smol cloud deploy {img}"
+                    );
+                }
                 use smolvm::data::image_source::{classify, resolve, ResolvedImage};
                 match resolve(classify(img))? {
                     ResolvedImage::Registry(reference) => (Some(reference), None),
@@ -233,5 +256,25 @@ fn strip_separator(args: &[String]) -> Vec<String> {
         args[1..].to_vec()
     } else {
         args.to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Bare / Docker-convention image names must never be treated as smolmachine
+    /// packs: the probe short-circuits them to `None` (no registry round-trip),
+    /// so `run`/`create` fall through to the ordinary image path instead of
+    /// rerouting a Docker Hub pull into the pack flow. This guards the invariant
+    /// that only explicit-registry refs are probed.
+    #[test]
+    fn bare_and_hub_refs_are_not_rerouted_as_packs() {
+        for img in ["alpine", "alpine:3.20", "library/ubuntu:24.04"] {
+            let probed = smolvm::data::pack_ref::resolve_pack_ref_blocking(img)
+                .expect("probe fails open, never errors on a bare name");
+            assert!(
+                probed.is_none(),
+                "bare ref {img:?} must not be rerouted through the pack flow"
+            );
+        }
     }
 }


### PR DESCRIPTION
Detect an image reference whose registry manifest is a smolmachine pack artifact and route `smol machine create` through the from-smolmachine flow while directing `smol run` to the persistent flow, and bump the CLI and SDKs to 1.6.3.