### PR TITLE
Resolve cloud connect by machine name in both SDKs, matching the CLI

### DIFF
--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -825,10 +825,24 @@ export async function connectTransport(
     DEFAULT_CLOUD_URL
   ).replace(/\/+$/, "");
   const cloudConn: CloudConn = { baseUrl, apiKey };
-  const m = await cloudFetch<MachineInfo>(
-    cloudConn,
-    "GET",
-    `/v1/machines/${id}`,
-  );
+  // Resolve like the CLI does: try the id path first, and when that 404s,
+  // list machines and match by NAME. `machine.name` returns the human name,
+  // so `Machine.connect(other.name)` — the natural composition of this API —
+  // must work, not just the raw `mach-…` id.
+  let m: MachineInfo;
+  try {
+    m = await cloudFetch<MachineInfo>(cloudConn, "GET", `/v1/machines/${id}`);
+  } catch (e) {
+    if (!/404/.test(String(e))) throw e;
+    const listed = await cloudFetch<{ machines?: MachineInfo[] } | MachineInfo[]>(
+      cloudConn,
+      "GET",
+      "/v1/machines",
+    );
+    const all = Array.isArray(listed) ? listed : (listed.machines ?? []);
+    const hit = all.find((x) => x.name === id || x.id === id);
+    if (!hit) throw e;
+    m = hit;
+  }
   return new CloudTransport(cloudConn, m.name ?? id, m.id ?? id);
 }

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -611,7 +611,24 @@ def connect_transport(machine_id: str, conn: Optional[ConnectOptions] = None) ->
             "or set SMOL_CLOUD_TOKEN (run `smol login`)."
         )
     base_url = (conn.base_url or os.environ.get("SMOL_CLOUD_URL") or DEFAULT_CLOUD_URL).rstrip("/")
-    m = _cloud_fetch(base_url, api_key, "GET", f"/v1/machines/{machine_id}") or {}
+    # Resolve like the CLI does: try the id path first, and when that 404s,
+    # list machines and match by NAME. `machine.name` returns the human name,
+    # so `Machine.connect(other.name)` — the natural composition of this API —
+    # must work, not just the raw `mach-…` id.
+    try:
+        m = _cloud_fetch(base_url, api_key, "GET", f"/v1/machines/{machine_id}") or {}
+    except SmolError as e:
+        if "404" not in str(e):
+            raise
+        listed = _cloud_fetch(base_url, api_key, "GET", "/v1/machines") or {}
+        machines = listed.get("machines", listed) if isinstance(listed, dict) else listed
+        hit = next(
+            (x for x in (machines or []) if x.get("name") == machine_id or x.get("id") == machine_id),
+            None,
+        )
+        if hit is None:
+            raise
+        m = hit
     return CloudTransport(base_url, api_key, str(m.get("id", machine_id)), str(m.get("name", machine_id)))
 
 


### PR DESCRIPTION
Machine.connect on the cloud target did a raw GET /v1/machines/{x}, which only accepts the mach- id — but machine.name returns the human name and neither SDK exposes the id, so connecting to a machine you just created (Machine.connect(other.name)) failed with 404. Both transports now fall back on 404 to listing machines and matching by name or id, exactly the CLI's resolution. Verified live against prod with the python SDK: connect by literal name and by machine.name both attach and exec.