### PR TITLE
Expose byte-exact, untruncated exec output in the Python and Node SDKs

### DIFF
--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -37,6 +37,10 @@ function makeExecResult(r: RawExec): ExecResult {
     // streams unbounded, so absent means false.
     stdoutTruncated: r.stdoutTruncated ?? false,
     stderrTruncated: r.stderrTruncated ?? false,
+    // Byte-exact output. The cloud transport decodes it from base64; the local
+    // transport has no bytes, so fall back to the UTF-8 encoding of the text.
+    stdoutBytes: r.stdoutBytes ?? new TextEncoder().encode(r.stdout),
+    stderrBytes: r.stderrBytes ?? new TextEncoder().encode(r.stderr),
     success,
     output: r.stdout + r.stderr,
     assertSuccess() {

--- a/sdk/node/test/cloud-mock.ts
+++ b/sdk/node/test/cloud-mock.ts
@@ -89,6 +89,9 @@ const server = createServer(async (req, res) => {
       stderr: "",
       stdoutTruncated: true,
       stderrTruncated: false,
+      // Byte-exact output includes a non-UTF-8 byte (0xFF) that the lossy text
+      // field can't represent — proves the SDK decodes b64, not the text.
+      stdoutB64: Buffer.from([0x68, 0x69, 0xff]).toString("base64"),
     });
   }
   if (method === "PUT" && url.startsWith("/v1/machines/m1/files/")) {
@@ -199,6 +202,11 @@ async function main(): Promise<void> {
     "exec surfaces truncation flags",
     r.stdoutTruncated === true && r.stderrTruncated === false,
     `${r.stdoutTruncated}/${r.stderrTruncated}`,
+  );
+  check(
+    "exec exposes byte-exact stdoutBytes from base64",
+    Buffer.from(r.stdoutBytes).equals(Buffer.from([0x68, 0x69, 0xff])),
+    Buffer.from(r.stdoutBytes).toString("hex"),
   );
   check(
     "exec sent command array",

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -59,9 +59,30 @@ export interface RawExec {
   exitCode: number;
   stdout: string;
   stderr: string;
-  /** Cloud only: output was capped at 1 MiB. Absent on the local target. */
+  /** Cloud only: the text field was capped at 1 MiB. Absent on the local target. */
   stdoutTruncated?: boolean;
   stderrTruncated?: boolean;
+  /** Cloud only: byte-exact, untruncated output decoded from the base64 fields.
+   *  Absent on the local target (machine.ts fills it from the text there). */
+  stdoutBytes?: Uint8Array;
+  stderrBytes?: Uint8Array;
+}
+
+/** Byte-exact exec output from a cloud response: prefer the base64 field
+ *  (binary-safe, untruncated), fall back to the UTF-8 bytes of the lossy text
+ *  when a control predates it or the value is malformed. */
+function decodeExecBytes(
+  b64: unknown,
+  text: string,
+): Uint8Array {
+  if (typeof b64 === "string") {
+    try {
+      return new Uint8Array(Buffer.from(b64, "base64"));
+    } catch {
+      // fall through to the text fallback
+    }
+  }
+  return new TextEncoder().encode(text);
 }
 
 export interface Transport {
@@ -600,14 +621,21 @@ class CloudTransport implements Transport {
         timeoutMs,
       },
     );
+    const stdout = r.stdout ?? "";
+    const stderr = r.stderr ?? "";
+    // `stdoutB64`/`stderrB64` are byte-exact and untruncated; the generated
+    // schema type may lag the server, so read them off the raw object.
+    const raw = r as Record<string, unknown>;
     return {
       exitCode: r.exitCode ?? 0,
-      stdout: r.stdout ?? "",
-      stderr: r.stderr ?? "",
-      // The cloud caps captured output at 1 MiB and flags the cut (camelCase
+      stdout,
+      stderr,
+      // The cloud caps the text fields at 1 MiB and flags the cut (camelCase
       // per smolfleet's MachineExecResponse).
       stdoutTruncated: r.stdoutTruncated ?? false,
       stderrTruncated: r.stderrTruncated ?? false,
+      stdoutBytes: decodeExecBytes(raw.stdoutB64, stdout),
+      stderrBytes: decodeExecBytes(raw.stderrB64, stderr),
     };
   }
 

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -102,18 +102,26 @@ export interface ExecOptions {
 export interface ExecResult {
   exitCode: number;
   /**
-   * Captured stdout as text (UTF-8; invalid bytes are replaced). For BINARY
-   * output, read it back with `readFile()` instead — the string conversion is
-   * lossy. Very large output (>~20 MB) is rejected; use `execStream` for that.
+   * Captured stdout as text (UTF-8; invalid bytes are replaced), truncated to
+   * ~1 MiB on the cloud target (see `stdoutTruncated`). This conversion is lossy
+   * for binary output — use `stdoutBytes` for byte-exact, untruncated output, or
+   * `execStream` to stream very large output.
    */
   stdout: string;
   stderr: string;
-  /** True when the cloud capped stdout (1 MiB); fetch big output via
-   *  `execStream` or `readFile`. Always false on the local target (the
-   *  embedded engine streams unbounded). */
+  /** True when the cloud capped the text `stdout` (1 MiB); `stdoutBytes` is still
+   *  complete, or fetch big output via `execStream` / `readFile`. Always false on
+   *  the local target (the embedded engine streams unbounded). */
   stdoutTruncated: boolean;
-  /** True when the cloud capped stderr (1 MiB); see `stdoutTruncated`. */
+  /** True when the cloud capped the text `stderr` (1 MiB); see `stdoutTruncated`. */
   stderrTruncated: boolean;
+  /** Byte-exact, untruncated stdout. Populated from the cloud's base64 output
+   *  when the control provides it (older controls fall back to the UTF-8 bytes of
+   *  the lossy `stdout`); on the local target it is the UTF-8 encoding of `stdout`.
+   *  Prefer this over `stdout` for binary or >1 MiB output. */
+  stdoutBytes: Uint8Array;
+  /** Byte-exact, untruncated stderr; see `stdoutBytes`. */
+  stderrBytes: Uint8Array;
   /** True when exitCode === 0. */
   success: boolean;
   /** stdout + stderr, concatenated. */

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -14,6 +14,7 @@ third-party dependencies.
 from __future__ import annotations
 
 import atexit
+import base64
 import json
 import os
 import time
@@ -40,6 +41,19 @@ CLOUD_TIMEOUT_S = 30.0
 # read timeout, covering network round-trip and server-side overhead so the
 # client never aborts before the server has had a chance to finish the command.
 CLOUD_EXEC_TIMEOUT_HEADROOM_S = 30.0
+
+
+def _decode_exec_bytes(raw: dict[str, Any], b64_key: str, text: str) -> bytes:
+    """Byte-exact exec output from a cloud response. Prefers the base64 field
+    (binary-safe, untruncated); falls back to the UTF-8 bytes of the lossy text
+    when a control predates it or the field is malformed."""
+    b64 = raw.get(b64_key)
+    if isinstance(b64, str):
+        try:
+            return base64.b64decode(b64, validate=True)
+        except Exception:  # noqa: BLE001 - any decode failure → fall back to text
+            pass
+    return text.encode("utf-8", "replace")
 
 
 class Transport(Protocol):
@@ -229,14 +243,26 @@ class LocalTransport:
             r = self._inner.exec(command, _native_exec_options(opts))
         except Exception as e:  # noqa: BLE001 - re-typed below
             raise wrap_native_error(e) from e
-        return ExecResult(exit_code=r.exit_code, stdout=r.stdout, stderr=r.stderr)
+        return ExecResult(
+            exit_code=r.exit_code,
+            stdout=r.stdout,
+            stderr=r.stderr,
+            stdout_bytes=r.stdout.encode("utf-8", "replace"),
+            stderr_bytes=r.stderr.encode("utf-8", "replace"),
+        )
 
     def run(self, image: str, command: list[str], opts: Optional[ExecOptions] = None) -> ExecResult:
         try:
             r = self._inner.run(image, command, _native_exec_options(opts))
         except Exception as e:  # noqa: BLE001
             raise wrap_native_error(e) from e
-        return ExecResult(exit_code=r.exit_code, stdout=r.stdout, stderr=r.stderr)
+        return ExecResult(
+            exit_code=r.exit_code,
+            stdout=r.stdout,
+            stderr=r.stderr,
+            stdout_bytes=r.stdout.encode("utf-8", "replace"),
+            stderr_bytes=r.stderr.encode("utf-8", "replace"),
+        )
 
     def exec_stream(self, command: list[str], opts: Optional[ExecOptions] = None):
         try:
@@ -384,14 +410,19 @@ class CloudTransport:
             self._base, self._key, "POST", f"/v1/machines/{self._id}/exec", json_body=body, timeout=http_timeout
         )
         r = r or {}
+        stdout = str(r.get("stdout", ""))
+        stderr = str(r.get("stderr", ""))
         return ExecResult(
             exit_code=int(r.get("exitCode", 0)),
-            stdout=str(r.get("stdout", "")),
-            stderr=str(r.get("stderr", "")),
-            # The cloud caps captured output at 1 MiB and flags the cut
+            stdout=stdout,
+            stderr=stderr,
+            # The cloud caps the text fields at 1 MiB and flags the cut
             # (camelCase per smolfleet's MachineExecResponse).
             stdout_truncated=bool(r.get("stdoutTruncated", False)),
             stderr_truncated=bool(r.get("stderrTruncated", False)),
+            # Byte-exact, untruncated output from the base64 fields when present.
+            stdout_bytes=_decode_exec_bytes(r, "stdoutB64", stdout),
+            stderr_bytes=_decode_exec_bytes(r, "stderrB64", stderr),
         )
 
     def run(self, image: str, command: list[str], opts: Optional[ExecOptions] = None) -> ExecResult:

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -114,16 +114,24 @@ class ExecOptions:
 class ExecResult:
     exit_code: int
     stdout: str
-    """Captured stdout as text (UTF-8; invalid bytes replaced). For BINARY output,
-    read it back with ``read_file()`` instead — this conversion is lossy. Very
-    large output (>~20 MB) is rejected; use ``exec_stream`` for that."""
+    """Captured stdout as text (UTF-8; invalid bytes replaced), truncated to ~1 MiB
+    on the cloud target (see :attr:`stdout_truncated`). This conversion is lossy for
+    binary output — use :attr:`stdout_bytes` for byte-exact, untruncated output, or
+    ``exec_stream`` to stream very large output."""
     stderr: str
     stdout_truncated: bool = False
-    """True when the cloud capped stdout (1 MiB); fetch big output via
-    ``exec_stream`` or ``read_file``. Always False on the local target
-    (the embedded engine streams unbounded)."""
+    """True when the cloud capped the text :attr:`stdout` (1 MiB). :attr:`stdout_bytes`
+    is still complete; or fetch big output via ``exec_stream`` / ``read_file``. Always
+    False on the local target (the embedded engine streams unbounded)."""
     stderr_truncated: bool = False
-    """True when the cloud capped stderr (1 MiB); see :attr:`stdout_truncated`."""
+    """True when the cloud capped the text :attr:`stderr` (1 MiB); see :attr:`stdout_truncated`."""
+    stdout_bytes: bytes = b""
+    """Byte-exact, untruncated stdout. Populated from the cloud's base64 output when
+    the control provides it (older controls fall back to the UTF-8 bytes of the lossy
+    :attr:`stdout`); on the local target it is the UTF-8 encoding of :attr:`stdout`.
+    Prefer this over :attr:`stdout` for binary or >1 MiB output."""
+    stderr_bytes: bytes = b""
+    """Byte-exact, untruncated stderr; see :attr:`stdout_bytes`."""
 
     @property
     def success(self) -> bool:

--- a/sdk/python/tests/test_cloud_mock.py
+++ b/sdk/python/tests/test_cloud_mock.py
@@ -5,6 +5,7 @@ Mirrors the Node ``test/cloud-mock.ts``: verifies the wire shapes the SDK sends
 exec response) and the routes/verbs, plus NotSupported gating.
 """
 
+import base64
 import json
 import sys
 import threading
@@ -70,6 +71,9 @@ class Handler(BaseHTTPRequestHandler):
                 "stdout": "hello\n", "stderr": "", "exitCode": 0,
                 "durationMs": 12, "machineId": MACHINE_ID,
                 "stdoutTruncated": True, "stderrTruncated": False,
+                # Byte-exact output includes a non-UTF-8 byte (0xFF) the lossy text
+                # can't hold — proves the SDK decodes b64, not the text.
+                "stdoutB64": base64.b64encode(bytes([0x68, 0x69, 0xFF])).decode(),
             }).encode())
         if self.path == f"/v1/machines/{MACHINE_ID}/stop":
             return self._send(200, json.dumps({"id": MACHINE_ID, "state": "stopped"}).encode())
@@ -194,6 +198,9 @@ def main() -> int:
         check("exec surfaces truncation flags",
               r.stdout_truncated is True and r.stderr_truncated is False,
               f"{r.stdout_truncated}/{r.stderr_truncated}")
+        check("exec exposes byte-exact stdout_bytes from base64",
+              r.stdout_bytes == bytes([0x68, 0x69, 0xFF]),
+              r.stdout_bytes.hex())
 
         m.write_file("/tmp/a b.txt", "payload")
         back = m.read_file("/tmp/a b.txt")


### PR DESCRIPTION
Cloud `exec` in both SDKs read only the lossy UTF-8 `stdout`/`stderr` text — so binary output was mangled (non-UTF-8 bytes became U+FFFD) and anything past the control's 1 MiB cap was silently dropped, with no way to recover the real bytes. The docstrings compounded it by claiming output is "rejected past ~20 MB" when it's actually a silent 1 MiB truncation (verified live).

The node now returns byte-exact base64 alongside the text, so this threads it through: `ExecResult` gains `stdout_bytes`/`stderr_bytes` (Python) and `stdoutBytes`/`stderrBytes` (Node), decoded from the response's `stdoutB64`/`stderrB64`. Decoding is defensive — it falls back to the UTF-8 bytes of the lossy text when the control predates the base64 fields, so it's safe to ship before the control rolls and lights up automatically after. The lossy text fields and truncation flags are unchanged for back-compat, and the misleading docstrings are corrected.

Adds cloud-mock coverage in both SDKs asserting a non-UTF-8 payload round-trips byte-exact through the new accessors; existing unit/mock suites stay green.