### PR TITLE
Send forkable in the machine create body so SDK goldens can be forked

### DIFF
--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -743,6 +743,11 @@ export async function makeTransport(
         : {}),
       autoStopSeconds: config.autoStopSeconds ?? null,
       ttlSeconds: config.ttlSeconds ?? null,
+      // Forkable is a CREATE-time property: the control plane persists it and the
+      // fork endpoint checks the stored flag, so it MUST be sent here. (The
+      // `?forkable=true` start param only affects the boot; without this field the
+      // golden is stored non-forkable and every fork() 409s.)
+      ...(config.forkable ? { forkable: true } : {}),
     };
     const created = await cloudFetch<MachineInfo>(
       cloudConn,

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -533,6 +533,11 @@ def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None)
             "resources": resources,
             "autoStopSeconds": config.auto_stop_seconds,
             "ttlSeconds": config.ttl_seconds,
+            # Forkable is a CREATE-time property: the control plane persists it and
+            # the fork endpoint checks the stored flag, so it MUST be sent here.
+            # (The `?forkable=true` start param only affects the boot; without this
+            # field the golden is stored non-forkable and every fork() 409s.)
+            "forkable": config.forkable,
         }
         if r and (r.allow_cidrs or r.allow_hosts):
             body["network"] = {


### PR DESCRIPTION
Both SDKs signal `forkable` only via a `?forkable=true` start-time query param, but the control plane persists `forkable` as a CREATE-time property and the fork endpoint checks that stored flag. So a machine created with `MachineConfig(forkable=true)`/`{ forkable: true }` is stored non-forkable, the start param makes the boot fork-capable but doesn't set the DB flag, and every `fork()` fails with 409 "machine was not created forkable".

Both SDKs now include `forkable` in the create body. Verified live end to end: before, an SDK-created forkable golden → `fork()` 409; after, `fork()` succeeds and the clone boots `started` and execs. (A network-enabled golden also needs `ResourceSpec(network=true)` to pull an unsteered image — orthogonal, already supported.)