### PR TITLE
Expose machine env and workdir at create, surface exec truncation flags, and fall back to the CLI login for cloud auth in both SDKs

### DIFF
--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -31,6 +31,10 @@ function makeExecResult(r: RawExec): ExecResult {
     exitCode: r.exitCode,
     stdout: r.stdout,
     stderr: r.stderr,
+    // Cloud-only truncation flags (output capped at 1 MiB); the local engine
+    // streams unbounded, so absent means false.
+    stdoutTruncated: r.stdoutTruncated ?? false,
+    stderrTruncated: r.stderrTruncated ?? false,
     success,
     output: r.stdout + r.stderr,
     assertSuccess() {

--- a/sdk/node/test/cloud-mock.ts
+++ b/sdk/node/test/cloud-mock.ts
@@ -72,7 +72,13 @@ const server = createServer(async (req, res) => {
     return json(200, { id: "m2", state: "running" });
   if (method === "POST" && url === "/v1/machines/m1/exec") {
     seen.execBody = JSON.parse((await readBody(req)).toString() || "{}");
-    return json(200, { exitCode: 0, stdout: "cloud-exec-ok\n", stderr: "" });
+    return json(200, {
+      exitCode: 0,
+      stdout: "cloud-exec-ok\n",
+      stderr: "",
+      stdoutTruncated: true,
+      stderrTruncated: false,
+    });
   }
   if (method === "PUT" && url.startsWith("/v1/machines/m1/files/")) {
     files.set(url, await readBody(req));
@@ -105,10 +111,22 @@ async function main(): Promise<void> {
   const baseUrl = `http://127.0.0.1:${port}`;
 
   const m = await Machine.create(
-    { image: "alpine", forkable: true, resources: { cpus: 2, memoryMb: 1024 } },
+    {
+      image: "alpine",
+      forkable: true,
+      env: { FOO: "bar" },
+      workdir: "/app",
+      resources: { cpus: 2, memoryMb: 1024 },
+    },
     { target: "cloud", baseUrl, apiKey: "smk_test123" },
   );
   check("created via cloud (name from API)", m.name === "cloud-test", m.name);
+  check(
+    "create sends env as a plain map + workdir",
+    JSON.stringify(seen.createBody?.env) === JSON.stringify({ FOO: "bar" }) &&
+      seen.createBody?.workdir === "/app",
+    JSON.stringify({ env: seen.createBody?.env, workdir: seen.createBody?.workdir }),
+  );
   check(
     "sent Bearer auth",
     seen.auth === "Bearer smk_test123",
@@ -123,6 +141,11 @@ async function main(): Promise<void> {
 
   const r = await m.exec(["echo", "hi"], { env: { A: "b" }, timeout: 5 });
   check("exec stdout mapped", r.stdout.trim() === "cloud-exec-ok");
+  check(
+    "exec surfaces truncation flags",
+    r.stdoutTruncated === true && r.stderrTruncated === false,
+    `${r.stdoutTruncated}/${r.stderrTruncated}`,
+  );
   check(
     "exec sent command array",
     JSON.stringify(seen.execBody?.command) === JSON.stringify(["echo", "hi"]),
@@ -169,6 +192,11 @@ async function main(): Promise<void> {
     "cloud create publishes ports (guest port only; hostPort allocated)",
     JSON.stringify(seen.createBody?.ports) === JSON.stringify([{ port: 80 }]),
     JSON.stringify(seen.createBody?.ports),
+  );
+  check(
+    "env/workdir omitted from the body when unset",
+    !("env" in (seen.createBody ?? {})) && !("workdir" in (seen.createBody ?? {})),
+    JSON.stringify(seen.createBody),
   );
 
   // --- fork: live-RAM RL clone over the cloud ---

--- a/sdk/node/test/unit.ts
+++ b/sdk/node/test/unit.ts
@@ -1,8 +1,11 @@
 /** Pure-unit tests — no VM boot, no network. Covers the error-parsing seam and
  *  cloud path encoding, the two places most likely to silently regress. */
 import assert from 'node:assert';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { wrapNativeError, SmolError } from '../errors';
-import { encodePath, toNativeConfig } from '../transport';
+import { cliConfigApiKey, encodePath, toNativeConfig } from '../transport';
 
 let passed = 0;
 let failed = 0;
@@ -77,6 +80,47 @@ check('forwards cuda to native resources', () => {
 check('omits cuda when unset (engine default applies)', () => {
   const cfg = toNativeConfig('m', { resources: { cpus: 2 } });
   assert.strictEqual(cfg.resources?.cuda, undefined);
+});
+
+// --- cliConfigApiKey: read the smol CLI's stored login from config.toml ---
+const withXdg = (fn: (dir: string) => void) => {
+  const dir = mkdtempSync(join(tmpdir(), 'smol-sdk-unit-'));
+  const prev = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = dir;
+  try {
+    fn(dir);
+  } finally {
+    if (prev === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+check('cliConfigApiKey: undefined when no config file exists', () => {
+  withXdg(() => assert.strictEqual(cliConfigApiKey(), undefined));
+});
+check('cliConfigApiKey: reads api_key from the [cloud] section', () => {
+  withXdg((dir) => {
+    mkdirSync(join(dir, 'smolvm'));
+    writeFileSync(
+      join(dir, 'smolvm', 'config.toml'),
+      '[images]\ndefault_registry = "docker.io"\n\n[cloud]\nendpoint = "https://api.example"\napi_key = "smk_from_cli"\n',
+    );
+    assert.strictEqual(cliConfigApiKey(), 'smk_from_cli');
+  });
+});
+check('cliConfigApiKey: ignores api_key outside [cloud]', () => {
+  withXdg((dir) => {
+    mkdirSync(join(dir, 'smolvm'));
+    writeFileSync(join(dir, 'smolvm', 'config.toml'), '[other]\napi_key = "smk_wrong"\n');
+    assert.strictEqual(cliConfigApiKey(), undefined);
+  });
+});
+check('cliConfigApiKey: empty api_key counts as absent', () => {
+  withXdg((dir) => {
+    mkdirSync(join(dir, 'smolvm'));
+    writeFileSync(join(dir, 'smolvm', 'config.toml'), '[cloud]\napi_key = ""\n');
+    assert.strictEqual(cliConfigApiKey(), undefined);
+  });
 });
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -7,6 +7,10 @@
  *  Cloud-only/local-only capability gaps surface as `NotSupportedError`.
  */
 
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 import {
   getNapiMachine,
   type NapiMachine as NapiInstance,
@@ -44,6 +48,9 @@ export interface RawExec {
   exitCode: number;
   stdout: string;
   stderr: string;
+  /** Cloud only: output was capped at 1 MiB. Absent on the local target. */
+  stdoutTruncated?: boolean;
+  stderrTruncated?: boolean;
 }
 
 export interface Transport {
@@ -69,6 +76,33 @@ export interface Transport {
 function generateName(): string {
   const rand = Math.random().toString(36).slice(2, 8);
   return `smol-${Date.now().toString(36)}-${rand}`;
+}
+
+/** API key from the smol CLI's stored login — `smol login` writes `api_key`
+ *  under `[cloud]` in `<config-dir>/smolvm/config.toml` (`$XDG_CONFIG_HOME`,
+ *  defaulting to `~/.config`). Tiny line parse so the SDK stays
+ *  dependency-free; returns undefined when the file or key is absent. */
+export function cliConfigApiKey(): string | undefined {
+  const base =
+    process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  let text: string;
+  try {
+    text = readFileSync(join(base, "smolvm", "config.toml"), "utf8");
+  } catch {
+    return undefined;
+  }
+  let inCloud = false;
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.startsWith("[")) {
+      inCloud = line === "[cloud]";
+      continue;
+    }
+    if (!inCloud) continue;
+    const m = /^api_key\s*=\s*(?:"([^"]*)"|'([^']*)')/.exec(line);
+    if (m) return m[1] || m[2] || undefined;
+  }
+  return undefined;
 }
 
 function toNativeExecOptions(
@@ -480,6 +514,10 @@ class CloudTransport implements Transport {
       exitCode: r.exitCode ?? 0,
       stdout: r.stdout ?? "",
       stderr: r.stderr ?? "",
+      // The cloud caps captured output at 1 MiB and flags the cut (camelCase
+      // per smolfleet's MachineExecResponse).
+      stdoutTruncated: r.stdoutTruncated ?? false,
+      stderrTruncated: r.stderrTruncated ?? false,
     };
   }
 
@@ -678,9 +716,14 @@ export async function makeTransport(
     conn.target === "cloud" || (conn.target !== "local" && Boolean(apiKey));
 
   if (useCloud) {
-    if (!apiKey) {
+    // Fall back to the CLI's stored login only AFTER the cloud target is
+    // selected, so a `smol login` on the machine never silently flips the
+    // SDK's default target away from local.
+    const key = apiKey ?? cliConfigApiKey();
+    if (!key) {
       throw new InvalidConfigError(
-        "cloud target requires an API key — pass { apiKey } or set SMOL_CLOUD_TOKEN (run 'smol login').",
+        "cloud target requires an API key — pass { apiKey }, set SMOL_CLOUD_TOKEN, " +
+          "or run 'smol login' (the SDK reads the CLI's config at ~/.config/smolvm/config.toml).",
       );
     }
     if (!config.image) {
@@ -705,7 +748,7 @@ export async function makeTransport(
       process.env.SMOL_CLOUD_URL ??
       DEFAULT_CLOUD_URL
     ).replace(/\/+$/, "");
-    const cloudConn: CloudConn = { baseUrl, apiKey };
+    const cloudConn: CloudConn = { baseUrl, apiKey: key };
 
     // smolfleet CreateMachineRequest (camelCase): source (tagged), nested
     // resources, network {mode}, autoStopSeconds, ttlSeconds. Optional numeric
@@ -741,6 +784,13 @@ export async function makeTransport(
       ...(config.ports?.length
         ? { ports: config.ports.map((p) => ({ port: p.guest })) }
         : {}),
+      // Machine-level workload env/workdir (the same shape the CLI's deploy
+      // sends: env as a plain map). Omitted entirely when unset so the server
+      // applies its own defaults.
+      ...(config.env && Object.keys(config.env).length
+        ? { env: config.env }
+        : {}),
+      ...(config.workdir !== undefined ? { workdir: config.workdir } : {}),
       autoStopSeconds: config.autoStopSeconds ?? null,
       ttlSeconds: config.ttlSeconds ?? null,
     };
@@ -777,6 +827,16 @@ export async function makeTransport(
   }
 
   // Local embedded engine.
+  // Machine-level env/workdir configure the machine's WORKLOAD (init commands
+  // and the image entrypoint) — a cloud concept; the embedded engine runs no
+  // workload at create, and its create spec has no field for them. Reject
+  // rather than silently drop (mirrors the mounts-on-cloud gate above).
+  if ((config.env && Object.keys(config.env).length) || config.workdir !== undefined) {
+    throw new NotSupportedError(
+      "machine-level env/workdir apply to the machine's workload and are cloud-only; " +
+        "on the local target pass { env, workdir } per exec instead.",
+    );
+  }
   const name = config.name ?? generateName();
   try {
     const inner = new (getNapiMachine())(toNativeConfig(name, config));
@@ -814,9 +874,13 @@ export async function connectTransport(
       throw wrapNativeError(e);
     }
   }
-  if (!apiKey) {
+  // As in makeTransport: the CLI-login fallback applies only once the cloud
+  // target is already selected.
+  const key = apiKey ?? cliConfigApiKey();
+  if (!key) {
     throw new InvalidConfigError(
-      "connect requires an API key — pass { apiKey } or set SMOL_CLOUD_TOKEN (run 'smol login').",
+      "connect requires an API key — pass { apiKey }, set SMOL_CLOUD_TOKEN, " +
+        "or run 'smol login' (the SDK reads the CLI's config at ~/.config/smolvm/config.toml).",
     );
   }
   const baseUrl = (
@@ -824,7 +888,7 @@ export async function connectTransport(
     process.env.SMOL_CLOUD_URL ??
     DEFAULT_CLOUD_URL
   ).replace(/\/+$/, "");
-  const cloudConn: CloudConn = { baseUrl, apiKey };
+  const cloudConn: CloudConn = { baseUrl, apiKey: key };
   // Resolve like the CLI does: try the id path first, and when that 404s,
   // list machines and match by NAME. `machine.name` returns the human name,
   // so `Machine.connect(other.name)` — the natural composition of this API —

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -80,6 +80,12 @@ export interface MachineConfig {
   /** Start as a live-RAM fork base (cloud) so the machine can be cloned with
    *  `Machine.fork`. The golden and its clones are pinned to one node. */
   forkable?: boolean;
+  /** Environment variables for the machine's workload (init commands and the
+   *  entrypoint), set at create. (cloud) */
+  env?: Record<string, string>;
+  /** Working directory for the machine's workload, set at create. Overrides
+   *  the image's own workdir. (cloud) */
+  workdir?: string;
 }
 
 /** Per-call execution options. */
@@ -102,6 +108,12 @@ export interface ExecResult {
    */
   stdout: string;
   stderr: string;
+  /** True when the cloud capped stdout (1 MiB); fetch big output via
+   *  `execStream` or `readFile`. Always false on the local target (the
+   *  embedded engine streams unbounded). */
+  stdoutTruncated: boolean;
+  /** True when the cloud capped stderr (1 MiB); see `stdoutTruncated`. */
+  stderrTruncated: boolean;
   /** True when exitCode === 0. */
   success: boolean;
   /** stdout + stderr, concatenated. */

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -293,6 +293,10 @@ class CloudTransport:
             exit_code=int(r.get("exitCode", 0)),
             stdout=str(r.get("stdout", "")),
             stderr=str(r.get("stderr", "")),
+            # The cloud caps captured output at 1 MiB and flags the cut
+            # (camelCase per smolfleet's MachineExecResponse).
+            stdout_truncated=bool(r.get("stdoutTruncated", False)),
+            stderr_truncated=bool(r.get("stderrTruncated", False)),
         )
 
     def run(self, image: str, command: list[str], opts: Optional[ExecOptions] = None) -> ExecResult:
@@ -472,6 +476,46 @@ def _cloud_fetch(
         raise SmolError("TIMEOUT", f"cloud {method} {path} timed out after {timeout}s") from e
 
 
+def _cli_config_api_key() -> Optional[str]:
+    """API key from the smol CLI's stored login — ``smol login`` writes
+    ``api_key`` under ``[cloud]`` in ``<config-dir>/smolvm/config.toml``
+    (``$XDG_CONFIG_HOME``, defaulting to ``~/.config``). Returns ``None`` when
+    the file or key is absent or unreadable."""
+    base = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
+    path = os.path.join(base, "smolvm", "config.toml")
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+    except OSError:
+        return None
+    try:
+        # Stdlib TOML parser on Python 3.11+; the hand parse below covers
+        # 3.9/3.10 (the package supports >=3.9) and malformed files.
+        import tomllib
+
+        cloud = tomllib.loads(text).get("cloud")
+        key = cloud.get("api_key") if isinstance(cloud, dict) else None
+        return key if isinstance(key, str) and key else None
+    except ModuleNotFoundError:
+        pass
+    except Exception:  # noqa: BLE001 - malformed TOML: fall through to the line parse
+        pass
+    in_cloud = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("["):
+            in_cloud = line == "[cloud]"
+        elif in_cloud and line.startswith("api_key"):
+            rest = line[len("api_key"):].lstrip()
+            if not rest.startswith("="):
+                continue
+            val = rest[1:].strip()
+            if len(val) >= 2 and val[0] == val[-1] and val[0] in "\"'":
+                val = val[1:-1]
+            return val or None
+    return None
+
+
 def _wait_for_ready(base_url: str, api_key: str, machine_id: str, timeout_s: float = 120.0) -> None:
     deadline = time.monotonic() + timeout_s
     while True:
@@ -499,10 +543,15 @@ def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None)
     use_cloud = conn.target == "cloud" or (conn.target != "local" and bool(api_key))
 
     if use_cloud:
+        # Fall back to the CLI's stored login only AFTER the cloud target is
+        # selected, so a `smol login` on the machine never silently flips the
+        # SDK's default target away from local.
+        api_key = api_key or _cli_config_api_key()
         if not api_key:
             raise InvalidConfigError(
-                "cloud target requires an api_key — pass ConnectOptions(api_key=...) "
-                "or set SMOL_CLOUD_TOKEN (run `smol login`)."
+                "cloud target requires an api_key — pass ConnectOptions(api_key=...), "
+                "set SMOL_CLOUD_TOKEN, or run `smol login` (the SDK reads the CLI's "
+                "config at ~/.config/smolvm/config.toml)."
             )
         if not config.image:
             raise InvalidConfigError(
@@ -547,6 +596,13 @@ def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None)
         # info after start). Publishing a port implies the virtio-net backend.
         if config.ports:
             body["ports"] = [{"port": p.guest} for p in config.ports]
+        # Machine-level workload env/workdir (the same shape the CLI's deploy
+        # sends: env as a plain map). Omitted entirely when unset so the server
+        # applies its own defaults.
+        if config.env:
+            body["env"] = dict(config.env)
+        if config.workdir is not None:
+            body["workdir"] = config.workdir
 
         created = _cloud_fetch(base_url, api_key, "POST", "/v1/machines", json_body=body) or {}
         machine_id = created["id"]
@@ -573,6 +629,16 @@ def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None)
         return CloudTransport(base_url, api_key, machine_id, name)
 
     # Local embedded engine via the native extension.
+    # Machine-level env/workdir configure the machine's WORKLOAD (init commands
+    # and the image entrypoint) — a cloud concept; the embedded engine runs no
+    # workload at create, and its create spec has no field for them. Reject
+    # rather than silently drop (mirrors the mounts-on-cloud gate above).
+    if config.env or config.workdir is not None:
+        raise NotSupportedError(
+            "machine-level env/workdir apply to the machine's workload and are "
+            "cloud-only; on the local target pass ExecOptions(env=..., "
+            "workdir=...) per command instead."
+        )
     native = _load_native()
     name = config.name or _generate_name()
     try:
@@ -605,10 +671,14 @@ def connect_transport(machine_id: str, conn: Optional[ConnectOptions] = None) ->
             return LocalTransport(native.Machine.connect(machine_id))
         except Exception as e:  # noqa: BLE001
             raise wrap_native_error(e) from e
+    # As in make_transport: the CLI-login fallback applies only once the cloud
+    # target is already selected.
+    api_key = api_key or _cli_config_api_key()
     if not api_key:
         raise InvalidConfigError(
-            "connect requires an api_key — pass ConnectOptions(api_key=...) "
-            "or set SMOL_CLOUD_TOKEN (run `smol login`)."
+            "connect requires an api_key — pass ConnectOptions(api_key=...), "
+            "set SMOL_CLOUD_TOKEN, or run `smol login` (the SDK reads the CLI's "
+            "config at ~/.config/smolvm/config.toml)."
         )
     base_url = (conn.base_url or os.environ.get("SMOL_CLOUD_URL") or DEFAULT_CLOUD_URL).rstrip("/")
     # Resolve like the CLI does: try the id path first, and when that 404s,

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -93,6 +93,12 @@ class MachineConfig:
     forkable: bool = False
     """Start as a live-RAM fork base (cloud) so the machine can be cloned with
     :meth:`Machine.fork`. The golden and its clones are pinned to one node."""
+    env: Optional[dict[str, str]] = None
+    """Environment variables for the machine's workload (init commands and the
+    entrypoint), set at create. Cloud target only."""
+    workdir: Optional[str] = None
+    """Working directory for the machine's workload, set at create. Overrides
+    the image's own workdir. Cloud target only."""
 
 
 @dataclass
@@ -111,6 +117,12 @@ class ExecResult:
     read it back with ``read_file()`` instead — this conversion is lossy. Very
     large output (>~20 MB) is rejected; use ``exec_stream`` for that."""
     stderr: str
+    stdout_truncated: bool = False
+    """True when the cloud capped stdout (1 MiB); fetch big output via
+    ``exec_stream`` or ``read_file``. Always False on the local target
+    (the embedded engine streams unbounded)."""
+    stderr_truncated: bool = False
+    """True when the cloud capped stderr (1 MiB); see :attr:`stdout_truncated`."""
 
     @property
     def success(self) -> bool:

--- a/sdk/python/tests/test_cloud_mock.py
+++ b/sdk/python/tests/test_cloud_mock.py
@@ -69,6 +69,7 @@ class Handler(BaseHTTPRequestHandler):
             return self._send(200, json.dumps({
                 "stdout": "hello\n", "stderr": "", "exitCode": 0,
                 "durationMs": 12, "machineId": MACHINE_ID,
+                "stdoutTruncated": True, "stderrTruncated": False,
             }).encode())
         if self.path == f"/v1/machines/{MACHINE_ID}/stop":
             return self._send(200, json.dumps({"id": MACHINE_ID, "state": "stopped"}).encode())
@@ -124,7 +125,8 @@ def main() -> int:
 
     try:
         m = Machine.create(
-            MachineConfig(image="alpine:3.20", forkable=True, resources=ResourceSpec(cpus=2, memory_mb=1024, network=True)),
+            MachineConfig(image="alpine:3.20", forkable=True, env={"FOO": "bar"}, workdir="/app",
+                          resources=ResourceSpec(cpus=2, memory_mb=1024, network=True)),
             ConnectOptions(target="cloud", base_url=base, api_key="smk_testkey"),
         )
         cb = captured["create_body"]
@@ -134,6 +136,8 @@ def main() -> int:
         check("resources nested camelCase", cb["resources"].get("cpus") == 2 and cb["resources"].get("memoryMb") == 1024,
               str(cb.get("resources")))
         check("network mode open", cb.get("network") == {"mode": "open"}, str(cb.get("network")))
+        check("create sends env as a plain map", cb.get("env") == {"FOO": "bar"}, str(cb.get("env")))
+        check("create sends workdir", cb.get("workdir") == "/app", str(cb.get("workdir")))
         check("waited for ready (GET machine)", any(h.startswith(f"GET /v1/machines/{MACHINE_ID}") for h in captured["hits"]))
         check("name from response", m.name == "auto", m.name)
         check("forkable start passes ?forkable=true", "forkable=true" in captured.get("start_path", ""),
@@ -155,6 +159,9 @@ def main() -> int:
         check("exec command sent as argv array", captured["exec_body"]["command"] == ["echo", "hello"],
               str(captured["exec_body"].get("command")))
         check("exec result maps camelCase", r.exit_code == 0 and r.stdout == "hello\n" and r.success is True)
+        check("exec surfaces truncation flags",
+              r.stdout_truncated is True and r.stderr_truncated is False,
+              f"{r.stdout_truncated}/{r.stderr_truncated}")
 
         m.write_file("/tmp/a b.txt", "payload")
         back = m.read_file("/tmp/a b.txt")
@@ -184,6 +191,9 @@ def main() -> int:
         check("cloud create publishes ports (guest port only; hostPort allocated)",
               captured["create_body"].get("ports") == [{"port": 80}],
               str(captured["create_body"].get("ports")))
+        check("env/workdir omitted from the body when unset",
+              "env" not in captured["create_body"] and "workdir" not in captured["create_body"],
+              str(captured["create_body"]))
 
         m.stop()
         check("stop hit POST /stop", f"POST /v1/machines/{MACHINE_ID}/stop" in captured["hits"])

--- a/sdk/python/tests/test_unit.py
+++ b/sdk/python/tests/test_unit.py
@@ -6,7 +6,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
 
 from smol.errors import ExecutionError, SmolError, wrap_native_error  # noqa: E402
-from smol.transport import _encode_path, _native_config  # noqa: E402
+from smol.transport import _cli_config_api_key, _encode_path, _native_config  # noqa: E402
 from smol.types import ExecResult, MachineConfig, ResourceSpec  # noqa: E402
 
 
@@ -58,6 +58,46 @@ def test_exec_result_helpers():
     except ExecutionError as e:
         assert e.exit_code == 7
         assert e.stderr == "nope"
+
+
+def test_exec_result_truncation_defaults_false():
+    r = ExecResult(exit_code=0, stdout="", stderr="")
+    assert r.stdout_truncated is False
+    assert r.stderr_truncated is False
+
+
+def test_cli_config_api_key_fallback():
+    import os
+    import tempfile
+
+    old = os.environ.get("XDG_CONFIG_HOME")
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            os.environ["XDG_CONFIG_HOME"] = d
+            # No config file at all → no key.
+            assert _cli_config_api_key() is None
+            cfg = Path(d) / "smolvm"
+            cfg.mkdir()
+            (cfg / "config.toml").write_text(
+                '[images]\ndefault_registry = "docker.io"\n\n'
+                '[cloud]\nendpoint = "https://api.example"\napi_key = "smk_from_cli"\n'
+            )
+            assert _cli_config_api_key() == "smk_from_cli"
+            # An api_key OUTSIDE the [cloud] section must not match.
+            (cfg / "config.toml").write_text('[other]\napi_key = "smk_wrong"\n')
+            assert _cli_config_api_key() is None
+            # An empty key counts as absent.
+            (cfg / "config.toml").write_text('[cloud]\napi_key = ""\n')
+            assert _cli_config_api_key() is None
+            # Malformed TOML elsewhere falls back to the line parse (also the
+            # 3.9/3.10 path, where tomllib is unavailable).
+            (cfg / "config.toml").write_text('[cloud]\napi_key = "smk_line"\n[broken\n')
+            assert _cli_config_api_key() == "smk_line"
+    finally:
+        if old is None:
+            os.environ.pop("XDG_CONFIG_HOME", None)
+        else:
+            os.environ["XDG_CONFIG_HOME"] = old
 
 
 def test_native_config_forwards_gpu():


### PR DESCRIPTION
MachineConfig in both the Python and Node SDKs now accepts machine-level env (a plain string map) and workdir, sent on the cloud POST /v1/machines body exactly as the CLI deploy path sends them, and omitted entirely when unset. On the local embedded target these fields configure a workload the embedded engine does not run at create, so setting them raises NotSupportedError with a pointer to per-exec env/workdir, mirroring the existing mounts-on-cloud gate rather than silently dropping them.

Cloud auth gains a third fallback: after an explicit apiKey option and SMOL_CLOUD_TOKEN, the SDKs now read the CLI's stored login from <config-dir>/smolvm/config.toml ($XDG_CONFIG_HOME or ~/.config), extracting api_key from the [cloud] section with no new dependencies (stdlib tomllib on Python 3.11+ with a line-parse fallback for 3.9/3.10 and malformed files; a small hand parse in Node). The fallback only applies once the cloud target is already selected, so a stored login never flips the SDK's default target away from local, and the auth error message now lists all three sources.

Exec results now surface the cloud's output-truncation flags (stdout/stderr are capped at 1 MiB server-side): ExecResult gains stdout_truncated/stderr_truncated in Python and stdoutTruncated/stderrTruncated in Node, mapped from the camelCase exec response and always false on the local target, which streams unbounded. Unit and cloud-mock tests in both SDKs cover the new create-body fields, the omission-when-unset behavior, the config-file fallback, and the truncation mapping.