### PR TITLE
Reuse the CLI login session in the Python and Node SDKs

### DIFF
--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -7,6 +7,9 @@
  *  Cloud-only/local-only capability gaps surface as `NotSupportedError`.
  */
 
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import {
   getNapiMachine,
   type NapiMachine as NapiInstance,
@@ -669,18 +672,82 @@ class CloudTransport implements Transport {
 // ---------------------------------------------------------------------------
 
 /** Build and start the right transport for the requested target. */
+// --- CLI session reuse -----------------------------------------------------
+// The `smol` CLI persists its login to `~/.config/smolvm/config.toml` (the same
+// path on every platform — home/.config/smolvm, not XDG or ~/Library). Reading
+// its `[cloud]` table lets an SDK process inherit a `smol auth login` session
+// without re-specifying credentials, matching how the CLI authenticates.
+interface CliSession {
+  apiKey?: string;
+  endpoint?: string;
+}
+
+function readCliCloudTable(): Record<string, string> {
+  let text: string;
+  try {
+    text = readFileSync(
+      join(homedir(), ".config", "smolvm", "config.toml"),
+      "utf8",
+    );
+  } catch {
+    return {};
+  }
+  // Minimal, dependency-free scan of the flat, tool-written `[cloud]` table.
+  const out: Record<string, string> = {};
+  let inCloud = false;
+  for (const raw of text.split(/\r?\n/)) {
+    const s = raw.trim();
+    if (s.startsWith("[") && s.endsWith("]")) {
+      inCloud = s === "[cloud]";
+      continue;
+    }
+    if (!inCloud || s.startsWith("#") || !s.includes("=")) continue;
+    const i = s.indexOf("=");
+    out[s.slice(0, i).trim()] = s
+      .slice(i + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+  }
+  return out;
+}
+
+function tokenIsExpired(expiresAt: string | undefined): boolean {
+  // Conservative: expired only when it parses cleanly AND is in the past, so a
+  // valid key is never blocked over a formatting quirk.
+  if (!expiresAt) return false;
+  const ms = Date.parse(expiresAt);
+  return !Number.isNaN(ms) && ms <= Date.now();
+}
+
+function cliSession(target: string | undefined): CliSession {
+  if (target === "local") return {};
+  const cloud = readCliCloudTable();
+  const apiKey = cloud.api_key;
+  if (!apiKey || tokenIsExpired(cloud.token_expires_at)) return {};
+  const session: CliSession = { apiKey };
+  if (cloud.endpoint) session.endpoint = cloud.endpoint;
+  return session;
+}
+
+// Accurate guidance for the missing-credential errors. The old text said "run
+// 'smol login'" — a command that doesn't exist (it's `smol auth login`) and
+// that writes to config.toml, which the SDK now reads. Point at the real path.
+const NO_KEY_HINT =
+  "pass { apiKey }, set SMOL_CLOUD_TOKEN, or run `smol auth login` to create a CLI session the SDK reuses";
+
 export async function makeTransport(
   config: MachineConfig,
   conn: ConnectOptions,
 ): Promise<Transport> {
-  const apiKey = conn.apiKey ?? process.env.SMOL_CLOUD_TOKEN;
+  const { apiKey: cliKey, endpoint: cliUrl } = cliSession(conn.target);
+  const apiKey = conn.apiKey ?? process.env.SMOL_CLOUD_TOKEN ?? cliKey;
   const useCloud =
     conn.target === "cloud" || (conn.target !== "local" && Boolean(apiKey));
 
   if (useCloud) {
     if (!apiKey) {
       throw new InvalidConfigError(
-        "cloud target requires an API key — pass { apiKey } or set SMOL_CLOUD_TOKEN (run 'smol login').",
+        `cloud target requires an API key — ${NO_KEY_HINT}.`,
       );
     }
     if (!config.image) {
@@ -703,6 +770,7 @@ export async function makeTransport(
     const baseUrl = (
       conn.baseUrl ??
       process.env.SMOL_CLOUD_URL ??
+      cliUrl ??
       DEFAULT_CLOUD_URL
     ).replace(/\/+$/, "");
     const cloudConn: CloudConn = { baseUrl, apiKey };
@@ -803,7 +871,8 @@ export async function connectTransport(
   id: string,
   conn: ConnectOptions,
 ): Promise<Transport> {
-  const apiKey = conn.apiKey ?? process.env.SMOL_CLOUD_TOKEN;
+  const { apiKey: cliKey, endpoint: cliUrl } = cliSession(conn.target);
+  const apiKey = conn.apiKey ?? process.env.SMOL_CLOUD_TOKEN ?? cliKey;
   const useCloud =
     conn.target === "cloud" || (conn.target !== "local" && !!apiKey);
   if (!useCloud) {
@@ -816,12 +885,13 @@ export async function connectTransport(
   }
   if (!apiKey) {
     throw new InvalidConfigError(
-      "connect requires an API key — pass { apiKey } or set SMOL_CLOUD_TOKEN (run 'smol login').",
+      `connect requires an API key — ${NO_KEY_HINT}.`,
     );
   }
   const baseUrl = (
     conn.baseUrl ??
     process.env.SMOL_CLOUD_URL ??
+    cliUrl ??
     DEFAULT_CLOUD_URL
   ).replace(/\/+$/, "");
   const cloudConn: CloudConn = { baseUrl, apiKey };

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -493,17 +493,99 @@ def _wait_for_ready(base_url: str, api_key: str, machine_id: str, timeout_s: flo
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
+def _cli_config_path() -> str:
+    """Path the `smol` CLI persists its config to — `~/.config/smolvm/config.toml`
+    on every platform (the CLI uses `home/.config/smolvm`, not XDG or ~/Library)."""
+    return os.path.join(os.path.expanduser("~"), ".config", "smolvm", "config.toml")
+
+
+def _read_cli_cloud_table() -> dict[str, Any]:
+    """Best-effort read of the `[cloud]` table the CLI writes on `smol auth login`,
+    so an SDK process inherits that session without re-specifying credentials.
+    Returns {} on any problem (missing file, no TOML parser, malformed)."""
+    try:
+        with open(_cli_config_path(), "rb") as f:
+            raw = f.read()
+    except OSError:
+        return {}
+    text = raw.decode("utf-8", "replace")
+    for mod_name in ("tomllib", "tomli"):  # tomllib is stdlib on 3.11+
+        try:
+            mod = __import__(mod_name)
+        except ModuleNotFoundError:
+            continue
+        try:
+            return mod.loads(text).get("cloud", {}) or {}
+        except Exception:  # noqa: BLE001 — malformed file, fall through
+            return {}
+    # No TOML parser available (Python <3.11 without `tomli`): scan the flat,
+    # tool-written `[cloud]` table for the two string keys we need.
+    return _scan_cloud_table(text)
+
+
+def _scan_cloud_table(text: str) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    in_cloud = False
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("[") and s.endswith("]"):
+            in_cloud = s == "[cloud]"
+            continue
+        if not in_cloud or "=" not in s or s.startswith("#"):
+            continue
+        key, _, val = s.partition("=")
+        out[key.strip()] = val.strip().strip('"').strip("'")
+    return out
+
+
+def _token_is_expired(expires_at: Any) -> bool:
+    """True only when `token_expires_at` parses cleanly AND is in the past.
+    Conservative: any parse failure returns False so a valid key is never
+    blocked over a formatting quirk."""
+    if not expires_at or not isinstance(expires_at, str):
+        return False
+    try:
+        import datetime
+
+        ts = expires_at.replace("Z", "+00:00")
+        dt = datetime.datetime.fromisoformat(ts)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return dt <= datetime.datetime.now(datetime.timezone.utc)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _cli_session() -> tuple[Optional[str], Optional[str]]:
+    """`(api_key, endpoint)` from the CLI's login session, or `(None, None)`.
+    An expired access token is treated as absent so the caller surfaces an
+    honest "run `smol auth login`" message rather than a raw 401 later."""
+    cloud = _read_cli_cloud_table()
+    key = cloud.get("api_key")
+    if not key or _token_is_expired(cloud.get("token_expires_at")):
+        return (None, None)
+    return (key, cloud.get("endpoint") or None)
+
+
+# Shared, accurate guidance for the missing-credential errors below. The old
+# text said "run `smol login`" — but that command doesn't exist (it's
+# `smol auth login`) and it writes the token to config.toml, which the SDK now
+# reads. Point users at the real, working path.
+_NO_KEY_HINT = (
+    "pass ConnectOptions(api_key=...), set SMOL_CLOUD_TOKEN, or run "
+    "`smol auth login` to create a CLI session the SDK reuses"
+)
+
+
 def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None) -> Transport:
     conn = conn or ConnectOptions()
-    api_key = conn.api_key or os.environ.get("SMOL_CLOUD_TOKEN")
+    cli_key, cli_url = _cli_session() if conn.target != "local" else (None, None)
+    api_key = conn.api_key or os.environ.get("SMOL_CLOUD_TOKEN") or cli_key
     use_cloud = conn.target == "cloud" or (conn.target != "local" and bool(api_key))
 
     if use_cloud:
         if not api_key:
-            raise InvalidConfigError(
-                "cloud target requires an api_key — pass ConnectOptions(api_key=...) "
-                "or set SMOL_CLOUD_TOKEN (run `smol login`)."
-            )
+            raise InvalidConfigError(f"cloud target requires an api_key — {_NO_KEY_HINT}.")
         if not config.image:
             raise InvalidConfigError(
                 "cloud target requires an image — pass MachineConfig(image=...)."
@@ -519,7 +601,7 @@ def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None)
                 "host mounts are local-only and are not applied on the cloud target; "
                 "use cloud volumes for persistent storage instead."
             )
-        base_url = (conn.base_url or os.environ.get("SMOL_CLOUD_URL") or DEFAULT_CLOUD_URL).rstrip("/")
+        base_url = (conn.base_url or os.environ.get("SMOL_CLOUD_URL") or cli_url or DEFAULT_CLOUD_URL).rstrip("/")
 
         r = config.resources
         resources: dict[str, Any] = {"diskGb": r.storage_gb if r else None}
@@ -596,7 +678,8 @@ def connect_transport(machine_id: str, conn: Optional[ConnectOptions] = None) ->
     * cloud: looks up the machine by id (raises NOT_FOUND otherwise).
     """
     conn = conn or ConnectOptions()
-    api_key = conn.api_key or os.environ.get("SMOL_CLOUD_TOKEN")
+    cli_key, cli_url = _cli_session() if conn.target != "local" else (None, None)
+    api_key = conn.api_key or os.environ.get("SMOL_CLOUD_TOKEN") or cli_key
     use_cloud = conn.target == "cloud" or (conn.target != "local" and bool(api_key))
     if not use_cloud:
         # Local: start-or-reconnect to the named machine via the native engine.
@@ -606,11 +689,8 @@ def connect_transport(machine_id: str, conn: Optional[ConnectOptions] = None) ->
         except Exception as e:  # noqa: BLE001
             raise wrap_native_error(e) from e
     if not api_key:
-        raise InvalidConfigError(
-            "connect requires an api_key — pass ConnectOptions(api_key=...) "
-            "or set SMOL_CLOUD_TOKEN (run `smol login`)."
-        )
-    base_url = (conn.base_url or os.environ.get("SMOL_CLOUD_URL") or DEFAULT_CLOUD_URL).rstrip("/")
+        raise InvalidConfigError(f"connect requires an api_key — {_NO_KEY_HINT}.")
+    base_url = (conn.base_url or os.environ.get("SMOL_CLOUD_URL") or cli_url or DEFAULT_CLOUD_URL).rstrip("/")
     # Resolve like the CLI does: try the id path first, and when that 404s,
     # list machines and match by NAME. `machine.name` returns the human name,
     # so `Machine.connect(other.name)` — the natural composition of this API —


### PR DESCRIPTION
Both SDKs resolved the cloud api_key only from an explicit `apiKey`/`ConnectOptions` or `SMOL_CLOUD_TOKEN` — they never read `~/.config/smolvm/config.toml`, where `smol auth login` persists the token and endpoint. So a user who authenticates with the CLI and then calls `Machine.create({ image }, { target: 'cloud' })` hit `cloud target requires an api_key`, and the error pointed them at `smol login` — a command that doesn't exist (it's `smol auth login`) and that writes to the very config file the SDK ignored. There's no token-print command either, so there was no working path from a CLI login to an authenticated SDK.

Both SDKs now fall back to the CLI's `[cloud]` session (after an explicit key and `SMOL_CLOUD_TOKEN`, so standalone/env usage is unchanged) for both api_key and endpoint, reading the same `~/.config/smolvm/config.toml` the CLI uses on every platform. An access token past its `token_expires_at` is treated as absent so the user gets an honest 're-login' message instead of a raw 401. The credential errors now name the real `smol auth login` flow.

Zero new dependencies: Python prefers `tomllib`/`tomli` and falls back to a minimal `[cloud]`-table scan on 3.9/3.10; Node scans the table directly. Verified end to end: with only a CLI login present (no key, no env var), `ConnectOptions(target='cloud')` now creates, execs, and deletes a cloud machine.