### PR TITLE
Honor Smolfile rosetta/cuda/docker_socket/restart on file up

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -163,6 +163,30 @@ impl UpCmd {
             record.ssh_agent = ssh_agent;
             record.dns_filter_hosts = dns_filter_hosts.clone();
 
+            // Runtime toggles from the Smolfile that would otherwise be silently
+            // dropped: Rosetta x86 emulation, CUDA, and exposing the Docker socket
+            // all have record fields the engine's own Smolfile path wires — mirror
+            // it here so `file up` honors them.
+            record.rosetta = sf.rosetta;
+            record.cuda = sf.cuda.unwrap_or(false);
+            record.docker_socket = sf.docker_socket.unwrap_or(false);
+
+            // Wire [restart] policy into record.
+            if let Some(ref r) = sf.restart {
+                if let Some(ref policy) = r.policy {
+                    record.restart.policy = policy
+                        .parse()
+                        .map_err(|e| anyhow::anyhow!("Smolfile [restart] policy: {e}"))?;
+                }
+                if let Some(mr) = r.max_retries {
+                    record.restart.max_retries = mr;
+                }
+                if let Some(secs) = r.max_backoff.as_deref().and_then(smolfile::parse_duration_secs)
+                {
+                    record.restart.max_backoff_secs = secs;
+                }
+            }
+
             // Wire [health] into record
             if let Some(ref h) = sf.health {
                 if !h.exec.is_empty() {

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -110,8 +110,8 @@ impl UpCmd {
             network_backend: None,
             gpu,
             gpu_vram_mib,
-            rosetta: false,
-            cuda: false,
+            rosetta: sf.rosetta.unwrap_or(false),
+            cuda: sf.cuda.unwrap_or(false),
             dns: None,
         };
 
@@ -218,6 +218,8 @@ impl UpCmd {
         let features = LaunchFeatures {
             ssh_agent_socket,
             dns_filter_hosts,
+            cuda: sf.cuda.unwrap_or(false),
+            expose_docker: sf.docker_socket.unwrap_or(false),
             ..Default::default()
         };
 


### PR DESCRIPTION
`smol file up` wired most Smolfile fields onto the machine record but silently dropped four runtime toggles the engine's own Smolfile path honors: `rosetta` (x86 emulation on arm), `cuda`, `docker_socket`, and the `[restart]` policy. So a Smolfile declaring e.g. `rosetta = true`, `docker_socket = true`, or a `[restart]` policy had no effect via `file up` — the feature appeared configured but never applied.

This wires them in two places so they take effect both on the initial `file up` boot AND on later `machine start`/`exec`:
- the persisted record (`record.rosetta`/`cuda`/`docker_socket`, and the mapped `[restart]` policy → RestartPolicy + max_retries + max_backoff-seconds), and
- the initial boot's `VmResources` (`rosetta`/`cuda`, previously hardcoded false) and `LaunchFeatures` (`cuda`/`expose_docker`).

Verified: a Smolfile with all four set produces a record with `rosetta:true, cuda:true, docker_socket:true, restart:{policy:on-failure, max_retries:5, max_backoff_secs:60}` (was all defaults before), and the same values now feed the first boot's resources/features.