### PR TITLE
Use the engine's shared from-vm pack export and workload launch instead of local copies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,7 +2272,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol-cli"
-version = "1.6.0"
+version = "1.6.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -2367,6 +2367,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tower-http",
  "tracing",
@@ -2380,17 +2381,19 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
+ "libc",
  "libloading",
 ]
 
 [[package]]
 name = "smolvm-network"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "crossbeam-queue",
  "humantime",
+ "libc",
  "polling",
  "smoltcp",
  "socket2",
@@ -2399,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2418,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "base64",
  "serde",
@@ -2428,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "bytes",
  "dirs",

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -6,7 +6,7 @@ use smolvm::config::{RecordState, SmolvmConfig};
 use smolvm::data::resources::DEFAULT_MICROVM_CPU_COUNT;
 use smolvm::smolfile;
 use smolvm_pack::assets::AssetCollector;
-use smolvm_pack::format::{PackManifest, PackMode};
+use smolvm_pack::format::PackManifest;
 use smolvm_pack::packer::Packer;
 use smolvm_protocol::AgentResponse;
 use std::path::PathBuf;
@@ -250,11 +250,6 @@ impl PackCreateCmd {
             );
         }
 
-        let overlay_path = smolvm::agent::vm_data_dir(&vm_name).join("overlay.raw");
-        if !overlay_path.exists() {
-            anyhow::bail!("overlay disk not found. The VM may not have been started yet.");
-        }
-
         println!("Packing VM '{}' snapshot...", vm_name);
 
         let temp_dir = tempfile::tempdir()?;
@@ -264,10 +259,18 @@ impl PackCreateCmd {
             .map_err(|e| anyhow::anyhow!("collect assets: {}", e))?;
         self.collect_base_assets(&mut collector)?;
 
-        println!("Copying overlay disk...");
-        collector
-            .add_overlay_template(&overlay_path)
-            .map_err(|e| anyhow::anyhow!("collect overlay: {}", e))?;
+        // Shared export: single source of truth for bare / image /
+        // artifact-sourced dispatch and the single-layer flatten. An
+        // image machine's base layers + container overlay are collected
+        // here — a bare machine contributes its rootfs overlay template.
+        let assets = smolvm::pack_export::collect_from_vm_assets(
+            &mut collector,
+            &vm_name,
+            vm,
+            temp_dir.path(),
+            &smolvm::pack_export::FromVmExportOptions::default(),
+        )
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
 
         let pack_config = self.resolve_pack_config()?;
 
@@ -281,17 +284,9 @@ impl PackCreateCmd {
             platform,
             host_platform,
         );
-        manifest.mode = PackMode::Vm;
+        smolvm::pack_export::seed_manifest_from_vm(&mut manifest, vm, &assets);
         manifest.cpus = pack_config.cpus;
         manifest.mem = pack_config.mem;
-        manifest.entrypoint = if !vm.entrypoint.is_empty() {
-            vm.entrypoint.clone()
-        } else {
-            vec!["/bin/sh".to_string()]
-        };
-        manifest.cmd = vm.cmd.clone();
-        manifest.env = vm.env.iter().map(|(k, v)| format!("{}={}", k, v)).collect();
-        manifest.workdir = vm.workdir.clone();
 
         apply_pack_overrides(&mut manifest, &pack_config);
 

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -208,28 +208,11 @@ impl StartCmd {
             exec_env.extend(super::common::resolve_record_secrets(&record.secret_refs)?);
             let mut cmd = record.entrypoint.clone();
             cmd.extend(record.cmd.clone());
-            if let Some(ref img) = record.image {
-                // Positional virtiofs tags, same rule as the engine (smolvm{i}).
-                let bindings: Vec<(String, String, bool)> = record
-                    .mounts
-                    .iter()
-                    .enumerate()
-                    .map(|(i, (_host, target, ro))| {
-                        (
-                            smolvm::data::storage::HostMount::mount_tag(i),
-                            target.clone(),
-                            *ro,
-                        )
-                    })
-                    .collect();
-                let bg = smolvm::agent::RunConfig::new(img, cmd)
-                    .with_env(exec_env)
-                    .with_workdir(record.workdir.clone())
-                    .with_user(record.user.clone())
-                    .with_mounts(bindings)
-                    .with_persistent_overlay(Some(name.clone()));
+            if record.image.is_some() {
                 let mut client = smolvm::AgentClient::connect_with_retry(manager.vsock_socket())?;
-                if let Err(e) = client.run_container_detached(bg) {
+                if let Err(e) =
+                    smolvm::workload::launch_image_workload(&mut client, &name, &record, exec_env)
+                {
                     if let Err(stop_err) = manager.stop() {
                         eprintln!(
                             "Warning: failed to stop machine after workload launch failure: {}",


### PR DESCRIPTION
The local pack --from-vm implementation only handled bare machines, silently dropping an image machine's base layers and container overlay from the artifact, and the start workload launch was a hand-copied variant of the engine's. Both now call the engine lib's shared implementations (pack_export, workload), which also brings the single-layer flatten to from-vm packs. Requires the paired engine change.