### PR TITLE
Resolve a short pack reference to the tenant namespace on pull and inspect, matching push

### DIFF
--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -38,7 +38,15 @@ impl InspectCmd {
             &settings.cloud,
         )?;
 
-        let repo = parsed.repository();
+        // Scope a bare repo under the caller's tenant on the smolmachines
+        // registry, matching `pack push`/`pack pull` — otherwise a short ref
+        // pushed as `tenants/<tenant>/<name>` resolves to the bare registry
+        // root and 401s on inspect.
+        let repo = super::common::namespaced_repo(
+            &parsed.registry,
+            &parsed.repository(),
+            &settings.machines,
+        );
         let tag_or_digest = parsed
             .digest
             .as_deref()

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -38,7 +38,15 @@ impl PullCmd {
             &settings.cloud,
         )?;
 
-        let repo = parsed.repository();
+        // Scope a bare repo under the caller's tenant on the smolmachines
+        // registry, matching `pack push` — otherwise a short ref pushed as
+        // `tenants/<tenant>/<name>` can't be pulled back by that same ref (it
+        // resolves to the bare registry root and 401s).
+        let repo = super::common::namespaced_repo(
+            &parsed.registry,
+            &parsed.repository(),
+            &settings.machines,
+        );
         let tag_or_digest = parsed
             .digest
             .as_deref()


### PR DESCRIPTION
`pack push -f art.smolmachine name:v1` scopes a bare repo under the caller's tenant (`tenants/<tenant>/name:v1`), but `pack pull name:v1` and `pack inspect name:v1` looked the ref up at the bare registry root and 401'd — you couldn't pull or inspect an artifact by the same short ref you pushed it with (verified: `pull name:v1` → 401; `pull registry.smolmachines.com/tenants/<tenant>/name:v1` → success).

Apply the same `namespaced_repo` resolution that push (and `cloud deploy`) already use, so pull and inspect resolve a short ref to the tenant namespace. The helper only rewrites bare repos on the smolmachines registry (library/ and tenants/ prefixes and other registries pass through unchanged), and is already unit-tested.

Note: inspect resolves the ref correctly now but still hits a separate pre-existing issue where the smolmachines registry serves .smolmachine artifacts under an OCI index that get_manifest rejects (pull handles it via the index-aware path); that's a deeper registry-crate fix, recorded separately.