### PR TITLE
Send the connect bridge's root path without a trailing slash so request and endpoint on the root no longer 404

### DIFF
--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -573,8 +573,12 @@ class CloudTransport implements Transport {
     // connect bridge — no tunnel, no public exposure. The server maps the guest
     // port to its node host-port (404 if the port isn't published, 503 if the
     // machine isn't started) and forwards WebSocket upgrades or plain HTTP.
-    const rel = path
-      ? `/v1/machines/${this.id}/connect/${port}/${path.replace(/^\/+/, "")}`
+    // Only append a sub-path when there's a non-empty segment: a bare "/" (or
+    // "") must stay `connect/<port>` (no trailing slash), which the control
+    // routes; `connect/<port>/` matches no route and 404s.
+    const sub = path.replace(/^\/+/, "");
+    const rel = sub
+      ? `/v1/machines/${this.id}/connect/${port}/${sub}`
       : `/v1/machines/${this.id}/connect/${port}`;
     return {
       httpUrl: `${this.conn.baseUrl}${rel}`,

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -358,8 +358,12 @@ class CloudTransport:
         # guest port to its node host-port (404 if the port isn't published, 503
         # if the machine isn't started) and forwards WebSocket upgrades or HTTP.
         rel = f"/v1/machines/{self._id}/connect/{port}"
-        if path:
-            rel = f"{rel}/{path.lstrip('/')}"
+        # Only append a sub-path when there's a non-empty segment: a bare "/"
+        # (or "") must stay `connect/<port>` (no trailing slash), which the
+        # control routes; `connect/<port>/` matches no route and 404s.
+        sub = path.lstrip("/") if path else ""
+        if sub:
+            rel = f"{rel}/{sub}"
         ws_base = self._base
         if ws_base.startswith("http"):
             ws_base = "ws" + ws_base[len("http"):]

--- a/sdk/python/tests/test_unit.py
+++ b/sdk/python/tests/test_unit.py
@@ -43,6 +43,22 @@ def test_encode_path_escapes_unsafe():
     assert _encode_path("/a/100%done") == "/a/100%25done"
 
 
+def test_connect_bridge_root_path_has_no_trailing_slash():
+    from smol.transport import CloudTransport
+
+    c = CloudTransport("https://x", "smk_k", "mID", "n")
+    base = "https://x/v1/machines/mID/connect/8080"
+    # A bare root ("/", "", or no path) must NOT add a trailing slash — the
+    # control routes `connect/<port>` but `connect/<port>/` matches no route.
+    assert c.endpoint(8080).http_url == base
+    assert c.endpoint(8080, "/").http_url == base
+    assert c.endpoint(8080, "").http_url == base
+    # A real sub-path is appended (leading slashes stripped, no double slash).
+    assert c.endpoint(8080, "/index.html").http_url == base + "/index.html"
+    assert c.endpoint(8080, "index.html").http_url == base + "/index.html"
+    assert c.endpoint(8080, "//a/b").http_url == base + "/a/b"
+
+
 def test_exec_result_helpers():
     ok = ExecResult(exit_code=0, stdout="hi\n", stderr="")
     assert ok.success is True


### PR DESCRIPTION
endpoint() and request() built connect/<port>/ for a root path, which matches neither the /connect/:port nor the /connect/:port/*rest control route and returned 404; a bare or empty path now maps to connect/<port> with no trailing slash.