### PR TITLE
Resolve an image index when inspecting a pack artifact

### DIFF
--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -64,7 +64,11 @@ async fn run_inspect(
     tag_or_digest: &str,
     json_output: bool,
 ) -> anyhow::Result<()> {
-    let manifest_bytes = client.get_manifest(repo, tag_or_digest).await?;
+    // Resolve an OCI image index to this host's platform manifest — the same
+    // path `pull` uses — so an index-wrapped .smolmachine (what `cloud export`
+    // and multi-arch packs produce) inspects instead of being rejected as a
+    // "Docker image". A plain single manifest passes straight through.
+    let manifest_bytes = client.get_manifest_resolved(repo, tag_or_digest).await?;
     let oci_manifest: smolvm_registry::OciManifest = serde_json::from_slice(&manifest_bytes)?;
 
     let layer_size = oci_manifest.layers.first().map(|l| l.size).unwrap_or(0);


### PR DESCRIPTION
`smol pack inspect` called `get_manifest`, which rejects any OCI image index with "OCI image indexes (multi-arch manifests) are not supported; this reference points to a Docker image, not a .smolmachine artifact". But `smol cloud export` and multi-arch `pack create` publish the smolmachine wrapped in an index — so inspecting a legitimately-exported artifact failed with a message claiming it isn't a smolmachine, even though `pack pull` reads the very same artifact fine (it resolves the index).

The registry crate already has `get_manifest_resolved` — documented as "shared by pull and inspect" — which resolves an index to the host platform's manifest (and passes a plain manifest straight through). Inspect now uses it, matching pull.

Verified live: before, inspecting an index-wrapped smolmachine → the bogus "Docker image" error; after, a same-arch artifact inspects fully (Image/Platform/CPUs/Cmd/…), and a cross-arch one gives the same clear "no linux/<arch> build available; the registry has: …" message pull already gives.