### PR TITLE
Persist Smolfile [secrets] on file up so they reach the workload

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -162,6 +162,11 @@ impl UpCmd {
             record.overlay_gb = sf.overlay;
             record.ssh_agent = ssh_agent;
             record.dns_filter_hosts = dns_filter_hosts.clone();
+            // Persist the Smolfile's [secrets] so they are resolved and injected
+            // into the machine's execs (matching the engine's Smolfile path).
+            // Without this the declared secrets are parsed then silently dropped,
+            // and the workload runs without the credentials it asked for.
+            record.secret_refs = sf.secrets.clone();
 
             // Wire [health] into record
             if let Some(ref h) = sf.health {


### PR DESCRIPTION
`smol file up` parsed a Smolfile's `[secrets]` table (the field deserializes) but never wrote it to the machine record — `up.rs` set image/env/init/health/… but not `secret_refs`. So a user who declares `[secrets] MY_TOKEN = { from_env = "…" }` got `secret_refs: None` on the record, and every exec ran WITHOUT the credential, silently. The engine's own Smolfile path wires `sf.secrets` in; the `smol` CLI's reimplementation dropped it.

`file up` now persists `sf.secrets` onto the record, matching the engine. Verified end to end: before, the declared secret was absent from execs (`MY_TOKEN=UNSET`); after, it injects (`MY_TOKEN=<value>`) when the host source var is set, and errors clearly (`resolve secret …: env_unset`) when it isn't — the plaintext is never persisted, only the `{from_env}` ref, resolved fresh from the host at exec time.