### PR TITLE
Fix the export hint to the valid positional deploy form

### DIFF
--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -651,7 +651,7 @@ fn export_machine(args: CloudExportArgs) -> Result<()> {
             println!("  platforms {}", out.platforms.join(", "));
         }
         println!();
-        println!("Re-deploy anywhere:  smol cloud deploy -I {}", out.reference);
+        println!("Re-deploy anywhere:  smol cloud deploy {}", out.reference);
         Ok(())
     })
 }


### PR DESCRIPTION
`smol cloud export` ends by printing a re-deploy command using `smol cloud deploy -I <ref>` — but `cloud deploy` takes its reference positionally and has no `-I` flag, so copy-pasting the tool's own hint fails with a clap usage error. The hint now prints the working positional form; verified by running the printed command end to end (deploy + state check on the redeployed machine).