### PR TITLE
Surface the machine's start-failure reason when a cloud create fails to become ready

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -66,6 +66,8 @@ jobs:
         run: python tests/test_unit.py
       - name: Cloud-transport tests (mock /v1 server; pure Python)
         run: python tests/test_cloud_mock.py
+      - name: Cloud start-failure surfacing (mock /v1 server; pure Python)
+        run: python tests/test_cloud_start_error.py
       - name: Async-transport tests (AsyncMachine vs mock /v1; pure Python)
         run: python tests/test_async_mock.py
 

--- a/sdk/node/test/cloud-start-error.ts
+++ b/sdk/node/test/cloud-start-error.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression: when a cloud machine fails to start and then enters `error`, the
+ * SDK must surface WHY start failed (the machine record carries no error detail)
+ * — not just an opaque "entered error state" — and still delete the orphan.
+ *
+ *   npx tsx test/cloud-start-error.ts
+ */
+
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Machine, SmolError } from '../index';
+
+let passed = 0;
+let failed = 0;
+const check = (label: string, ok: boolean, detail = '') => {
+  if (ok) { passed++; console.log(`  ✓ ${label}`); }
+  else { failed++; console.error(`  ✗ ${label}${detail ? ` — ${detail}` : ''}`); }
+};
+
+const REASON = 'pull image: crane manifest failed: manifest unknown';
+const seen = { deleted: false };
+// Mock: create OK, start FAILS with the real reason, machine reports `error`.
+const server = createServer((req, res) => {
+  const url = req.url ?? '';
+  const method = req.method ?? 'GET';
+  const json = (code: number, obj: unknown) => {
+    res.writeHead(code, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(obj));
+  };
+  if (method === 'POST' && url === '/v1/machines') return json(201, { id: 'mX', name: 'boom', state: 'stopped' });
+  if (method === 'POST' && url === '/v1/machines/mX/start') return json(500, { error: REASON });
+  if (method === 'GET' && url === '/v1/machines/mX') return json(200, { id: 'mX', state: 'error' });
+  if (method === 'DELETE' && url === '/v1/machines/mX') { seen.deleted = true; res.writeHead(204); return res.end(); }
+  res.writeHead(404); res.end('no route');
+});
+
+async function main(): Promise<void> {
+  console.log('smol SDK cloud start-failure surfacing test (mock /v1)\n');
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const port = (server.address() as AddressInfo).port;
+
+  let threw = false;
+  let message = '';
+  try {
+    await Machine.create({ image: 'alpine' }, { target: 'cloud', baseUrl: `http://127.0.0.1:${port}`, apiKey: 'smk_t' });
+  } catch (e) {
+    threw = true;
+    message = e instanceof SmolError ? e.message : String(e);
+  }
+  check('create() rejects when the machine enters error state', threw);
+  check('error message surfaces the start-failure reason', message.includes(REASON), message);
+  check('orphan machine was deleted (no leak)', seen.deleted);
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  server.close();
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((e) => { console.error('cloud-start-error crashed:', e); server.close(); process.exit(1); });

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -998,6 +998,7 @@ export async function makeTransport(
     const name: string = created.name ?? config.name ?? id;
     // The machine now exists on the cloud. If start/readiness fails, delete it
     // before propagating — otherwise it leaks (and bills) as an orphan.
+    let startError: string | undefined;
     try {
       // Best-effort start (cloud may auto-start; waitForReady is the gate).
       // A forkable golden boots with cloneable guest RAM (memfd) so it can later
@@ -1005,10 +1006,19 @@ export async function makeTransport(
       const startPath = `/v1/machines/${id}/start${config.forkable ? "?forkable=true" : ""}`;
       try {
         await cloudFetch(cloudConn, "POST", startPath);
-      } catch {
-        /* auto-start backends 4xx here — waitForReady decides readiness */
+      } catch (e) {
+        // waitForReady decides readiness; remember why start failed so a
+        // subsequent readiness failure can surface it (the machine record
+        // carries no error detail of its own).
+        startError = e instanceof Error ? e.message : String(e);
       }
-      await waitForReady(cloudConn, id);
+      try {
+        await waitForReady(cloudConn, id);
+      } catch (e) {
+        if (startError !== undefined && e instanceof SmolError)
+          throw new SmolError(e.code, `${e.message} (start failed: ${startError})`);
+        throw e;
+      }
     } catch (e) {
       await cloudFetch(cloudConn, "DELETE", `/v1/machines/${id}`).catch(
         () => {},

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -859,12 +859,21 @@ def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None)
         start_path = f"/v1/machines/{machine_id}/start"
         if config.forkable:
             start_path += "?forkable=true"
+        start_error: Optional[str] = None
         try:
             try:
                 _cloud_fetch(base_url, api_key, "POST", start_path)
-            except SmolError:
-                pass  # best-effort; _wait_for_ready is the gate
-            _wait_for_ready(base_url, api_key, machine_id)
+            except SmolError as e:
+                # Best-effort; _wait_for_ready is the gate. Remember the reason so
+                # a subsequent readiness failure can surface WHY start failed — the
+                # machine record carries no error detail of its own.
+                start_error = str(e)
+            try:
+                _wait_for_ready(base_url, api_key, machine_id)
+            except SmolError as e:
+                if start_error is not None:
+                    raise SmolError(e.code, f"{e} (start failed: {start_error})") from e
+                raise
         except BaseException:
             try:
                 _cloud_fetch(base_url, api_key, "DELETE", f"/v1/machines/{machine_id}")

--- a/sdk/python/tests/test_cloud_start_error.py
+++ b/sdk/python/tests/test_cloud_start_error.py
@@ -1,0 +1,95 @@
+"""Regression: when a cloud machine fails to start and then enters `error`, the
+SDK must surface WHY start failed (the machine record carries no error detail) —
+not just an opaque "entered error state" — and still delete the orphan."""
+
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+from smol import ConnectOptions, Machine, MachineConfig  # noqa: E402
+from smol.errors import SmolError  # noqa: E402
+
+MID = "mach-starterr"
+REASON = "pull image: crane manifest failed: manifest unknown"
+seen = {"deleted": False}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):  # silence
+        pass
+
+    def _send(self, code: int, body: bytes = b""):
+        self.send_response(code)
+        if body:
+            self.send_header("content-type", "application/json")
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def do_POST(self):
+        if self.path == "/v1/machines":
+            n = int(self.headers.get("content-length", 0))
+            self.rfile.read(n)
+            return self._send(201, json.dumps({"id": MID, "name": "boom", "state": "stopped"}).encode())
+        if self.path == f"/v1/machines/{MID}/start":
+            # Start fails with the real reason in the body.
+            return self._send(500, json.dumps({"error": REASON}).encode())
+        return self._send(404)
+
+    def do_GET(self):
+        if self.path == f"/v1/machines/{MID}":
+            # The record itself has no error detail — only `state`.
+            return self._send(200, json.dumps({"id": MID, "state": "error"}).encode())
+        return self._send(404)
+
+    def do_DELETE(self):
+        if self.path == f"/v1/machines/{MID}":
+            seen["deleted"] = True
+            return self._send(204)
+        return self._send(404)
+
+
+def main() -> int:
+    srv = HTTPServer(("127.0.0.1", 0), Handler)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+
+    passed = failed = 0
+
+    def check(name: str, cond: bool, detail: str = ""):
+        nonlocal passed, failed
+        if cond:
+            passed += 1
+            print(f"  ok {name}")
+        else:
+            failed += 1
+            print(f"  FAIL {name} {detail}")
+
+    threw = False
+    message = ""
+    try:
+        Machine.create(
+            MachineConfig(image="alpine"),
+            ConnectOptions(target="cloud", base_url=base, api_key="smk_t"),
+        )
+    except SmolError as e:
+        threw = True
+        message = str(e)
+
+    check("create() raised when the machine entered error state", threw)
+    check("error message surfaces the start-failure reason", REASON in message, message)
+    check("orphan machine was deleted (no leak)", seen["deleted"])
+
+    srv.shutdown()
+    print(f"\n{passed} passed, {failed} failed")
+    print("RESULT=PASS" if failed == 0 else "RESULT=FAIL")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
When a cloud machine fails to start and enters the error state, create() now includes the start API's failure reason in the raised error instead of an opaque "entered error state" message, since the machine record carries no error detail of its own.