### PR TITLE
Script the release cut and warn when an older smol shadows the install

### DIFF
--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Cut a smol CLI + SDK release: bump every manifest to VERSION on a fresh
+# branch off origin/main, tag vVERSION, and push — which triggers the
+# "Release smol" (CLI dist) and "SDK Release" (npm/PyPI) workflows.
+#
+# HARD PRECONDITION (enforced): the smolvm engine release vVERSION must
+# already exist with its platform assets. smol releases in version lockstep —
+# the build checks out the engine at the same tag and downloads its runtime
+# tarballs, so tagging smol before the engine has published fails every
+# platform job with "release not found".
+#
+# Usage: ./scripts/cut-release.sh 1.7.0
+set -euo pipefail
+
+VERSION="${1:?usage: cut-release.sh X.Y.Z}"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "error: '$VERSION' is not X.Y.Z" >&2; exit 1; }
+
+ENGINE_REPO="${ENGINE_REPO:-smol-machines/smolvm}"
+
+# ── engine release must exist first ─────────────────────────────────────────
+ASSETS="$(gh release view "v$VERSION" --repo "$ENGINE_REPO" --json assets --jq '.assets | length' 2>/dev/null || echo 0)"
+if [ "${ASSETS:-0}" -lt 5 ]; then
+  echo "error: engine $ENGINE_REPO v$VERSION is not published (found $ASSETS assets, need >=5)." >&2
+  echo "       cut the engine first:  (in smolvm)  ./scripts/cut-release.sh $VERSION" >&2
+  exit 1
+fi
+echo ">>> engine v$VERSION present ($ASSETS assets)"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+git fetch origin main --tags
+if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+  echo "error: tag v$VERSION already exists" >&2; exit 1
+fi
+
+BRANCH="release-v$VERSION"
+WT="$(mktemp -d)/smol-rel-$VERSION"
+git worktree add -b "$BRANCH" "$WT" origin/main
+trap 'git worktree remove "$WT" --force 2>/dev/null || true' EXIT
+cd "$WT"
+
+# The current baseline is whatever the CLI manifest declares on main (version
+# bumps live only on release branches, so main sits at the last baseline).
+BASE="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
+echo ">>> bumping manifests $BASE -> $VERSION"
+
+for f in Cargo.toml sdk/python/Cargo.toml sdk/python/pyproject.toml sdk/node/Cargo.toml; do
+  perl -i -pe "s/^version = \"\Q$BASE\E\"/version = \"$VERSION\"/" "$f"
+done
+perl -i -pe "s/\"version\": \"\Q$BASE\E\"/\"version\": \"$VERSION\"/" sdk/node/package.json
+perl -i -pe "s/__version__ = \"\Q$BASE\E\"/__version__ = \"$VERSION\"/" sdk/python/python/smol/__init__.py
+
+# The same gate CI runs — catches any manifest this script (or a future
+# layout change) missed.
+bash scripts/check-versions.sh
+
+git add Cargo.toml sdk/
+git commit -m "Bump smol CLI and SDKs to $VERSION"
+git tag -a "v$VERSION" -m "smol v$VERSION"
+git push -u origin "$BRANCH"
+git push origin "v$VERSION"
+
+echo ">>> v$VERSION tagged and pushed. Watch the CLI + SDK release workflows:"
+echo "    gh run list --repo smol-machines/smol --limit 4"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,6 +146,28 @@ main() {
     *":$BIN_DIR:"*) ;;
     *) echo ">> add $BIN_DIR to your PATH:  export PATH=\"$BIN_DIR:\$PATH\"" ;;
   esac
+
+  # ── warn about OTHER smol binaries shadowing this one ─────────────────────
+  # A stale copy earlier in PATH (e.g. an old `cargo install` in ~/.cargo/bin)
+  # silently wins over this install: `smol` then reports an old version and
+  # lacks newer subcommands — a very confusing failure. Detect and say so.
+  local shadow="" dir
+  local IFS_SAVE="$IFS"
+  IFS=":"
+  for dir in $PATH; do
+    [ -z "$dir" ] && continue
+    [ "$dir" = "$BIN_DIR" ] && break        # ours resolves first — all good
+    if [ -x "$dir/smol" ] && [ ! -d "$dir/smol" ]; then
+      shadow="$dir/smol"
+      break
+    fi
+  done
+  IFS="$IFS_SAVE"
+  if [ -n "$shadow" ]; then
+    echo ">> WARNING: another smol at $shadow comes BEFORE $BIN_DIR in your PATH"
+    echo "   ($("$shadow" --version 2>/dev/null || echo "version unknown") — it will shadow the version you just installed)"
+    echo "   remove it:  rm '$shadow'   then run:  hash -r"
+  fi
   echo ">> done — try:  smol run -I alpine --net -- cat /etc/os-release"
 }
 


### PR DESCRIPTION
scripts/cut-release.sh codifies the release dance — it refuses to tag until the engine release of the same version is published with its assets (the ordering that fails every platform job when violated), then bumps all six version spots from a fresh origin/main, runs check-versions, tags, and pushes. The installer now scans PATH after linking and warns loudly when another smol earlier in PATH will shadow the fresh install, printing its version and the exact removal command.