### PR TITLE
Add smol cloud share and unshare for anonymous app links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["sdk", "__engine__"]
 name = "smol-cli"
 # Tracks the bundled smolvm engine release: a `smol` vX.Y.Z ships smolvm vX.Y.Z's
 # libkrun + agent-rootfs, so the host CLI and guest agent can never drift.
-version = "1.6.3"
+version = "1.6.4"
 edition = "2021"
 description = "Ship and run software with isolation by default"
 license = "Apache-2.0"

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "smol-node"
-version = "1.6.3"
+version = "1.6.4"
 edition = "2021"
 description = "Native NAPI core for the smol SDK — embed microVMs directly in Node.js"
 license = "Apache-2.0"

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smolmachines",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Embed isolated microVM sandboxes directly in your code — no server to run.",
   "license": "Apache-2.0",
   "author": "smol-machines",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol-py"
-version = "1.6.3"
+version = "1.6.4"
 edition = "2021"
 description = "Native (pyo3) core for the smol Python SDK — embeds the smolvm engine in-process."
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smolmachines"
-version = "1.6.3"
+version = "1.6.4"
 description = "Embed isolated microVM sandboxes directly in your Python code — local (embedded) or smolfleet cloud."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -57,7 +57,7 @@ from .types import (
     ResourceSpec,
 )
 
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 
 __all__ = [
     "Machine",

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -491,6 +491,17 @@ pub enum CloudSubcommand {
     ///
     ///   smol cloud export myapp --tag v1
     Export(CloudExportArgs),
+
+    /// Mint an anonymous share link for a machine's published app: anyone with
+    /// the URL can reach it without a smolmachines account.
+    ///
+    ///   smol cloud share myapp
+    Share(CloudShareArgs),
+
+    /// Revoke a machine's anonymous share link (existing link stops working).
+    ///
+    ///   smol cloud unshare myapp
+    Unshare(CloudShareArgs),
 }
 
 /// Arguments for `smol cloud export`.
@@ -503,6 +514,14 @@ pub struct CloudExportArgs {
     /// Tag for the artifact (default: latest)
     #[arg(long, default_value = "latest")]
     pub tag: String,
+}
+
+/// Arguments for `smol cloud share` / `smol cloud unshare`.
+#[derive(Args, Debug)]
+pub struct CloudShareArgs {
+    /// Machine name or ID
+    #[arg(value_name = "MACHINE")]
+    pub name: String,
 }
 
 /// Arguments for `smol cloud exec` (non-interactive cloud command execution).
@@ -567,6 +586,8 @@ impl CloudCmd {
             }
             .run(),
             CloudSubcommand::Export(a) => export_machine(a),
+            CloudSubcommand::Share(a) => share_machine(a),
+            CloudSubcommand::Unshare(a) => unshare_machine(a),
         }
     }
 }
@@ -605,6 +626,58 @@ fn export_machine(args: CloudExportArgs) -> Result<()> {
         }
         println!();
         println!("Re-deploy anywhere:  smol cloud deploy -I {}", out.reference);
+        Ok(())
+    })
+}
+
+/// `smol cloud share <machine>` — mint a per-machine anonymous share link. The
+/// returned URL carries the token as `?t=`, so anyone with it reaches this
+/// machine's published app without a smolmachines account. Re-running mints a
+/// fresh token (the previous link stops working).
+fn share_machine(args: CloudShareArgs) -> Result<()> {
+    run_cloud_command(Some(args.name), move |http, endpoint, id| async move {
+        let resp = http
+            .post(format!("{}/v1/machines/{}/share", endpoint, id))
+            .send()
+            .await?;
+        let resp = check_response(resp, "share machine").await?;
+
+        #[derive(serde::Deserialize)]
+        struct ShareResp {
+            token: String,
+            #[serde(default)]
+            url: Option<String>,
+        }
+        let out: ShareResp = resp.json().await?;
+
+        match out.url {
+            Some(url) => {
+                println!("Anonymous share link (anyone with this URL can reach the app):");
+                println!("  {url}");
+            }
+            None => {
+                // No apps domain configured or the name isn't DNS-safe — surface
+                // the raw token so the caller can still attach it as `?t=`.
+                println!("Share token minted (attach as `?t=` on the app URL):");
+                println!("  {}", out.token);
+            }
+        }
+        println!();
+        println!("Revoke with:  smol cloud unshare");
+        Ok(())
+    })
+}
+
+/// `smol cloud unshare <machine>` — revoke the machine's anonymous share link.
+/// The existing URL immediately stops granting access.
+fn unshare_machine(args: CloudShareArgs) -> Result<()> {
+    run_cloud_command(Some(args.name), move |http, endpoint, id| async move {
+        let resp = http
+            .delete(format!("{}/v1/machines/{}/share", endpoint, id))
+            .send()
+            .await?;
+        check_response(resp, "unshare machine").await?;
+        println!("Share link revoked.");
         Ok(())
     })
 }


### PR DESCRIPTION
Adds `smol cloud share <machine>` to mint a per-machine anonymous link that lets anyone with the URL reach the machine's published app without an account, and `smol cloud unshare <machine>` to revoke it.