### PR TITLE
fix(install): make `curl | bash` install work on macOS Bash 3.2

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,7 +63,9 @@ main() {
     local auth=()
     [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
     local api
-    api="$(curl -fsSL "${auth[@]}" "https://api.github.com/repos/$SMOL_REPO/releases/latest" 2>/dev/null || true)"
+    # "${auth[@]+...}" guards the empty-array expansion: under `set -u`,
+    # bare "${auth[@]}" on an empty array aborts on Bash 3.2 (macOS default).
+    api="$(curl -fsSL "${auth[@]+"${auth[@]}"}" "https://api.github.com/repos/$SMOL_REPO/releases/latest" 2>/dev/null || true)"
     VERSION="$(printf '%s' "$api" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
     if [ -z "$VERSION" ]; then
       if printf '%s' "$api" | grep -q "rate limit"; then


### PR DESCRIPTION
## Problem

The documented install one-liner:

```
curl -sSL https://raw.githubusercontent.com/smol-machines/smol/main/scripts/install.sh | bash
```

fails on a stock macOS before any download happens:

```
>> resolving latest release of smol-machines/smol
bash: line 66: auth[@]: unbound variable
```

## Root cause

`scripts/install.sh` runs under `set -euo pipefail`. In the latest-release resolution block:

```bash
local auth=()
[ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
api="$(curl -fsSL "${auth[@]}" ...)"
```

When `GITHUB_TOKEN` is unset (the common case for `curl | bash`), the `auth` array stays empty. Expanding a bare `"${auth[@]}"` on an empty array aborts under `set -u` on **Bash 3.2 — the default `/bin/bash` on macOS** (3.2.57). Bash 4.4+ (typical on Linux) tolerates it, which is why CI/Linux never caught it.

## Fix

Guard the expansion with the standard `set -u`-safe idiom `"${auth[@]+"${auth[@]}"}"`, which expands to nothing when the array is empty and to the header args when `GITHUB_TOKEN` is set. No behavior change when a token is present; restores Bash 3.2 compatibility.

```diff
-    api="$(curl -fsSL "${auth[@]}" "https://api.github.com/repos/$SMOL_REPO/releases/latest" 2>/dev/null || true)"
+    # "${auth[@]+...}" guards the empty-array expansion: under `set -u`,
+    # bare "${auth[@]}" on an empty array aborts on Bash 3.2 (macOS default).
+    api="$(curl -fsSL "${auth[@]+"${auth[@]}"}" "https://api.github.com/repos/$SMOL_REPO/releases/latest" 2>/dev/null || true)"
```

## Testing

- `bash -n scripts/install.sh` clean under `/bin/bash` 3.2.57 (macOS).
- Before: no-token run aborts with `auth[@]: unbound variable`.
- After: no-token run gets past the auth line and resolves the release normally.
- Idiom verified on Bash 3.2: empty array → expands to nothing; populated array → passes `-H "Authorization: Bearer ..."` as two intact args.
