### PR TITLE
Run the machine's workload at start, and accept a workload command on machine create

### DIFF
--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -48,6 +48,11 @@ pub struct CreateCmd {
     #[arg(long, help_heading = "Hardware")]
     pub cuda: bool,
 
+    /// Workload command to run when the machine starts (overrides the image's
+    /// entrypoint/cmd, matching the engine's `machine create -- <command>`).
+    #[arg(trailing_var_arg = true, value_name = "COMMAND")]
+    pub command: Vec<String>,
+
     /// Mount host directory (HOST:GUEST[:ro])
     #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
     pub volume: Vec<String>,
@@ -129,10 +134,11 @@ impl CreateCmd {
             .name
             .unwrap_or_else(smolvm::util::generate_machine_name);
 
-        let mounts: Vec<(String, String, bool)> = smolvm::data::storage::HostMount::parse(&self.volume)?
-            .into_iter()
-            .map(|m| m.to_storage_tuple())
-            .collect();
+        let mounts: Vec<(String, String, bool)> =
+            smolvm::data::storage::HostMount::parse(&self.volume)?
+                .into_iter()
+                .map(|m| m.to_storage_tuple())
+                .collect();
 
         let ports = smolvm::data::network::PortMapping::to_tuples(&self.port);
 
@@ -144,7 +150,8 @@ impl CreateCmd {
         let mut allow_cidrs: Vec<String> = Vec::new();
         for c in &self.allow_cidr {
             allow_cidrs.push(
-                smolvm::smolfile::parse_cidr(c).map_err(|e| anyhow::anyhow!("--allow-cidr: {e}"))?,
+                smolvm::smolfile::parse_cidr(c)
+                    .map_err(|e| anyhow::anyhow!("--allow-cidr: {e}"))?,
             );
         }
         for h in &self.allow_host {
@@ -158,14 +165,8 @@ impl CreateCmd {
         }
         let net = self.net || !allow_cidrs.is_empty();
 
-        let mut record = smolvm::config::VmRecord::new(
-            name.clone(),
-            self.cpus,
-            self.mem,
-            mounts,
-            ports,
-            net,
-        );
+        let mut record =
+            smolvm::config::VmRecord::new(name.clone(), self.cpus, self.mem, mounts, ports, net);
         if !allow_cidrs.is_empty() {
             record.allowed_cidrs = Some(allow_cidrs);
         }
@@ -173,12 +174,18 @@ impl CreateCmd {
             record.dns_filter_hosts = Some(self.allow_host.clone());
         }
         record.image = self.image;
+        // CLI trailing args become the machine's workload (entrypoint cleared
+        // so they win over the image default, matching the engine).
+        if !self.command.is_empty() {
+            record.cmd = self.command.clone();
+        }
         record.env = env;
         record.workdir = self.workdir;
         record.init = self.init;
         record.ssh_agent = self.ssh_agent;
         // Store secret references (not plaintext); resolved at each start/exec.
-        record.secret_refs = super::common::parse_cli_secret_refs(&self.secret_env, &self.secret_file)?;
+        record.secret_refs =
+            super::common::parse_cli_secret_refs(&self.secret_env, &self.secret_file)?;
         record.network_backend = self.net_backend;
         record.storage_gb = self.storage;
         record.overlay_gb = self.overlay;
@@ -194,7 +201,10 @@ impl CreateCmd {
 
         println!("Created machine: {}", name);
         println!("  CPUs: {}, Memory: {} MiB", self.cpus, self.mem);
-        println!("\nUse 'smol machine start --name {}' to start the machine", name);
+        println!(
+            "\nUse 'smol machine start --name {}' to start the machine",
+            name
+        );
         Ok(())
     }
 
@@ -222,8 +232,16 @@ impl CreateCmd {
             .unwrap_or_else(smolvm::util::generate_machine_name);
 
         // CLI flags override manifest defaults (defaults are 4 cpus / 8192 MiB).
-        let cpus = if self.cpus != 4 { self.cpus } else { manifest.cpus };
-        let mem = if self.mem != 8192 { self.mem } else { manifest.mem };
+        let cpus = if self.cpus != 4 {
+            self.cpus
+        } else {
+            manifest.cpus
+        };
+        let mem = if self.mem != 8192 {
+            self.mem
+        } else {
+            manifest.mem
+        };
 
         // A .smolmachine is an untrusted, portable artifact: reject any secret
         // refs it carries (Untrusted scope rejects every source kind) so a packed
@@ -235,10 +253,11 @@ impl CreateCmd {
                 })?;
         }
 
-        let mounts: Vec<(String, String, bool)> = smolvm::data::storage::HostMount::parse(&self.volume)?
-            .into_iter()
-            .map(|m| m.to_storage_tuple())
-            .collect();
+        let mounts: Vec<(String, String, bool)> =
+            smolvm::data::storage::HostMount::parse(&self.volume)?
+                .into_iter()
+                .map(|m| m.to_storage_tuple())
+                .collect();
         let ports = smolvm::data::network::PortMapping::to_tuples(&self.port);
         let mut env = smolvm::util::parse_env_list(&manifest.env);
         env.extend(smolvm::util::parse_env_list(&self.env));
@@ -252,8 +271,15 @@ impl CreateCmd {
             self.net || manifest.network,
         );
         record.image = Some(manifest.image);
-        record.entrypoint = manifest.entrypoint;
-        record.cmd = manifest.cmd;
+        // CLI trailing args override the artifact's baked (entrypoint, cmd),
+        // matching the engine's precedence.
+        if self.command.is_empty() {
+            record.entrypoint = manifest.entrypoint;
+            record.cmd = manifest.cmd;
+        } else {
+            record.entrypoint = Vec::new();
+            record.cmd = self.command.clone();
+        }
         record.env = env;
         record.workdir = manifest.workdir;
         record.init = self.init;
@@ -280,8 +306,9 @@ impl CreateCmd {
             Err(e) => anyhow::bail!("clear packed layers cache: {e}"),
         }
         println!("Extracting .smolmachine assets...");
-        let result = smolvm_pack::extract::extract_sidecar(sidecar_path, &cache_dir, &footer, false, false)
-            .map_err(|e| anyhow::anyhow!("extract sidecar: {e}"));
+        let result =
+            smolvm_pack::extract::extract_sidecar(sidecar_path, &cache_dir, &footer, false, false)
+                .map_err(|e| anyhow::anyhow!("extract sidecar: {e}"));
         smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
         result?;
 

--- a/src/commands/fork.rs
+++ b/src/commands/fork.rs
@@ -11,8 +11,8 @@ use smolvm::agent::{resolve_disk_image, vm_data_dir, AgentClient, AgentManager, 
 use smolvm::config::RecordState;
 use smolvm::data::network::PortMapping;
 use smolvm::db::SmolvmDb;
-use std::io::{Read, Write};
 use smolvm::platform::uds::UdsStream;
+use std::io::{Read, Write};
 use std::path::Path;
 use std::time::Duration;
 
@@ -102,8 +102,22 @@ impl ForkCmd {
             anyhow::bail!("machine '{clone}' already exists");
         }
 
+        // Clone dir must be PRISTINE at disk-clone time: a leftover directory
+        // (orphan of a crashed fork) holds stale qcow2 overlays that make
+        // krun_create_disk_overlay refuse with rc=-5. The DB check above
+        // guarantees no live clone owns this name, so clearing is safe.
         let clone_dir = vm_data_dir(clone);
-        let snapshot_dir = clone_dir.join("snapshot");
+        if clone_dir.exists() {
+            std::fs::remove_dir_all(&clone_dir)?;
+        }
+        std::fs::create_dir_all(&clone_dir)?;
+        // The snapshot lives under the GOLDEN's dir (gdir/fork-snapshots/<clone>),
+        // matching the engine: the frozen golden VMM writes the checkpoint AND
+        // pre-creates disk overlays NEXT TO the snapshot dir — putting it inside
+        // the clone dir made those collide with clone_disks below (rc=-5), and a
+        // Landlock-confined golden could not write outside its own dir anyway.
+        let gdir = vm_data_dir(golden);
+        let snapshot_dir = gdir.join("fork-snapshots").join(clone);
         std::fs::create_dir_all(&snapshot_dir)?;
 
         // Clone the golden's config, clear running-state, and remap inbound
@@ -137,7 +151,6 @@ impl ForkCmd {
             clone_rec.ports = remapped;
         }
         clone_rec.golden = Some(golden.clone());
-        let gdir = vm_data_dir(golden);
         db.insert_vm(clone, &clone_rec)?;
 
         // Freeze the golden and write its snapshot (checkpoint + memfd manifest).
@@ -302,6 +315,26 @@ fn clone_disks(gdir: &Path, clone_dir: &Path) -> anyhow::Result<()> {
                 .map_err(|e| anyhow::anyhow!("clone disk {}: {e}", src.display()))?;
             let overlay = clone_dir.join(Path::new(raw).with_extension("qcow2"));
             specs.push((overlay, base, *fmt));
+        }
+        if std::env::var_os("SMOL_FORK_DEBUG").is_some() {
+            for (overlay, base, fmt) in &specs {
+                eprintln!(
+                    "[fork-dbg] overlay={} exists={} | base={} exists={} fmt={:?}",
+                    overlay.display(),
+                    overlay.exists(),
+                    base.display(),
+                    base.exists(),
+                    fmt
+                );
+            }
+            if let Ok(rd) = std::fs::read_dir(clone_dir) {
+                for e in rd.flatten() {
+                    eprintln!(
+                        "[fork-dbg] clone_dir has: {}",
+                        e.file_name().to_string_lossy()
+                    );
+                }
+            }
         }
         smolvm::agent::create_disk_overlays(&specs)
             .map_err(|e| anyhow::anyhow!("create clone overlays: {e}"))?;

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -197,6 +197,61 @@ impl StartCmd {
             }
         }
 
+        // Launch the machine's workload, mirroring the engine's `machine start`:
+        // an image machine runs its (entrypoint, cmd) as a detached container
+        // (empty command → the agent resolves the image's own ENTRYPOINT+CMD);
+        // a bare machine execs it directly. Without this, a golden created with
+        // `smol machine create ... -- <workload>` silently never ran it — which
+        // also left CUDA fork goldens with nothing to fork.
+        {
+            let mut exec_env = record.env.clone();
+            exec_env.extend(super::common::resolve_record_secrets(&record.secret_refs)?);
+            let mut cmd = record.entrypoint.clone();
+            cmd.extend(record.cmd.clone());
+            if let Some(ref img) = record.image {
+                // Positional virtiofs tags, same rule as the engine (smolvm{i}).
+                let bindings: Vec<(String, String, bool)> = record
+                    .mounts
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (_host, target, ro))| {
+                        (
+                            smolvm::data::storage::HostMount::mount_tag(i),
+                            target.clone(),
+                            *ro,
+                        )
+                    })
+                    .collect();
+                let bg = smolvm::agent::RunConfig::new(img, cmd)
+                    .with_env(exec_env)
+                    .with_workdir(record.workdir.clone())
+                    .with_user(record.user.clone())
+                    .with_mounts(bindings)
+                    .with_persistent_overlay(Some(name.clone()));
+                let mut client = smolvm::AgentClient::connect_with_retry(manager.vsock_socket())?;
+                if let Err(e) = client.run_container_detached(bg) {
+                    if let Err(stop_err) = manager.stop() {
+                        eprintln!(
+                            "Warning: failed to stop machine after workload launch failure: {}",
+                            stop_err
+                        );
+                    }
+                    anyhow::bail!("start workload: {}", e);
+                }
+            } else if !cmd.is_empty() {
+                let mut client = smolvm::AgentClient::connect_with_retry(manager.vsock_socket())?;
+                let (exit_code, _stdout, stderr) =
+                    client.vm_exec(cmd, exec_env, record.workdir.clone(), None, None)?;
+                if exit_code != 0 {
+                    eprintln!(
+                        "workload exited with code {}: {}",
+                        exit_code,
+                        String::from_utf8_lossy(&stderr).trim()
+                    );
+                }
+            }
+        }
+
         println!("Machine '{}' running (PID: {})", name, pid.unwrap_or(0));
 
         // Persist running state

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,25 @@ enum Commands {
         /// Path to boot config JSON file
         config: std::path::PathBuf,
     },
+
+    /// Internal: the shared CUDA daemon (not for direct use). The engine
+    /// spawns `current_exe() _cuda-daemon <socket>` on first CUDA use, and
+    /// current_exe is THIS binary — without this arm, CUDA machines silently
+    /// fall back to per-VM in-process serving, which breaks fork clones (their
+    /// warm GPU state lives in the shared daemon, not the golden's VMM).
+    #[command(name = "_cuda-daemon", hide = true)]
+    CudaDaemon {
+        /// Unix socket path to listen on
+        socket: std::path::PathBuf,
+    },
+
+    /// Internal: serve one isolating fork-clone connection in this dedicated
+    /// worker process (own CUDA context/UVA). Spawned by the daemon.
+    #[command(name = "_cuda-clone-worker", hide = true)]
+    CudaCloneWorker {
+        /// Inherited connection file descriptor
+        fd: i32,
+    },
 }
 
 /// Build the tracing `EnvFilter` for the CLI.
@@ -138,6 +157,19 @@ fn main() {
         Commands::Cloud(cmd) => cmd.run(),
         Commands::Config(cmd) => cmd.run(),
         Commands::BootVm { config } => boot_vm(config).map_err(|e| anyhow::anyhow!("{}", e)),
+        #[cfg(unix)]
+        Commands::CudaDaemon { socket } => {
+            smolvm::cuda_daemon::run(&socket).map_err(|e| anyhow::anyhow!("cuda daemon: {e}"))
+        }
+        #[cfg(not(unix))]
+        Commands::CudaDaemon { .. } => Err(anyhow::anyhow!("the shared CUDA daemon is unix-only")),
+        #[cfg(unix)]
+        Commands::CudaCloneWorker { fd } => smolvm::cuda_daemon::run_clone_worker(fd)
+            .map_err(|e| anyhow::anyhow!("cuda clone worker: {e}")),
+        #[cfg(not(unix))]
+        Commands::CudaCloneWorker { .. } => {
+            Err(anyhow::anyhow!("the CUDA clone worker is unix-only"))
+        }
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
machine create gains trailing '-- <command>' (engine precedence) and machine start now launches the workload container/exec like the engine — previously image machines booted idle, which also left CUDA fork goldens with nothing to fork.