### PR TITLE
Request billing:write on login so tenant self-service top-up works

### DIFF
--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -53,7 +53,7 @@ const CLIENT_ID: &str = "Df3M6TXvVVMmTTzfyo0mjaLl9rhaI7nZ";
 /// the `scope` claim when RBAC isn't injecting `permissions`).
 const SCOPES: &str = "openid offline_access \
     machine:read machine:create machine:exec machine:delete machine:files \
-    usage:read billing:read app:write \
+    usage:read billing:read billing:write app:write \
     volume:read volume:create volume:delete ops:read";
 
 /// OAuth audience — the platform-wide API identifier registered in Auth0.


### PR DESCRIPTION
`smol auth login` (device flow) requests a fixed `SCOPES` string that includes `billing:read` but not `billing:write`. Regular users have no org-role claim, so smolfleet derives their authorization from the token's raw `scope` claim (not the server-side role→scopes map) — which means the missing `billing:write` never reaches them, and `POST /v1/billing/checkout-session` (the Stripe top-up) 403s with "missing scope: billing:write". Verified by decoding a real login token: it carries `billing:read app:write …` and `aud=api.smolmachines.com` but no `billing:write` and no role claim.

This adds `billing:write` to the requested scopes so a login token can start a top-up. Pairs with smolcloud #325 (which adds `billing:write` to the server-side role→scopes map for org-role users / API keys): #325 covers role-bearing identities, this covers the raw-scope-claim login tokens that regular console/CLI users actually get.

NOTE (needs owner verification, outside this repo): the Auth0 API (`api.smolmachines.com`) must have `billing:write` defined as a grantable scope/permission — same as the already-working `billing:read`. If Auth0 drops unknown requested scopes, re-login after this merge and confirm the token's `scope` claim now contains `billing:write`. The web console, if it mints its own API token via a separate Auth0 flow, needs the same scope added there too.