### PR TITLE
Include the server's x-request-id in cloud SDK error messages so a failed call can be correlated

### DIFF
--- a/sdk/node/test/cloud-mock.ts
+++ b/sdk/node/test/cloud-mock.ts
@@ -39,6 +39,9 @@ const server = createServer(async (req, res) => {
   const url = req.url ?? "";
   const method = req.method ?? "GET";
   seen.auth = req.headers["authorization"] ?? seen.auth;
+  // The real control plane sets x-request-id on every response; mirror it so the
+  // SDK's error-message surfacing can be asserted.
+  res.setHeader("x-request-id", "req-test-abc");
   const json = (code: number, obj: unknown) => {
     res.writeHead(code, { "content-type": "application/json" });
     res.end(JSON.stringify(obj));
@@ -270,6 +273,20 @@ async function main(): Promise<void> {
     "fork returns running clone handle",
     clone.name === "rollout-1" && (await clone.state()) === "running",
     clone.name,
+  );
+
+  // Errors surface the server's x-request-id so support can correlate the call
+  // (clients see the error body but not response headers).
+  let ridErrMsg = "";
+  try {
+    await m.readFile("/does-not-exist");
+  } catch (e) {
+    ridErrMsg = String((e as Error).message);
+  }
+  check(
+    "error message surfaces x-request-id",
+    ridErrMsg.includes("[request id: req-test-abc]"),
+    ridErrMsg,
   );
 
   await m.stop();

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -431,13 +431,17 @@ async function cloudFetch<T = unknown>(
   }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
+    // Surface the server's correlation id (every response carries `x-request-id`)
+    // in the error message — clients see the error body but not headers, so
+    // without this the id is invisible and support can't correlate the call.
+    const rid = res.headers.get("x-request-id");
     throw new SmolError(
       res.status === 404
         ? "NOT_FOUND"
         : res.status === 401
           ? "UNAUTHORIZED"
           : "SMOLVM_ERROR",
-      `cloud ${method} ${path} → ${res.status}${text ? `: ${text}` : ""}`,
+      `cloud ${method} ${path} → ${res.status}${text ? `: ${text}` : ""}${rid ? ` [request id: ${rid}]` : ""}`,
     );
   }
   if (opts.accept === "bytes") return Buffer.from(await res.arrayBuffer()) as T;
@@ -654,13 +658,14 @@ class CloudTransport implements Transport {
     }
     if (!res.ok) {
       const text = await res.text().catch(() => "");
+      const rid = res.headers.get("x-request-id");
       throw new SmolError(
         res.status === 404
           ? "NOT_FOUND"
           : res.status === 401
             ? "UNAUTHORIZED"
             : "SMOLVM_ERROR",
-        `cloud POST /v1/machines/${this.id}/exec/stream → ${res.status}${text ? `: ${text}` : ""}`,
+        `cloud POST /v1/machines/${this.id}/exec/stream → ${res.status}${text ? `: ${text}` : ""}${rid ? ` [request id: ${rid}]` : ""}`,
       );
     }
     if (!res.body)

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -428,7 +428,9 @@ class CloudTransport:
             except Exception:  # noqa: BLE001
                 pass
             code = "NOT_FOUND" if e.code == 404 else "UNAUTHORIZED" if e.code == 401 else "SMOLVM_ERROR"
-            raise SmolError(code, f"cloud POST exec/stream → {e.code}{(': ' + text) if text else ''}") from e
+            rid = e.headers.get("x-request-id") if e.headers else None
+            suffix = f" [request id: {rid}]" if rid else ""
+            raise SmolError(code, f"cloud POST exec/stream → {e.code}{(': ' + text) if text else ''}{suffix}") from e
         except urllib.error.URLError as e:
             raise SmolError("CONNECTION", f"cloud exec/stream failed: {getattr(e, 'reason', e)}") from e
 
@@ -563,7 +565,12 @@ def _cloud_fetch(
         except Exception:  # noqa: BLE001
             pass
         code = "NOT_FOUND" if e.code == 404 else "UNAUTHORIZED" if e.code == 401 else "SMOLVM_ERROR"
-        raise SmolError(code, f"cloud {method} {path} → {e.code}{(': ' + text) if text else ''}") from e
+        # Surface the server's `x-request-id` correlation id — the error body is
+        # visible to callers but the response headers aren't, so without this the
+        # id is invisible and support can't correlate the failed call.
+        rid = e.headers.get("x-request-id") if e.headers else None
+        suffix = f" [request id: {rid}]" if rid else ""
+        raise SmolError(code, f"cloud {method} {path} → {e.code}{(': ' + text) if text else ''}{suffix}") from e
     except urllib.error.URLError as e:
         reason = getattr(e, "reason", e)
         raise SmolError("CONNECTION", f"cloud request failed: {reason}") from e

--- a/sdk/python/tests/test_cloud_mock.py
+++ b/sdk/python/tests/test_cloud_mock.py
@@ -13,7 +13,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
 
-from smol import ConnectOptions, Machine, MachineConfig, MountSpec, NotSupportedError, PortSpec, ResourceSpec  # noqa: E402
+from smol import ConnectOptions, Machine, MachineConfig, MountSpec, NotSupportedError, PortSpec, ResourceSpec, SmolError  # noqa: E402
+from smol.transport import _cloud_fetch  # noqa: E402  (internal — asserts request-id surfacing)
 
 MACHINE_ID = "mach-test123"
 CLONE_ID = "mach-clone456"
@@ -29,6 +30,9 @@ class Handler(BaseHTTPRequestHandler):
 
     def _send(self, code: int, body: bytes = b"", ctype: str = "application/json"):
         self.send_response(code)
+        # The real control plane sets x-request-id on every response; mirror it
+        # so the SDK's error-message surfacing can be asserted.
+        self.send_header("x-request-id", "req-test-xyz")
         if body:
             self.send_header("content-type", ctype)
         self.end_headers()
@@ -226,6 +230,15 @@ def main() -> int:
         check("env/workdir omitted from the body when unset",
               "env" not in captured["create_body"] and "workdir" not in captured["create_body"],
               str(captured["create_body"]))
+
+        # Errors surface the server's x-request-id so support can correlate the
+        # call (clients see the error body but not response headers).
+        rid_msg = ""
+        try:
+            _cloud_fetch(base, "smk_testkey", "GET", "/v1/does-not-exist")
+        except SmolError as e:
+            rid_msg = str(e)
+        check("error surfaces x-request-id", "[request id: req-test-xyz]" in rid_msg, rid_msg)
 
         m.stop()
         check("stop hit POST /stop", f"POST /v1/machines/{MACHINE_ID}/stop" in captured["hits"])


### PR DESCRIPTION
Appends the response x-request-id to cloud error messages in the Node and Python SDKs (clients see the error body but not response headers), with tests, so a failed call surfaces the correlation id support needs.