### PR TITLE
Add a machine readiness signal, native connect-bridge helpers, and an async Python API to the SDK

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -66,6 +66,8 @@ jobs:
         run: python tests/test_unit.py
       - name: Cloud-transport tests (mock /v1 server; pure Python)
         run: python tests/test_cloud_mock.py
+      - name: Async-transport tests (AsyncMachine vs mock /v1; pure Python)
+        run: python tests/test_async_mock.py
 
   # --------------------------------------------------------------------------
   # Native build + microVM end-to-end. Requires a runner WITH libkrun + a

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -26,6 +26,37 @@ const res = await cloud.exec(['python', '-c', 'print(40 + 2)']);
 Cloud-only gaps (`run`, `execStream`, `pullImage`, `listImages`) throw `NotSupportedError`;
 the common surface (create/exec/files/state/stop/delete) is identical on both.
 
+### Disposable workers: wait for `ready`, then connect (cloud)
+
+Launching a machine as a **disposable agent runtime** has two easy-to-miss steps;
+both are first-class here.
+
+`Machine.create()` already waits for the machine to be **ready** — not merely
+`started`. `state === "started"` means the VM process launched; the guest is
+still booting and is **not** usable yet. Acting on `started` is the classic
+teardown race (works on a slow cold start, times out on a warm one). Gate on the
+unambiguous signal:
+
+```ts
+const m = await Machine.create({ image, ports: [{ host: 8080, guest: 8080 }] },
+                               { target: 'cloud' });
+await m.waitUntilReady();          // create() already waited; re-assert if reconnecting
+console.log(await m.ready(), await m.readyAt());
+```
+
+To reach a service **inside** the VM, use the authenticated connect bridge —
+**no Cloudflare/localhost.run tunnel, no public exposure, no egress allow-list.**
+Have the worker LISTEN on a published port and connect *inbound*:
+
+```ts
+// HTTP to a published guest port:
+const res = await m.fetch(8080, '/healthz');
+
+// Or a WebSocket, using your own ws client with the authed endpoint:
+const { wsUrl, headers } = m.endpoint(8080, '/socket');
+const ws = new WebSocket(wsUrl, { headers });   // e.g. the `ws` package
+```
+
 ## Install
 
 ```bash

--- a/sdk/node/index.ts
+++ b/sdk/node/index.ts
@@ -30,4 +30,6 @@ export type {
   ImageInfo,
   ExecEvent,
   ConnectOptions,
+  WaitReadyOptions,
+  PortEndpoint,
 } from './types';

--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -22,7 +22,9 @@ import type {
   ExecResult,
   ImageInfo,
   MachineConfig,
+  PortEndpoint,
   PortSpec,
+  WaitReadyOptions,
 } from "./types";
 
 function makeExecResult(r: RawExec): ExecResult {
@@ -85,6 +87,56 @@ export class Machine {
   /** Current state (e.g. "running" | "stopped"). */
   state(): Promise<string> {
     return this.transport.state();
+  }
+
+  /** Whether the machine is READY to do work. `state()` becoming "started"
+   *  means only that the VM process launched — the guest is still booting and
+   *  is NOT yet usable. `ready` becomes true once the in-VM agent is reachable
+   *  (an `exec`/`connect` will succeed) and any published port accepts
+   *  connections. Gate on this, not `state`, before driving the machine.
+   *  (cloud; the local target reports ready once running.) */
+  ready(): Promise<boolean> {
+    return this.transport.ready();
+  }
+
+  /** When the machine first became ready (RFC3339), or `null` if not yet ready. */
+  readyAt(): Promise<string | null> {
+    return this.transport.readyAt();
+  }
+
+  /** Block until the machine is `ready` (or throw on a failed/stopped state or
+   *  timeout). `create()` already waits for readiness, so this is for machines
+   *  attached via `Machine.connect(...)`, or to re-assert readiness before use.
+   *  Poll ceiling and interval are configurable (defaults: 120s / 1s). */
+  waitUntilReady(opts?: WaitReadyOptions): Promise<void> {
+    return this.transport.waitUntilReady(opts);
+  }
+
+  /** An authenticated endpoint (URL + headers) to reach a PUBLISHED guest port
+   *  through the control plane's connect bridge — no Cloudflare/localhost.run
+   *  tunnel, no public exposure, no egress allow-list. Have the in-VM worker
+   *  LISTEN on the port and connect *inbound*: plug `wsUrl` into a WebSocket
+   *  client (passing `headers`) or `httpUrl` into `fetch`. The machine must
+   *  publish the port (`ports: [{ guest }]` at create). (cloud) */
+  endpoint(port: number, path?: string): PortEndpoint {
+    return this.transport.endpoint(port, path);
+  }
+
+  /** Convenience: an authenticated HTTP request to a published guest port via
+   *  the connect bridge. Returns the raw `fetch` `Response`. (cloud)
+   *
+   *  @param port  a published GUEST port the in-VM service listens on
+   *  @param path  optional path on that service (e.g. `"healthz"`)
+   *  @param init  standard `fetch` init; its headers merge over the auth header */
+  fetch(port: number, path?: string, init?: RequestInit): Promise<Response> {
+    const e = this.transport.endpoint(port, path);
+    return fetch(e.httpUrl, {
+      ...init,
+      headers: {
+        ...e.headers,
+        ...((init?.headers as Record<string, string> | undefined) ?? {}),
+      },
+    });
   }
 
   /** Public ingress URL for the machine's first published port (cloud).

--- a/sdk/node/test/cloud-mock.ts
+++ b/sdk/node/test/cloud-mock.ts
@@ -67,7 +67,18 @@ const server = createServer(async (req, res) => {
     });
   }
   if (method === "GET" && url === "/v1/machines/m1")
-    return json(200, { id: "m1", state: "running" });
+    return json(200, {
+      id: "m1",
+      state: "started",
+      ready: true,
+      readyAt: "2026-07-22T20:01:41.152Z",
+    });
+  // The connect bridge: GET /v1/machines/:id/connect/:port[/rest]. Echo the
+  // path + auth so the SDK's endpoint()/fetch() wiring can be asserted.
+  if (method === "GET" && url.startsWith("/v1/machines/m1/connect/")) {
+    seen.connectUrl = url;
+    return json(200, { ok: true, path: url });
+  }
   if (method === "GET" && url === "/v1/machines/m2")
     return json(200, { id: "m2", state: "running" });
   if (method === "POST" && url === "/v1/machines/m1/exec") {
@@ -132,11 +143,54 @@ async function main(): Promise<void> {
     seen.auth === "Bearer smk_test123",
     String(seen.auth),
   );
-  check("state() over REST", (await m.state()) === "running");
+  check("state() over REST", (await m.state()) === "started");
+  // Readiness: the machine can be `started` yet report `ready` separately — the
+  // SDK surfaces the unambiguous signal (gate on this, not state).
+  check("ready() reads the readiness flag", (await m.ready()) === true);
+  check(
+    "readyAt() reads the readiness timestamp",
+    (await m.readyAt()) === "2026-07-22T20:01:41.152Z",
+    String(await m.readyAt()),
+  );
+  await m.waitUntilReady({ timeoutMs: 2000, intervalMs: 50 });
+  check("waitUntilReady() resolves on ready", true);
   check(
     "forkable start passes ?forkable=true",
     String(seen.startUrl ?? "").includes("forkable=true"),
     String(seen.startUrl),
+  );
+
+  // --- connect bridge: authed endpoint URL + fetch to a published guest port ---
+  const ep = m.endpoint(80);
+  check(
+    "endpoint() builds the connect-bridge httpUrl",
+    ep.httpUrl === `${baseUrl}/v1/machines/m1/connect/80`,
+    ep.httpUrl,
+  );
+  check(
+    "endpoint() derives a wss/ws URL from the base",
+    ep.wsUrl === `${baseUrl.replace(/^http/, "ws")}/v1/machines/m1/connect/80`,
+    ep.wsUrl,
+  );
+  check(
+    "endpoint() carries the Bearer auth header",
+    ep.headers.authorization === "Bearer smk_test123",
+    ep.headers.authorization,
+  );
+  check(
+    "endpoint(port, path) appends the sub-path",
+    m.endpoint(80, "/healthz").httpUrl ===
+      `${baseUrl}/v1/machines/m1/connect/80/healthz`,
+    m.endpoint(80, "/healthz").httpUrl,
+  );
+  const bridged = await m.fetch(80, "healthz");
+  const bridgedBody = (await bridged.json()) as { ok?: boolean; path?: string };
+  check(
+    "fetch() reaches the guest port through the authed bridge",
+    bridged.ok &&
+      bridgedBody.ok === true &&
+      seen.connectUrl === "/v1/machines/m1/connect/80/healthz",
+    String(seen.connectUrl),
   );
 
   const r = await m.exec(["echo", "hi"], { env: { A: "b" }, timeout: 5 });

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -28,7 +28,9 @@ import type {
   ExecOptions,
   ImageInfo,
   MachineConfig,
+  PortEndpoint,
   PortSpec,
+  WaitReadyOptions,
 } from "./types";
 // Cloud wire shapes are generated from smolfleet's OpenAPI document (npm run
 // gen:openapi → generated/smolfleet.ts), itself derived from the shared
@@ -38,9 +40,19 @@ import type { components } from "./generated/smolfleet";
 
 type Schemas = components["schemas"];
 type CreateMachineRequest = Schemas["CreateMachineRequest"];
-type MachineInfo = Schemas["MachineInfo"];
 type MachineCommandRequest = Schemas["MachineCommandRequest"];
 type MachineExecResponse = Schemas["MachineExecResponse"];
+
+// The server carries an unambiguous readiness signal (`ready`/`readyAt`) that the
+// generated OpenAPI snapshot doesn't yet include; extend the type locally. `url`
+// is likewise widened where read (see `url()`). `ready` is absent (undefined) on
+// older control planes — distinguished from `false` so we can fall back to the
+// coarse state gate rather than hanging.
+type MachineInfo = Schemas["MachineInfo"] & {
+  ready?: boolean;
+  readyAt?: string | null;
+  url?: string | null;
+};
 
 /** Raw exec result (the ergonomic wrapper is added in machine.ts). */
 export interface RawExec {
@@ -55,6 +67,10 @@ export interface RawExec {
 export interface Transport {
   readonly name: string;
   state(): Promise<string>;
+  ready(): Promise<boolean>;
+  readyAt(): Promise<string | null>;
+  waitUntilReady(opts?: WaitReadyOptions): Promise<void>;
+  endpoint(port: number, path?: string): PortEndpoint;
   url(): Promise<string | null>;
   exec(command: string[], opts?: ExecOptions): Promise<RawExec>;
   run(image: string, command: string[], opts?: ExecOptions): Promise<RawExec>;
@@ -191,6 +207,27 @@ class LocalTransport implements Transport {
 
   async state(): Promise<string> {
     return this.inner.state();
+  }
+
+  async ready(): Promise<boolean> {
+    // A local machine is created already started; "running" means usable.
+    return (await this.inner.state()) === "running";
+  }
+
+  async readyAt(): Promise<string | null> {
+    // No readiness timestamp for the embedded engine.
+    return null;
+  }
+
+  async waitUntilReady(_opts?: WaitReadyOptions): Promise<void> {
+    // Local create()/start() awaits the boot, so the machine is already ready.
+  }
+
+  endpoint(_port: number, _path?: string): PortEndpoint {
+    throw new NotSupportedError(
+      "endpoint() is a cloud connect-bridge feature; the local target has no " +
+        "control plane. Publish a port and reach it on the host directly.",
+    );
   }
 
   async url(): Promise<string | null> {
@@ -409,24 +446,27 @@ async function cloudFetch<T = unknown>(
   return (ct.includes("application/json") ? await res.json() : undefined) as T;
 }
 
-/** Poll a cloud machine until it is started/running; throw on error state or
+/** Poll a cloud machine until it is READY to do work; throw on error state or
  *  timeout. Mirrors the Python SDK's `_wait_for_ready`. Auth/not-found errors are
- *  fatal (re-thrown immediately); other errors are treated as transient booting. */
+ *  fatal (re-thrown immediately); other errors are treated as transient booting.
+ *
+ *  Readiness is the machine's `ready` flag — true only once the guest agent is
+ *  reachable (and any published port accepts). A machine reaching state
+ *  `started` is NOT yet usable: the guest is still booting, and acting then is
+ *  the classic teardown race (works on a slow cold start, times out on a warm
+ *  one). Older control planes omit `ready`; there we fall back to the coarse
+ *  `started`/`running` state so this never hangs against them. */
 async function waitForReady(
   conn: CloudConn,
   id: string,
   timeoutMs = 120_000,
+  intervalMs = 1_000,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
-    let state: string | undefined;
+    let m: MachineInfo | undefined;
     try {
-      const m = await cloudFetch<MachineInfo>(
-        conn,
-        "GET",
-        `/v1/machines/${id}`,
-      );
-      state = m?.state ?? undefined;
+      m = await cloudFetch<MachineInfo>(conn, "GET", `/v1/machines/${id}`);
     } catch (e) {
       if (
         e instanceof SmolError &&
@@ -435,20 +475,33 @@ async function waitForReady(
         throw e;
       // transient while booting — keep polling
     }
-    if (state === "started" || state === "running") return;
+    const state = m?.state ?? undefined;
+    // Prefer the unambiguous readiness signal.
+    if (m?.ready === true) return;
     if (state === "error") {
       throw new SmolError(
         "SMOLVM_ERROR",
         `machine ${id} entered error state while starting`,
       );
     }
+    // A machine that reached a definitively-terminal non-ready state won't
+    // become ready by waiting.
+    if (state === "stopped" || state === "deleted") {
+      throw new SmolError(
+        "SMOLVM_ERROR",
+        `machine ${id} entered ${state} before becoming ready`,
+      );
+    }
+    // Back-compat: `ready` absent entirely → old server, gate on state.
+    if (m && m.ready === undefined && (state === "started" || state === "running"))
+      return;
     if (Date.now() >= deadline) {
       throw new SmolError(
         "TIMEOUT",
         `machine ${id} not ready after ${timeoutMs}ms (state=${state ?? "unknown"})`,
       );
     }
-    await new Promise((r) => setTimeout(r, 1000));
+    await new Promise((r) => setTimeout(r, intervalMs));
   }
 }
 
@@ -466,6 +519,44 @@ class CloudTransport implements Transport {
       `/v1/machines/${this.id}`,
     );
     return m?.state ?? "unknown";
+  }
+
+  async ready(): Promise<boolean> {
+    const m = await cloudFetch<MachineInfo>(
+      this.conn,
+      "GET",
+      `/v1/machines/${this.id}`,
+    );
+    return m?.ready === true;
+  }
+
+  async readyAt(): Promise<string | null> {
+    const m = await cloudFetch<MachineInfo>(
+      this.conn,
+      "GET",
+      `/v1/machines/${this.id}`,
+    );
+    return m?.readyAt ?? null;
+  }
+
+  async waitUntilReady(opts?: WaitReadyOptions): Promise<void> {
+    await waitForReady(this.conn, this.id, opts?.timeoutMs, opts?.intervalMs);
+  }
+
+  endpoint(port: number, path = ""): PortEndpoint {
+    // Reach a PUBLISHED guest port through the control plane's authenticated
+    // connect bridge — no tunnel, no public exposure. The server maps the guest
+    // port to its node host-port (404 if the port isn't published, 503 if the
+    // machine isn't started) and forwards WebSocket upgrades or plain HTTP.
+    const rel = path
+      ? `/v1/machines/${this.id}/connect/${port}/${path.replace(/^\/+/, "")}`
+      : `/v1/machines/${this.id}/connect/${port}`;
+    return {
+      httpUrl: `${this.conn.baseUrl}${rel}`,
+      // https → wss, http → ws (local dev endpoints).
+      wsUrl: `${this.conn.baseUrl.replace(/^http/, "ws")}${rel}`,
+      headers: { authorization: `Bearer ${this.conn.apiKey}` },
+    };
   }
 
   async url(): Promise<string | null> {

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -139,6 +139,27 @@ export type ExecEvent =
   | { kind: "exit"; exitCode: number }
   | { kind: "error"; message: string };
 
+/** Options for `Machine.waitUntilReady`. */
+export interface WaitReadyOptions {
+  /** Give up after this many milliseconds (default: 120000). */
+  timeoutMs?: number;
+  /** Delay between readiness polls, in milliseconds (default: 1000). */
+  intervalMs?: number;
+}
+
+/** An authenticated way to reach a PUBLISHED guest port through the control
+ *  plane's connect bridge — no tunnel, no public exposure. Returned by
+ *  `Machine.endpoint(port)`. Plug `wsUrl` into a WebSocket client or `httpUrl`
+ *  into `fetch`, passing `headers` so the request authenticates. */
+export interface PortEndpoint {
+  /** `https://…/v1/machines/:id/connect/:port[/path]` — for HTTP requests. */
+  httpUrl: string;
+  /** `wss://…/v1/machines/:id/connect/:port[/path]` — for WebSocket upgrades. */
+  wsUrl: string;
+  /** Headers to send (the tenant Bearer token). */
+  headers: Record<string, string>;
+}
+
 /** Selects and configures the backend. Local (embedded) is the default. */
 export interface ConnectOptions {
   /** 'local' = embedded engine (default). 'cloud' = remote (not yet implemented). */

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -30,6 +30,37 @@ with Machine.create(
     print(m.exec(["echo", "hi"]).stdout)
 ```
 
+### Async: `AsyncMachine` (non-blocking)
+
+`Machine` is synchronous — each call blocks the calling thread. When you're
+driving many machines from one event loop (a fleet of disposable workers), use
+`AsyncMachine`: the **same API**, but every I/O method is a coroutine that runs
+off the loop, so launches and calls overlap instead of serializing.
+
+```python
+import asyncio
+from smol import AsyncMachine, MachineConfig, ConnectOptions, PortSpec
+
+async def main():
+    cfg = MachineConfig(image="alpine:3.20", ports=[PortSpec(host=8080, guest=8080)])
+    conn = ConnectOptions(target="cloud")  # or SMOL_CLOUD_TOKEN
+    # Launch a fleet concurrently — none blocks the loop.
+    machines = await asyncio.gather(*(AsyncMachine.create(cfg, conn) for _ in range(8)))
+    try:
+        await asyncio.gather(*(m.wait_until_ready() for m in machines))
+        # Reach a service inside a vm via the authed connect bridge (no tunnel):
+        health = await machines[0].request(8080, "healthz")
+    finally:
+        await asyncio.gather(*(m.delete() for m in machines))
+
+asyncio.run(main())
+```
+
+Every `Machine` method has an `await`able counterpart on `AsyncMachine`
+(`create`/`connect`/`exec`/`wait_until_ready`/`request`/`fork`/…), plus
+`async with` for auto-delete. `endpoint(port)` stays synchronous — it only builds
+a URL and does no I/O.
+
 ## Architecture
 - **Pure-Python layer** (`python/smol`): `Machine`, transports, types, errors —
   zero third-party deps (the cloud transport uses only `urllib`).
@@ -39,10 +70,40 @@ with Machine.create(
 - **Cloud transport**: a REST client to smolfleet `/v1` whose request/response
   shapes match smolfleet's OpenAPI contract (Bearer `smk_…`).
 
+### Disposable workers: wait for `ready`, then connect (cloud)
+
+Launching a machine as a **disposable agent runtime** has two easy-to-miss steps;
+both are first-class here.
+
+`Machine.create()` already waits for the machine to be **ready** — not merely
+`started`. `state == "started"` means the VM process launched; the guest is
+still booting and is **not** usable yet. Acting on `started` is the classic
+teardown race (works on a slow cold start, times out on a warm one). Gate on the
+unambiguous signal:
+
+```python
+with Machine.create(
+    MachineConfig(image="alpine:3.20", ports=[PortSpec(host=8080, guest=8080)]),
+    ConnectOptions(target="cloud"),
+) as m:
+    m.wait_until_ready()           # create() already waited; re-assert if reconnecting
+    print(m.ready(), m.ready_at())
+
+    # Reach a service INSIDE the vm through the authenticated connect bridge —
+    # no Cloudflare/localhost.run tunnel, no public exposure, no egress allow-list.
+    # Have the worker LISTEN on a published port and connect *inbound*:
+    print(m.request(8080, "healthz").decode())     # authed HTTP to the guest port
+    ep = m.endpoint(8080, "/socket")               # or build a ws:// url for your ws client
+    # websocket.connect(ep.ws_url, additional_headers=ep.headers)
+```
+
 ## API
+- `Machine` (sync) / `AsyncMachine` (awaitable, non-blocking) — identical surface; see the async example above.
 - `Machine.create(config=None, conn=None)` — create and start a machine.
 - `machine.exec(command, opts=None)` / `machine.run(image, command, opts=None)` → `ExecResult`
 - `machine.read_file(path)` → `bytes` / `machine.write_file(path, data, mode=None)`
+- `machine.ready()` / `machine.ready_at()` / `machine.wait_until_ready(timeout_s=120, interval_s=1)`  *(cloud)*
+- `machine.endpoint(port, path=None)` → `PortEndpoint` / `machine.request(port, path=None, method="GET", data=None)` → `bytes`  *(cloud connect bridge)*
 - `machine.pull_image(image)` / `machine.list_images()`  *(local)*
 - `machine.stop()` / `machine.delete()` / `machine.state()`
 - Use it as a context manager to auto-`delete()` on exit.
@@ -79,6 +140,7 @@ On Linux the host needs `/dev/kvm`.
 ```bash
 python tests/test_unit.py        # error parsing + path encoding (no VM/network)
 python tests/test_cloud_mock.py  # cloud transport vs a mock /v1 (no VM/network)
+python tests/test_async_mock.py  # AsyncMachine vs a mock /v1 (concurrency, no VM/network)
 # Local VM boot (needs the native build + the env above):
 SMOLVM_BOOT_BINARY=… SMOLVM_LIB_DIR=… .venv/bin/python tests/test_local_e2e.py
 ```

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -45,6 +45,7 @@ from .errors import (
     SmolError,
     wrap_native_error,
 )
+from .async_machine import AsyncMachine
 from .machine import Machine
 from .types import (
     ConnectOptions,
@@ -53,6 +54,7 @@ from .types import (
     ImageInfo,
     MachineConfig,
     MountSpec,
+    PortEndpoint,
     PortSpec,
     ResourceSpec,
 )
@@ -61,10 +63,12 @@ __version__ = "1.6.4"
 
 __all__ = [
     "Machine",
+    "AsyncMachine",
     "MachineConfig",
     "ResourceSpec",
     "MountSpec",
     "PortSpec",
+    "PortEndpoint",
     "ExecOptions",
     "ExecResult",
     "ImageInfo",

--- a/sdk/python/python/smol/async_machine.py
+++ b/sdk/python/python/smol/async_machine.py
@@ -1,0 +1,184 @@
+"""Async wrapper over :class:`Machine` — the same API, but every call that does
+I/O is awaitable and runs off the event loop, so nothing blocks.
+
+The sync :class:`Machine` (and its transports) is the single source of truth for
+behaviour; ``AsyncMachine`` just offloads each blocking call to a worker thread
+via :func:`asyncio.to_thread`. That keeps one implementation of the wire
+protocol, readiness gating, and capability rules, while letting callers drive
+many machines concurrently::
+
+    import asyncio
+    from smol import AsyncMachine, MachineConfig, ConnectOptions, PortSpec
+
+    async def main():
+        # Launch a fleet of disposable workers concurrently — none blocks the loop.
+        cfg = MachineConfig(image="alpine:3.20", ports=[PortSpec(host=8080, guest=8080)])
+        conn = ConnectOptions(target="cloud")
+        machines = await asyncio.gather(*(AsyncMachine.create(cfg, conn) for _ in range(8)))
+        try:
+            await asyncio.gather(*(m.wait_until_ready() for m in machines))
+            outs = await asyncio.gather(*(m.exec(["echo", "hi"]) for m in machines))
+        finally:
+            await asyncio.gather(*(m.delete() for m in machines))
+
+    asyncio.run(main())
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Optional
+
+from .machine import Machine
+from .types import (
+    ConnectOptions,
+    ExecOptions,
+    ExecResult,
+    ImageInfo,
+    MachineConfig,
+    PortEndpoint,
+    PortSpec,
+)
+
+__all__ = ["AsyncMachine"]
+
+
+class AsyncMachine:
+    """An awaitable view of a :class:`Machine`. Construct with :meth:`create`
+    (or :meth:`connect`); clean up with :meth:`delete` (or ``async with``).
+
+    Every I/O method mirrors :class:`Machine` but is a coroutine that runs the
+    underlying blocking call in a thread — so a single event loop can create,
+    drive, and tear down many machines at once without blocking."""
+
+    def __init__(self, machine: Machine) -> None:
+        self._m = machine
+
+    @classmethod
+    async def create(
+        cls,
+        config: Optional[MachineConfig] = None,
+        conn: Optional[ConnectOptions] = None,
+    ) -> "AsyncMachine":
+        """Create and start a machine (awaits readiness, off the event loop)."""
+        m = await asyncio.to_thread(Machine.create, config, conn)
+        return cls(m)
+
+    @classmethod
+    async def connect(
+        cls,
+        machine_id: str,
+        conn: Optional[ConnectOptions] = None,
+    ) -> "AsyncMachine":
+        """Attach to an EXISTING machine without creating a new one."""
+        m = await asyncio.to_thread(Machine.connect, machine_id, conn)
+        return cls(m)
+
+    @property
+    def name(self) -> str:
+        """The machine's name / identifier."""
+        return self._m.name
+
+    async def state(self) -> str:
+        """Current state, e.g. ``"running"`` / ``"stopped"``."""
+        return await asyncio.to_thread(self._m.state)
+
+    async def ready(self) -> bool:
+        """Whether the machine is READY to do work (see :meth:`Machine.ready`)."""
+        return await asyncio.to_thread(self._m.ready)
+
+    async def ready_at(self) -> Optional[str]:
+        """When the machine first became ready (RFC3339), or ``None``."""
+        return await asyncio.to_thread(self._m.ready_at)
+
+    async def wait_until_ready(self, timeout_s: float = 120.0, interval_s: float = 1.0) -> None:
+        """Await readiness (or raise on a failed/stopped state or timeout)."""
+        await asyncio.to_thread(self._m.wait_until_ready, timeout_s, interval_s)
+
+    def endpoint(self, port: int, path: Optional[str] = None) -> PortEndpoint:
+        """Build an authenticated connect-bridge endpoint (URL + headers) for a
+        published guest port. Pure URL construction — no I/O — so it is a plain
+        (non-awaitable) method. See :meth:`Machine.endpoint`. (cloud)"""
+        return self._m.endpoint(port, path)
+
+    async def request(
+        self,
+        port: int,
+        path: Optional[str] = None,
+        method: str = "GET",
+        data: Optional[bytes] = None,
+        timeout_s: float = 30.0,
+    ) -> bytes:
+        """Authenticated HTTP request to a published guest port via the connect
+        bridge; returns the raw response body bytes. (cloud)"""
+        return await asyncio.to_thread(self._m.request, port, path, method, data, timeout_s)
+
+    async def url(self) -> Optional[str]:
+        """Public ingress URL for the machine's first published port (cloud)."""
+        return await asyncio.to_thread(self._m.url)
+
+    async def exec(self, command: list[str], opts: Optional[ExecOptions] = None) -> ExecResult:
+        """Execute a command directly in the machine."""
+        return await asyncio.to_thread(self._m.exec, command, opts)
+
+    async def run(self, image: str, command: list[str], opts: Optional[ExecOptions] = None) -> ExecResult:
+        """Pull an image (if needed) and run a command in a container. (local)"""
+        return await asyncio.to_thread(self._m.run, image, command, opts)
+
+    async def exec_stream(
+        self, command: list[str], opts: Optional[ExecOptions] = None
+    ) -> AsyncIterator[dict]:
+        """Execute a command and yield its output events LIVE. (local)
+
+        Bridges the sync generator to async by pulling each event off the event
+        loop, so streaming never blocks other coroutines."""
+        sync_gen = self._m.exec_stream(command, opts)
+        sentinel = object()
+
+        def _next():
+            try:
+                return next(sync_gen)
+            except StopIteration:
+                return sentinel
+
+        while True:
+            event = await asyncio.to_thread(_next)
+            if event is sentinel:
+                return
+            yield event
+
+    async def read_file(self, path: str) -> bytes:
+        """Read a file from the machine."""
+        return await asyncio.to_thread(self._m.read_file, path)
+
+    async def write_file(self, path: str, data: bytes | str, mode: Optional[int] = None) -> None:
+        """Write a file into the machine."""
+        await asyncio.to_thread(self._m.write_file, path, data, mode)
+
+    async def pull_image(self, image: str) -> ImageInfo:
+        """Pull an OCI image into the machine's storage. (local)"""
+        return await asyncio.to_thread(self._m.pull_image, image)
+
+    async def list_images(self) -> list[ImageInfo]:
+        """List cached OCI images. (local)"""
+        return await asyncio.to_thread(self._m.list_images)
+
+    async def stop(self) -> None:
+        """Stop the machine."""
+        await asyncio.to_thread(self._m.stop)
+
+    async def delete(self) -> None:
+        """Stop the machine and delete its storage."""
+        await asyncio.to_thread(self._m.delete)
+
+    async def fork(self, name: str, ports: Optional[list[PortSpec]] = None) -> "AsyncMachine":
+        """Fork this running, forkable machine into a new clone. (cloud/local)"""
+        clone = await asyncio.to_thread(self._m.fork, name, ports)
+        return AsyncMachine(clone)
+
+    # -- async context manager: auto-delete on exit --
+    async def __aenter__(self) -> "AsyncMachine":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.delete()

--- a/sdk/python/python/smol/machine.py
+++ b/sdk/python/python/smol/machine.py
@@ -15,7 +15,15 @@ from __future__ import annotations
 from typing import Optional
 
 from .transport import Transport, connect_transport, make_transport
-from .types import ConnectOptions, ExecOptions, ExecResult, ImageInfo, MachineConfig, PortSpec
+from .types import (
+    ConnectOptions,
+    ExecOptions,
+    ExecResult,
+    ImageInfo,
+    MachineConfig,
+    PortEndpoint,
+    PortSpec,
+)
 
 __all__ = ["Machine"]
 
@@ -69,6 +77,47 @@ class Machine:
     def state(self) -> str:
         """Current state, e.g. ``"running"`` / ``"stopped"``."""
         return self._t.state()
+
+    def ready(self) -> bool:
+        """Whether the machine is READY to do work. :meth:`state` becoming
+        ``"started"`` means only that the VM process launched — the guest is
+        still booting and is NOT yet usable. ``ready`` becomes true once the
+        in-VM agent is reachable (an ``exec``/``connect`` will succeed) and any
+        published port accepts connections. Gate on this, not ``state``, before
+        driving the machine. (cloud; local reports ready once running.)"""
+        return self._t.ready()
+
+    def ready_at(self) -> Optional[str]:
+        """When the machine first became ready (RFC3339), or ``None`` if not yet."""
+        return self._t.ready_at()
+
+    def wait_until_ready(self, timeout_s: float = 120.0, interval_s: float = 1.0) -> None:
+        """Block until the machine is ``ready`` (or raise on a failed/stopped
+        state or timeout). :meth:`create` already waits for readiness, so this is
+        for machines attached via :meth:`connect`, or to re-assert readiness."""
+        self._t.wait_until_ready(timeout_s, interval_s)
+
+    def endpoint(self, port: int, path: Optional[str] = None) -> PortEndpoint:
+        """An authenticated endpoint (URL + headers) to reach a PUBLISHED guest
+        port through the control plane's connect bridge — no Cloudflare/
+        localhost.run tunnel, no public exposure, no egress allow-list. Have the
+        in-VM worker LISTEN on the port and connect *inbound*: plug ``ws_url``
+        into a WebSocket client (passing ``headers``) or ``http_url`` into an
+        HTTP client. The machine must publish the port
+        (``ports=[PortSpec(...)]`` at create). (cloud)"""
+        return self._t.endpoint(port, path)
+
+    def request(
+        self,
+        port: int,
+        path: Optional[str] = None,
+        method: str = "GET",
+        data: Optional[bytes] = None,
+        timeout_s: float = 30.0,
+    ) -> bytes:
+        """Convenience: an authenticated HTTP request to a published guest port
+        via the connect bridge; returns the raw response body bytes. (cloud)"""
+        return self._t.request(port, path, method, data, timeout_s)
 
     def url(self) -> Optional[str]:
         """Public ingress URL for the machine's first published port (cloud).

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -24,7 +24,15 @@ from typing import Any, Optional, Protocol
 from urllib.parse import quote
 
 from .errors import InvalidConfigError, NotSupportedError, SmolError, wrap_native_error
-from .types import ConnectOptions, ExecOptions, ExecResult, ImageInfo, MachineConfig, PortSpec
+from .types import (
+    ConnectOptions,
+    ExecOptions,
+    ExecResult,
+    ImageInfo,
+    MachineConfig,
+    PortEndpoint,
+    PortSpec,
+)
 
 DEFAULT_CLOUD_URL = "https://api.smolmachines.com"
 CLOUD_TIMEOUT_S = 30.0
@@ -38,6 +46,18 @@ class Transport(Protocol):
     @property
     def name(self) -> str: ...
     def state(self) -> str: ...
+    def ready(self) -> bool: ...
+    def ready_at(self) -> Optional[str]: ...
+    def wait_until_ready(self, timeout_s: float = 120.0, interval_s: float = 1.0) -> None: ...
+    def endpoint(self, port: int, path: Optional[str] = None) -> PortEndpoint: ...
+    def request(
+        self,
+        port: int,
+        path: Optional[str] = None,
+        method: str = "GET",
+        data: Optional[bytes] = None,
+        timeout_s: float = CLOUD_TIMEOUT_S,
+    ) -> bytes: ...
     def url(self) -> Optional[str]: ...
     def exec(self, command: list[str], opts: Optional[ExecOptions] = None) -> ExecResult: ...
     def run(self, image: str, command: list[str], opts: Optional[ExecOptions] = None) -> ExecResult: ...
@@ -169,6 +189,37 @@ class LocalTransport:
     def state(self) -> str:
         return str(self._inner.state())
 
+    def ready(self) -> bool:
+        # A local machine is created already started; "running" means usable.
+        return str(self._inner.state()) == "running"
+
+    def ready_at(self) -> Optional[str]:
+        # No readiness timestamp for the embedded engine.
+        return None
+
+    def wait_until_ready(self, timeout_s: float = 120.0, interval_s: float = 1.0) -> None:
+        # Local create()/start() blocks on the boot, so it is already ready.
+        return None
+
+    def endpoint(self, port: int, path: Optional[str] = None) -> PortEndpoint:
+        raise NotSupportedError(
+            "endpoint() is a cloud connect-bridge feature; the local target has "
+            "no control plane. Publish a port and reach it on the host directly."
+        )
+
+    def request(
+        self,
+        port: int,
+        path: Optional[str] = None,
+        method: str = "GET",
+        data: Optional[bytes] = None,
+        timeout_s: float = CLOUD_TIMEOUT_S,
+    ) -> bytes:
+        raise NotSupportedError(
+            "request() is a cloud connect-bridge feature; the local target has "
+            "no control plane. Publish a port and reach it on the host directly."
+        )
+
     def url(self) -> Optional[str]:
         # Local machines have no public ingress URL — that's a cloud feature.
         return None
@@ -263,6 +314,50 @@ class CloudTransport:
     def state(self) -> str:
         m = _cloud_fetch(self._base, self._key, "GET", f"/v1/machines/{self._id}")
         return str((m or {}).get("state", "unknown"))
+
+    def ready(self) -> bool:
+        m = _cloud_fetch(self._base, self._key, "GET", f"/v1/machines/{self._id}")
+        return bool((m or {}).get("ready") is True)
+
+    def ready_at(self) -> Optional[str]:
+        m = _cloud_fetch(self._base, self._key, "GET", f"/v1/machines/{self._id}")
+        return (m or {}).get("readyAt")
+
+    def wait_until_ready(self, timeout_s: float = 120.0, interval_s: float = 1.0) -> None:
+        _wait_for_ready(self._base, self._key, self._id, timeout_s, interval_s)
+
+    def endpoint(self, port: int, path: Optional[str] = None) -> PortEndpoint:
+        # Reach a PUBLISHED guest port through the control plane's authenticated
+        # connect bridge — no tunnel, no public exposure. The server maps the
+        # guest port to its node host-port (404 if the port isn't published, 503
+        # if the machine isn't started) and forwards WebSocket upgrades or HTTP.
+        rel = f"/v1/machines/{self._id}/connect/{port}"
+        if path:
+            rel = f"{rel}/{path.lstrip('/')}"
+        ws_base = self._base
+        if ws_base.startswith("http"):
+            ws_base = "ws" + ws_base[len("http"):]
+        return PortEndpoint(
+            http_url=f"{self._base}{rel}",
+            ws_url=f"{ws_base}{rel}",
+            headers={"authorization": f"Bearer {self._key}"},
+        )
+
+    def request(
+        self,
+        port: int,
+        path: Optional[str] = None,
+        method: str = "GET",
+        data: Optional[bytes] = None,
+        timeout_s: float = CLOUD_TIMEOUT_S,
+    ) -> bytes:
+        """Convenience: an authenticated HTTP request to a published guest port
+        via the connect bridge. Returns the raw response body bytes."""
+        ep = self.endpoint(port, path)
+        rel = ep.http_url[len(self._base):]
+        return _cloud_fetch(
+            self._base, self._key, method, rel, raw_body=data, accept="bytes", timeout=timeout_s
+        )
 
     def url(self) -> Optional[str]:
         # Public ingress URL for the first published port; None until the machine
@@ -516,22 +611,48 @@ def _cli_config_api_key() -> Optional[str]:
     return None
 
 
-def _wait_for_ready(base_url: str, api_key: str, machine_id: str, timeout_s: float = 120.0) -> None:
+def _wait_for_ready(
+    base_url: str,
+    api_key: str,
+    machine_id: str,
+    timeout_s: float = 120.0,
+    interval_s: float = 1.0,
+) -> None:
+    """Poll until the machine is READY to do work; raise on error/terminal state
+    or timeout. Auth/not-found errors are fatal; others are transient booting.
+
+    Readiness is the machine's ``ready`` flag — true only once the guest agent
+    is reachable (and any published port accepts). Reaching state ``started`` is
+    NOT enough: the guest is still booting, and acting then is the classic
+    teardown race (works on a slow cold start, times out on a warm one). Older
+    control planes omit ``ready``; there we fall back to the coarse
+    ``started``/``running`` state so this never hangs against them."""
     deadline = time.monotonic() + timeout_s
     while True:
-        state = None
+        m: Optional[dict] = None
         try:
             m = _cloud_fetch(base_url, api_key, "GET", f"/v1/machines/{machine_id}")
-            state = (m or {}).get("state")
-        except SmolError:
-            pass  # transient while booting
-        if state in ("started", "running"):
+        except SmolError as e:
+            if e.code in ("UNAUTHORIZED", "NOT_FOUND"):
+                raise
+            # transient while booting
+        m = m or {}
+        state = m.get("state")
+        # Prefer the unambiguous readiness signal.
+        if m.get("ready") is True:
             return
         if state == "error":
             raise SmolError("SMOLVM_ERROR", f"machine {machine_id} entered error state while starting")
+        if state in ("stopped", "deleted"):
+            raise SmolError(
+                "SMOLVM_ERROR", f"machine {machine_id} entered {state} before becoming ready"
+            )
+        # Back-compat: `ready` absent entirely → old server, gate on state.
+        if "ready" not in m and state in ("started", "running"):
+            return
         if time.monotonic() >= deadline:
             raise SmolError("TIMEOUT", f"machine {machine_id} not ready after {timeout_s}s (state={state})")
-        time.sleep(1.0)
+        time.sleep(interval_s)
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -15,6 +15,7 @@ __all__ = [
     "ImageInfo",
     "ConnectOptions",
     "MachineState",
+    "PortEndpoint",
 ]
 
 MachineState = str  # "created" | "running" | "stopped"
@@ -160,3 +161,18 @@ class ConnectOptions:
     target: Optional[Literal["local", "cloud"]] = None
     base_url: Optional[str] = None
     api_key: Optional[str] = None
+
+
+@dataclass
+class PortEndpoint:
+    """An authenticated way to reach a PUBLISHED guest port through the control
+    plane's connect bridge — no tunnel, no public exposure. Returned by
+    :meth:`Machine.endpoint`. Plug ``ws_url`` into a WebSocket client or
+    ``http_url`` into an HTTP client, sending ``headers`` so it authenticates."""
+
+    http_url: str
+    """``https://…/v1/machines/:id/connect/:port[/path]`` — for HTTP requests."""
+    ws_url: str
+    """``wss://…/v1/machines/:id/connect/:port[/path]`` — for WebSocket upgrades."""
+    headers: dict
+    """Headers to send (the tenant Bearer token)."""

--- a/sdk/python/tests/test_async_mock.py
+++ b/sdk/python/tests/test_async_mock.py
@@ -1,0 +1,157 @@
+"""Async-transport test: AsyncMachine against a threaded mock of smolfleet /v1.
+
+Verifies the awaitable API mirrors the sync one AND that calls don't block the
+event loop — several machines are created/driven concurrently with
+``asyncio.gather`` and their slow (sleepy) boots overlap in wall-clock time.
+
+    python tests/test_async_mock.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from smol import AsyncMachine, ConnectOptions, MachineConfig, PortSpec
+
+# Each machine's GET returns not-ready for the first BOOT_DELAY_S, then ready.
+BOOT_DELAY_S = 0.4
+_created_at: dict[str, float] = {}
+captured: dict = {"connect_paths": []}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):  # silence
+        pass
+
+    def _auth_ok(self) -> bool:
+        return self.headers.get("authorization") == "Bearer smk_async"
+
+    def _send(self, code: int, body: bytes = b"", ctype: str = "application/json"):
+        self.send_response(code)
+        self.send_header("content-type", ctype)
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def _read(self) -> bytes:
+        n = int(self.headers.get("content-length", 0) or 0)
+        return self.rfile.read(n) if n else b""
+
+    def do_POST(self):
+        if not self._auth_ok():
+            return self._send(401, b"bad token")
+        if self.path == "/v1/machines":
+            body = json.loads(self._read() or b"{}")
+            mid = body.get("name") or "auto"
+            _created_at[mid] = time.monotonic()
+            return self._send(200, json.dumps({"id": mid, "name": mid, "state": "created"}).encode())
+        # start / stop / exec
+        parts = self.path.split("/")
+        mid = parts[3] if len(parts) > 3 else ""
+        if self.path.endswith("/exec"):
+            self._read()
+            return self._send(200, json.dumps({"exitCode": 0, "stdout": f"{mid}-ok\n", "stderr": ""}).encode())
+        return self._send(200, json.dumps({"id": mid, "state": "started"}).encode())
+
+    def do_GET(self):
+        if not self._auth_ok():
+            return self._send(401, b"bad token")
+        parts = self.path.split("/")
+        mid = parts[3] if len(parts) > 3 else ""
+        if "/connect/" in self.path:
+            captured["connect_paths"].append(self.path)
+            return self._send(200, json.dumps({"ok": True, "path": self.path}).encode())
+        # Readiness flips true only after BOOT_DELAY_S — mimics a real boot so a
+        # blocking wait would serialize; a non-blocking one overlaps.
+        started = _created_at.get(mid, 0.0)
+        ready = (time.monotonic() - started) >= BOOT_DELAY_S if started else True
+        payload = {"id": mid, "state": "started", "ready": ready}
+        if ready:
+            payload["readyAt"] = "2026-07-22T20:01:41.152Z"
+        return self._send(200, json.dumps(payload).encode())
+
+    def do_DELETE(self):
+        if not self._auth_ok():
+            return self._send(401, b"bad token")
+        return self._send(204)
+
+
+async def run() -> int:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    import threading
+
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+    conn = ConnectOptions(target="cloud", base_url=base, api_key="smk_async")
+
+    passed = failed = 0
+
+    def check(name: str, cond: bool, detail: str = ""):
+        nonlocal passed, failed
+        if cond:
+            passed += 1
+            print(f"  ok {name}")
+        else:
+            failed += 1
+            print(f"  FAIL {name} {detail}")
+
+    try:
+        # --- single machine: awaitable surface mirrors the sync one ---
+        m = await AsyncMachine.create(
+            MachineConfig(image="alpine:3.20", name="solo",
+                          ports=[PortSpec(host=8080, guest=8080)]),
+            conn,
+        )
+        check("create returns an AsyncMachine", isinstance(m, AsyncMachine))
+        check("state() awaitable", (await m.state()) == "started")
+        check("ready() awaitable + true after boot", (await m.ready()) is True)
+        check("ready_at() awaitable", (await m.ready_at()) == "2026-07-22T20:01:41.152Z")
+        r = await m.exec(["echo", "hi"])
+        check("exec() awaitable", r.stdout.strip() == "solo-ok")
+        ep = m.endpoint(8080, "/socket")
+        check("endpoint() builds authed ws url (sync, no I/O)",
+              ep.ws_url == f"{base.replace('http', 'ws', 1)}/v1/machines/solo/connect/8080/socket"
+              and ep.headers.get("authorization") == "Bearer smk_async", ep.ws_url)
+        body = json.loads((await m.request(8080, "healthz")).decode())
+        check("request() awaitable reaches the bridge", body.get("ok") is True)
+        await m.delete()
+
+        # --- concurrency: N sleepy boots overlap, proving non-blocking ---
+        n = 5
+        t0 = time.monotonic()
+        machines = await asyncio.gather(
+            *(AsyncMachine.create(MachineConfig(image="alpine:3.20", name=f"w{i}"), conn) for i in range(n))
+        )
+        elapsed = time.monotonic() - t0
+        check(f"created {n} machines concurrently", len(machines) == n)
+        # If create() blocked the loop, wall-clock would be ~n * BOOT_DELAY_S.
+        # Non-blocking, the boots overlap and it lands well under that.
+        check("concurrent creates overlapped (non-blocking)",
+              elapsed < BOOT_DELAY_S * n * 0.6,
+              f"{elapsed:.2f}s vs serialized ~{BOOT_DELAY_S * n:.2f}s")
+        outs = await asyncio.gather(*(mm.exec(["echo", "hi"]) for mm in machines))
+        check("concurrent exec on all", all(o.success for o in outs))
+        await asyncio.gather(*(mm.delete() for mm in machines))
+
+        # --- async context manager ---
+        async with await AsyncMachine.create(MachineConfig(image="alpine:3.20", name="ctx"), conn) as cm:
+            check("async with yields a usable machine", (await cm.ready()) is True)
+    finally:
+        server.shutdown()
+
+    print(f"\n{passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+def test_async_mock():
+    assert asyncio.run(run()) == 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(run()))

--- a/sdk/python/tests/test_async_mock.py
+++ b/sdk/python/tests/test_async_mock.py
@@ -14,8 +14,11 @@ import json
 import sys
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 
-from smol import AsyncMachine, ConnectOptions, MachineConfig, PortSpec
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+from smol import AsyncMachine, ConnectOptions, MachineConfig, PortSpec  # noqa: E402
 
 # Each machine's GET returns not-ready for the first BOOT_DELAY_S, then ready.
 BOOT_DELAY_S = 0.4

--- a/sdk/python/tests/test_cloud_mock.py
+++ b/sdk/python/tests/test_cloud_mock.py
@@ -80,9 +80,17 @@ class Handler(BaseHTTPRequestHandler):
         if not self._auth_ok():
             return self._send(401, b"bad token")
         if self.path == f"/v1/machines/{MACHINE_ID}":
-            return self._send(200, json.dumps({"id": MACHINE_ID, "state": "started"}).encode())
+            return self._send(200, json.dumps({
+                "id": MACHINE_ID, "state": "started",
+                "ready": True, "readyAt": "2026-07-22T20:01:41.152Z",
+            }).encode())
         if self.path == f"/v1/machines/{CLONE_ID}":
-            return self._send(200, json.dumps({"id": CLONE_ID, "state": "started"}).encode())
+            return self._send(200, json.dumps({"id": CLONE_ID, "state": "started", "ready": True}).encode())
+        # The connect bridge: GET /v1/machines/:id/connect/:port[/rest]. Echo the
+        # path + auth so the SDK's endpoint()/request() wiring can be asserted.
+        if self.path.startswith(f"/v1/machines/{MACHINE_ID}/connect/"):
+            captured["connect_path"] = self.path
+            return self._send(200, json.dumps({"ok": True, "path": self.path}).encode())
         if self.path.startswith(f"/v1/machines/{MACHINE_ID}/files/"):
             return self._send(200, captured.get("file") or b"", "application/octet-stream")
         return self._send(404, b"no route")
@@ -142,6 +150,30 @@ def main() -> int:
         check("name from response", m.name == "auto", m.name)
         check("forkable start passes ?forkable=true", "forkable=true" in captured.get("start_path", ""),
               captured.get("start_path"))
+
+        # --- readiness: `started` but the unambiguous ready flag is separate ---
+        check("state() over REST", m.state() == "started", m.state())
+        check("ready() reads the readiness flag", m.ready() is True)
+        check("ready_at() reads the readiness timestamp",
+              m.ready_at() == "2026-07-22T20:01:41.152Z", str(m.ready_at()))
+        m.wait_until_ready(timeout_s=2, interval_s=0.05)
+        check("wait_until_ready() resolves on ready", True)
+
+        # --- connect bridge: authed endpoint URL + request to a published port ---
+        ep = m.endpoint(80)
+        check("endpoint() builds the connect-bridge http_url",
+              ep.http_url == f"{base}/v1/machines/{MACHINE_ID}/connect/80", ep.http_url)
+        check("endpoint() derives a ws url",
+              ep.ws_url == f"{base.replace('http', 'ws', 1)}/v1/machines/{MACHINE_ID}/connect/80", ep.ws_url)
+        check("endpoint() carries Bearer auth", ep.headers.get("authorization") == "Bearer smk_testkey",
+              str(ep.headers))
+        check("endpoint(port, path) appends the sub-path",
+              m.endpoint(80, "/healthz").http_url == f"{base}/v1/machines/{MACHINE_ID}/connect/80/healthz",
+              m.endpoint(80, "/healthz").http_url)
+        body = json.loads(m.request(80, "healthz").decode())
+        check("request() reaches the guest port through the authed bridge",
+              body.get("ok") is True and captured.get("connect_path") == f"/v1/machines/{MACHINE_ID}/connect/80/healthz",
+              str(captured.get("connect_path")))
 
         # --- fork: live-RAM RL clone over the cloud ---
         clone = m.fork("rollout-1", ports=[PortSpec(host=18080, guest=80)])


### PR DESCRIPTION
Adds `ready`/`readyAt` and `waitUntilReady` so callers gate on true readiness instead of the coarse `started` state, first-class connect-bridge helpers (`endpoint`/`fetch`) to reach a published guest port over the authenticated control-plane bridge, and an `AsyncMachine` that mirrors the sync API without blocking the event loop.