### PR TITLE
Clarify cloud readiness semantics across SDKs and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,14 @@ try {
 // Cloud: same API, just point at smolfleet.
 const c = await Machine.create(
   { image: 'alpine:3.20' },
-  { target: 'cloud', apiKey: process.env.SMOL_CLOUD_TOKEN },
+  { target: 'cloud' }, // uses SMOL_CLOUD_TOKEN
 );
+try {
+  // create() waits for "ready"; cloud state "started" only means VM launched.
+  console.log((await c.exec(['echo', 'ready for work'])).stdout);
+} finally {
+  await c.delete();
+}
 ```
 
 ## Quickstart — Python
@@ -97,12 +103,16 @@ with Machine.create(MachineConfig(resources=ResourceSpec(cpus=2, memory_mb=1024,
     r = m.run("python:3.12", ["python", "-c", "print(2 ** 10)"]).assert_success()
     print(r.stdout)                  # 1024
 
-# Cloud — same API.
-with Machine.create(
+# Cloud — create() waits until the guest agent is reachable. A cloud state of
+# "started" means only that the VM launched, not that it is ready for work.
+m = Machine.create(
     MachineConfig(image="alpine:3.20"),
-    ConnectOptions(target="cloud", api_key="smk_…"),  # or set SMOL_CLOUD_TOKEN
-) as m:
-    print(m.exec(["echo", "hi"]).stdout)
+    ConnectOptions(target="cloud"),  # uses SMOL_CLOUD_TOKEN
+)
+try:
+    print(m.exec(["echo", "ready for work"]).stdout)
+finally:
+    m.delete()
 ```
 
 ## Quickstart — CLI

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,6 +79,12 @@ Global behavior:
 Cloud machines are also reachable through `smol machine …` with `--cloud` (or a
 `cloud/<name>` prefix); this group holds the cloud-only operations.
 
+For cloud machines, `state: "started"` means only that the VM process launched.
+It is **ready for work** only when `ready: true`: the guest agent is reachable
+and, when a port is published, that port is accepting connections. Cloud start
+and deploy output distinguishes these conditions; do not treat “VM launched” as
+permission to exec, connect, or expect the workload to respond.
+
 | Command | Description |
 |---------|-------------|
 | `smol cloud deploy --image <ref>` | Create + start a machine on the cloud cluster. Scope egress with `--allow-host`/`--allow-cidr`. |

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -15,12 +15,18 @@ the backend is chosen by `ConnectOptions`:
 // Local (embedded, default) — no server, no config:
 const local = await Machine.create({ resources: { cpus: 2, memoryMb: 1024 } });
 
-// Cloud (smolfleet) — pass an API key, or set SMOL_CLOUD_TOKEN (e.g. via `smol login`):
+// Cloud (smolfleet) — pass an API key, or set SMOL_CLOUD_TOKEN.
 const cloud = await Machine.create(
   { image: 'python:3.12' },
-  { target: 'cloud', apiKey: process.env.SMOL_CLOUD_TOKEN },
+  { target: 'cloud' }, // uses SMOL_CLOUD_TOKEN
 );
-const res = await cloud.exec(['python', '-c', 'print(40 + 2)']);
+try {
+  // create() returned only after the guest agent became reachable.
+  const res = await cloud.exec(['python', '-c', 'print(40 + 2)']);
+  console.log(res.stdout);
+} finally {
+  await cloud.delete();
+}
 ```
 
 Cloud-only gaps (`run`, `execStream`, `pullImage`, `listImages`) throw `NotSupportedError`;
@@ -38,10 +44,18 @@ teardown race (works on a slow cold start, times out on a warm one). Gate on the
 unambiguous signal:
 
 ```ts
-const m = await Machine.create({ image, ports: [{ host: 8080, guest: 8080 }] },
-                               { target: 'cloud' });
-await m.waitUntilReady();          // create() already waited; re-assert if reconnecting
-console.log(await m.ready(), await m.readyAt());
+const m = await Machine.create(
+  { image, ports: [{ host: 8080, guest: 8080 }] },
+  { target: 'cloud' },
+);
+try {
+  // create() has already waited: the guest agent is reachable and the
+  // published port is accepting connections.
+  const res = await m.fetch(8080, '/healthz');
+  console.log(await res.text());
+} finally {
+  await m.delete();
+}
 ```
 
 To reach a service **inside** the VM, use the authenticated connect bridge —
@@ -49,11 +63,12 @@ To reach a service **inside** the VM, use the authenticated connect bridge —
 Have the worker LISTEN on a published port and connect *inbound*:
 
 ```ts
-// HTTP to a published guest port:
-const res = await m.fetch(8080, '/healthz');
+// Machine.connect() does not wait. Explicitly gate a pre-existing machine:
+const existing = await Machine.connect(machineId, { target: 'cloud' });
+await existing.waitUntilReady();
 
 // Or a WebSocket, using your own ws client with the authed endpoint:
-const { wsUrl, headers } = m.endpoint(8080, '/socket');
+const { wsUrl, headers } = existing.endpoint(8080, '/socket');
 const ws = new WebSocket(wsUrl, { headers });   // e.g. the `ws` package
 ```
 
@@ -89,12 +104,18 @@ try {
 
 ## API
 
-- `Machine.create(config?, conn?)` — create and start a machine.
+- `Machine.create(config?, conn?)` — create and start a machine; cloud waits for
+  `ready === true` before returning.
+- `Machine.connect(id, conn?)` — attach to an existing machine without waiting;
+  call `waitUntilReady()` before use.
+- `machine.ready()` / `machine.readyAt()` /
+  `machine.waitUntilReady({ timeoutMs, intervalMs })` *(cloud)*.
 - `machine.exec(command, opts?)` / `machine.run(image, command, opts?)` → `ExecResult`.
 - `machine.execStream(command, opts?)` → `AsyncGenerator<ExecEvent>`.
 - `machine.readFile(path)` / `machine.writeFile(path, data, mode?)`.
 - `machine.pullImage(image)` / `machine.listImages()`.
-- `machine.stop()` / `machine.delete()` / `await machine.state()` → `"running" | "stopped"`.
+- `machine.stop()` / `machine.delete()` / `await machine.state()`. Cloud
+  `"started"` means VM launched, not ready for work.
 
 Errors are typed: `SmolError` (with `.code`), `ExecutionError`, `NotSupportedError`, `InvalidConfigError`.
 

--- a/sdk/node/examples/cloud.ts
+++ b/sdk/node/examples/cloud.ts
@@ -1,0 +1,22 @@
+import { Machine } from "smolmachines";
+
+async function main() {
+  const machine = await Machine.create(
+    { image: "alpine:3.20" },
+    { target: "cloud" }, // uses SMOL_CLOUD_TOKEN
+  );
+
+  try {
+    // create() waits for ready=true; state "started" only means VM launched.
+    const result = await machine.exec(["echo", "ready for work"]);
+    result.assertSuccess();
+    console.log(result.stdout);
+  } finally {
+    await machine.delete();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -53,7 +53,10 @@ export class Machine {
   private constructor(private readonly transport: Transport) {}
 
   /**
-   * Create and start a machine.
+   * Create and start a machine. On the cloud target, this does not return until
+   * the machine is ready for work: the guest agent is reachable and any
+   * published port is accepting connections. A cloud state of `"started"`
+   * alone means only that the VM process launched.
    *
    * @param config  machine configuration (a name is generated if omitted; `image`
    *                is the base image — required for cloud, optional for local)
@@ -72,6 +75,8 @@ export class Machine {
    *  - local (default): re-opens a persisted machine by NAME, starting it if
    *    stopped — pairs with `Machine.create({ name, … }, …)` + `persistent`.
    *  - cloud: looks up the machine by id; throws if it doesn't exist.
+   *    This does not wait for readiness; call `waitUntilReady()` before `exec`,
+   *    using a connect endpoint, or expecting the workload to respond.
    *
    * @param id    local machine name, or cloud machine id (`mach-…`)
    * @param conn  backend selection (local by default; cloud via `{ target: 'cloud', apiKey }` or `SMOL_CLOUD_TOKEN`)
@@ -88,7 +93,9 @@ export class Machine {
     return this.transport.name;
   }
 
-  /** Current state (e.g. "running" | "stopped"). */
+  /** Current lifecycle state. On cloud, `"started"` means only that the VM
+   *  process launched; it does not mean the guest or workload is ready. Use
+   *  `ready()` or `waitUntilReady()` before doing work. */
   state(): Promise<string> {
     return this.transport.state();
   }

--- a/sdk/node/test/cloud-mock.ts
+++ b/sdk/node/test/cloud-mock.ts
@@ -9,7 +9,7 @@
 
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
-import { Machine, NotSupportedError } from "../index";
+import { Machine, NotSupportedError, SmolError } from "../index";
 
 let passed = 0;
 let failed = 0;
@@ -26,6 +26,18 @@ const check = (label: string, ok: boolean, detail = "") => {
 // --- in-memory mock cloud ---
 const seen: any = { auth: null, execBody: null };
 const files = new Map<string, Buffer>();
+const readinessGets: Record<string, number> = {};
+
+function readinessResponse(id: string, readyAfter: number, state = "started") {
+  readinessGets[id] = (readinessGets[id] ?? 0) + 1;
+  return {
+    id,
+    state,
+    ready: readinessGets[id] >= readyAfter,
+    readyAt:
+      readinessGets[id] >= readyAfter ? "2026-07-22T20:01:41.152Z" : null,
+  };
+}
 
 function readBody(req: any): Promise<Buffer> {
   return new Promise((resolve) => {
@@ -53,7 +65,7 @@ const server = createServer(async (req, res) => {
   }
   if (method === "POST" && url.startsWith("/v1/machines/m1/start")) {
     seen.startUrl = url;
-    return json(200, { state: "running" });
+    return json(200, { state: "started", ready: false });
   }
   if (method === "POST" && url === "/v1/machines/m1/fork") {
     seen.forkBody = JSON.parse((await readBody(req)).toString() || "{}");
@@ -70,12 +82,13 @@ const server = createServer(async (req, res) => {
     });
   }
   if (method === "GET" && url === "/v1/machines/m1")
-    return json(200, {
-      id: "m1",
-      state: "started",
-      ready: true,
-      readyAt: "2026-07-22T20:01:41.152Z",
-    });
+    return json(200, readinessResponse("m1", 2));
+  if (method === "GET" && url === "/v1/machines/m-wait")
+    return json(200, readinessResponse("m-wait", 5));
+  if (method === "GET" && url === "/v1/machines/m-timeout")
+    return json(200, readinessResponse("m-timeout", Number.POSITIVE_INFINITY));
+  if (method === "GET" && url === "/v1/machines/m-stopped")
+    return json(200, readinessResponse("m-stopped", Number.POSITIVE_INFINITY, "stopped"));
   // The connect bridge: GET /v1/machines/:id/connect/:port[/rest]. Echo the
   // path + auth so the SDK's endpoint()/fetch() wiring can be asserted.
   if (method === "GET" && url.startsWith("/v1/machines/m1/connect/")) {
@@ -139,6 +152,11 @@ async function main(): Promise<void> {
   );
   check("created via cloud (name from API)", m.name === "cloud-test", m.name);
   check(
+    "Machine.create() waited past started/ready=false",
+    readinessGets.m1 >= 2,
+    `${readinessGets.m1} readiness GET(s)`,
+  );
+  check(
     "create sends env as a plain map + workdir",
     JSON.stringify(seen.createBody?.env) === JSON.stringify({ FOO: "bar" }) &&
       seen.createBody?.workdir === "/app",
@@ -164,6 +182,65 @@ async function main(): Promise<void> {
     "forkable start passes ?forkable=true",
     String(seen.startUrl ?? "").includes("forkable=true"),
     String(seen.startUrl),
+  );
+
+  // Machine.connect() only attaches. Its caller must explicitly wait, and a
+  // lifecycle state of "started" must not short-circuit ready=false.
+  const connected = await Machine.connect("m-wait", {
+    target: "cloud",
+    baseUrl,
+    apiKey: "smk_test123",
+  });
+  check(
+    "connected started machine is not yet usable",
+    (await connected.state()) === "started" && (await connected.ready()) === false,
+  );
+  const beforeWait = readinessGets["m-wait"];
+  await connected.waitUntilReady({ timeoutMs: 500, intervalMs: 10 });
+  check(
+    "waitUntilReady() polls through started/ready=false",
+    readinessGets["m-wait"] - beforeWait >= 2,
+    `${readinessGets["m-wait"] - beforeWait} readiness GET(s)`,
+  );
+
+  const neverReady = await Machine.connect("m-timeout", {
+    target: "cloud",
+    baseUrl,
+    apiKey: "smk_test123",
+  });
+  let timeoutError: unknown;
+  try {
+    await neverReady.waitUntilReady({ timeoutMs: 25, intervalMs: 5 });
+  } catch (e) {
+    timeoutError = e;
+  }
+  check(
+    "readiness timeout reports machine, state, and duration",
+    timeoutError instanceof SmolError &&
+      timeoutError.code === "TIMEOUT" &&
+      timeoutError.message.includes("m-timeout") &&
+      timeoutError.message.includes("25ms") &&
+      timeoutError.message.includes("state=started"),
+    String(timeoutError),
+  );
+
+  const stopped = await Machine.connect("m-stopped", {
+    target: "cloud",
+    baseUrl,
+    apiKey: "smk_test123",
+  });
+  let terminalError: unknown;
+  try {
+    await stopped.waitUntilReady({ timeoutMs: 100, intervalMs: 5 });
+  } catch (e) {
+    terminalError = e;
+  }
+  check(
+    "terminal state fails readiness with a useful error",
+    terminalError instanceof SmolError &&
+      terminalError.message.includes("m-stopped") &&
+      terminalError.message.includes("stopped before becoming ready"),
+    String(terminalError),
   );
 
   // --- connect bridge: authed endpoint URL + fetch to a published guest port ---

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -1,8 +1,10 @@
 /** Public types for the `smol` SDK. Backend-agnostic; mapped to the native
  *  addon (local) or, in a later phase, the cloud REST API. */
 
-/** Lifecycle state of a machine. */
-export type MachineState = "created" | "running" | "stopped";
+/** Lifecycle state of a machine. Cloud `"started"` means the VM process
+ * launched, not that the guest agent or workload is ready; use `ready()` or
+ * `waitUntilReady()` before doing work. */
+export type MachineState = "created" | "started" | "running" | "stopped";
 
 /** CPU / memory / disk / network allocation for a machine. */
 export interface ResourceSpec {
@@ -67,7 +69,9 @@ export interface MachineConfig {
   image?: string;
   /** Host directories to mount. (local) */
   mounts?: MountSpec[];
-  /** Port mappings. (local) */
+  /** Port mappings. On cloud, the guest port is published and the control plane
+   *  allocates the host port; readiness includes that published port accepting
+   *  connections. */
   ports?: PortSpec[];
   /** Resource allocation. */
   resources?: ResourceSpec;
@@ -170,7 +174,7 @@ export interface PortEndpoint {
 
 /** Selects and configures the backend. Local (embedded) is the default. */
 export interface ConnectOptions {
-  /** 'local' = embedded engine (default). 'cloud' = remote (not yet implemented). */
+  /** 'local' = embedded engine (default). 'cloud' = smolfleet remote. */
   target?: "local" | "cloud";
   /** Cloud base URL (cloud target only). */
   baseUrl?: string;

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -21,13 +21,16 @@ with Machine.create(MachineConfig(resources=ResourceSpec(cpus=2, memory_mb=1024,
     m.write_file("/tmp/in.txt", "hi")
     print(m.read_file("/tmp/in.txt").decode())
 
-# Cloud (smolfleet) — same API, just point at the cloud.
+# Cloud (smolfleet) — create() waits until it is ready for work.
 from smol import ConnectOptions
-with Machine.create(
+m = Machine.create(
     MachineConfig(image="alpine:3.20"),
-    ConnectOptions(target="cloud", api_key="smk_…"),  # or set SMOL_CLOUD_TOKEN
-) as m:
-    print(m.exec(["echo", "hi"]).stdout)
+    ConnectOptions(target="cloud"),  # uses SMOL_CLOUD_TOKEN
+)
+try:
+    print(m.exec(["echo", "ready for work"]).stdout)
+finally:
+    m.delete()
 ```
 
 ### Async: `AsyncMachine` (non-blocking)
@@ -82,24 +85,33 @@ teardown race (works on a slow cold start, times out on a warm one). Gate on the
 unambiguous signal:
 
 ```python
-with Machine.create(
+m = Machine.create(
     MachineConfig(image="alpine:3.20", ports=[PortSpec(host=8080, guest=8080)]),
     ConnectOptions(target="cloud"),
-) as m:
-    m.wait_until_ready()           # create() already waited; re-assert if reconnecting
-    print(m.ready(), m.ready_at())
-
+)
+try:
+    # create() already waited: the guest agent is reachable and the published
+    # port is accepting connections.
     # Reach a service INSIDE the vm through the authenticated connect bridge —
     # no Cloudflare/localhost.run tunnel, no public exposure, no egress allow-list.
     # Have the worker LISTEN on a published port and connect *inbound*:
     print(m.request(8080, "healthz").decode())     # authed HTTP to the guest port
     ep = m.endpoint(8080, "/socket")               # or build a ws:// url for your ws client
     # websocket.connect(ep.ws_url, additional_headers=ep.headers)
+finally:
+    m.delete()
+
+# Machine.connect() intentionally does not wait for readiness:
+existing = Machine.connect(machine_id, ConnectOptions(target="cloud"))
+existing.wait_until_ready()
 ```
 
 ## API
 - `Machine` (sync) / `AsyncMachine` (awaitable, non-blocking) — identical surface; see the async example above.
-- `Machine.create(config=None, conn=None)` — create and start a machine.
+- `Machine.create(config=None, conn=None)` — create and start a machine; cloud
+  waits for `ready is True` before returning.
+- `Machine.connect(machine_id, conn=None)` — attach without waiting; call
+  `wait_until_ready()` before use.
 - `machine.exec(command, opts=None)` / `machine.run(image, command, opts=None)` → `ExecResult`
 - `machine.read_file(path)` → `bytes` / `machine.write_file(path, data, mode=None)`
 - `machine.ready()` / `machine.ready_at()` / `machine.wait_until_ready(timeout_s=120, interval_s=1)`  *(cloud)*

--- a/sdk/python/examples/cloud.py
+++ b/sdk/python/examples/cloud.py
@@ -1,0 +1,13 @@
+from smol import ConnectOptions, Machine, MachineConfig
+
+
+machine = Machine.create(
+    MachineConfig(image="alpine:3.20"),
+    ConnectOptions(target="cloud"),  # uses SMOL_CLOUD_TOKEN
+)
+try:
+    # create() waits for ready=True; state "started" only means VM launched.
+    result = machine.exec(["echo", "ready for work"]).assert_success()
+    print(result.stdout)
+finally:
+    machine.delete()

--- a/sdk/python/python/smol/async_machine.py
+++ b/sdk/python/python/smol/async_machine.py
@@ -70,7 +70,10 @@ class AsyncMachine:
         machine_id: str,
         conn: Optional[ConnectOptions] = None,
     ) -> "AsyncMachine":
-        """Attach to an EXISTING machine without creating a new one."""
+        """Attach to an EXISTING machine without creating a new one.
+
+        This does not wait for cloud readiness; await :meth:`wait_until_ready`
+        before doing work."""
         m = await asyncio.to_thread(Machine.connect, machine_id, conn)
         return cls(m)
 
@@ -80,7 +83,8 @@ class AsyncMachine:
         return self._m.name
 
     async def state(self) -> str:
-        """Current state, e.g. ``"running"`` / ``"stopped"``."""
+        """Current lifecycle state. Cloud ``"started"`` means the VM process
+        launched, not that it is ready for work."""
         return await asyncio.to_thread(self._m.state)
 
     async def ready(self) -> bool:

--- a/sdk/python/python/smol/machine.py
+++ b/sdk/python/python/smol/machine.py
@@ -43,6 +43,11 @@ class Machine:
     ) -> "Machine":
         """Create and start a machine.
 
+        On the cloud target, this does not return until the machine is ready for
+        work: the guest agent is reachable and any published port is accepting
+        connections. Cloud state ``"started"`` alone means only that the VM
+        process launched.
+
         :param config: machine configuration (a name is generated if omitted;
             ``image`` is required for the cloud target, optional for local).
         :param conn: backend selection (local embedded by default).
@@ -63,6 +68,10 @@ class Machine:
           persistent=True)``.
         * cloud: looks up the machine by id; raises if it doesn't exist.
 
+          This does not wait for readiness; call :meth:`wait_until_ready`
+          before ``exec``, using a connect endpoint, or expecting the workload
+          to respond.
+
         :param machine_id: local machine name, or cloud machine id (``mach-…``).
         :param conn: backend selection (local by default; cloud via
             ``ConnectOptions(target='cloud', api_key=…)`` or ``SMOL_CLOUD_TOKEN``).
@@ -75,7 +84,9 @@ class Machine:
         return self._t.name
 
     def state(self) -> str:
-        """Current state, e.g. ``"running"`` / ``"stopped"``."""
+        """Current lifecycle state. On cloud, ``"started"`` means only that the
+        VM process launched; use :meth:`ready` or :meth:`wait_until_ready`
+        before doing work."""
         return self._t.state()
 
     def ready(self) -> bool:

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -18,7 +18,9 @@ __all__ = [
     "PortEndpoint",
 ]
 
-MachineState = str  # "created" | "running" | "stopped"
+# Lifecycle state. Cloud "started" means the VM process launched, not that the
+# guest agent or workload is ready; use ready()/wait_until_ready() before work.
+MachineState = str  # "created" | "started" | "running" | "stopped"
 
 
 @dataclass
@@ -70,6 +72,9 @@ class MountSpec:
 
 @dataclass
 class PortSpec:
+    """Host/guest port mapping. On cloud, readiness includes the published
+    guest port accepting connections."""
+
     host: int
     guest: int
 

--- a/sdk/python/tests/test_cloud_mock.py
+++ b/sdk/python/tests/test_cloud_mock.py
@@ -20,6 +20,18 @@ from smol.transport import _cloud_fetch  # noqa: E402  (internal — asserts req
 MACHINE_ID = "mach-test123"
 CLONE_ID = "mach-clone456"
 captured: dict = {"hits": [], "create_body": None, "exec_body": None, "file": None}
+readiness_gets: dict[str, int] = {}
+
+
+def readiness_response(machine_id: str, ready_after: int, state: str = "started") -> dict:
+    readiness_gets[machine_id] = readiness_gets.get(machine_id, 0) + 1
+    ready = readiness_gets[machine_id] >= ready_after
+    return {
+        "id": machine_id,
+        "state": state,
+        "ready": ready,
+        "readyAt": "2026-07-22T20:01:41.152Z" if ready else None,
+    }
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -88,10 +100,16 @@ class Handler(BaseHTTPRequestHandler):
         if not self._auth_ok():
             return self._send(401, b"bad token")
         if self.path == f"/v1/machines/{MACHINE_ID}":
-            return self._send(200, json.dumps({
-                "id": MACHINE_ID, "state": "started",
-                "ready": True, "readyAt": "2026-07-22T20:01:41.152Z",
-            }).encode())
+            return self._send(200, json.dumps(readiness_response(MACHINE_ID, 2)).encode())
+        if self.path == "/v1/machines/mach-wait":
+            return self._send(200, json.dumps(readiness_response("mach-wait", 5)).encode())
+        if self.path == "/v1/machines/mach-timeout":
+            return self._send(200, json.dumps(readiness_response("mach-timeout", sys.maxsize)).encode())
+        if self.path == "/v1/machines/mach-stopped":
+            return self._send(
+                200,
+                json.dumps(readiness_response("mach-stopped", sys.maxsize, "stopped")).encode(),
+            )
         if self.path == f"/v1/machines/{CLONE_ID}":
             return self._send(200, json.dumps({"id": CLONE_ID, "state": "started", "ready": True}).encode())
         # The connect bridge: GET /v1/machines/:id/connect/:port[/rest]. Echo the
@@ -155,6 +173,8 @@ def main() -> int:
         check("create sends env as a plain map", cb.get("env") == {"FOO": "bar"}, str(cb.get("env")))
         check("create sends workdir", cb.get("workdir") == "/app", str(cb.get("workdir")))
         check("waited for ready (GET machine)", any(h.startswith(f"GET /v1/machines/{MACHINE_ID}") for h in captured["hits"]))
+        check("Machine.create() waited past started/ready=false",
+              readiness_gets.get(MACHINE_ID, 0) >= 2, str(readiness_gets.get(MACHINE_ID, 0)))
         check("name from response", m.name == "auto", m.name)
         check("forkable start passes ?forkable=true", "forkable=true" in captured.get("start_path", ""),
               captured.get("start_path"))
@@ -166,6 +186,51 @@ def main() -> int:
               m.ready_at() == "2026-07-22T20:01:41.152Z", str(m.ready_at()))
         m.wait_until_ready(timeout_s=2, interval_s=0.05)
         check("wait_until_ready() resolves on ready", True)
+
+        # connect() only attaches. A caller must explicitly wait, and "started"
+        # must not short-circuit the control plane's ready=False signal.
+        connected = Machine.connect(
+            "mach-wait", ConnectOptions(target="cloud", base_url=base, api_key="smk_testkey")
+        )
+        check("connected started machine is not yet usable",
+              connected.state() == "started" and connected.ready() is False)
+        before_wait = readiness_gets["mach-wait"]
+        connected.wait_until_ready(timeout_s=0.5, interval_s=0.01)
+        check("wait_until_ready() polls through started/ready=false",
+              readiness_gets["mach-wait"] - before_wait >= 2,
+              str(readiness_gets["mach-wait"] - before_wait))
+
+        never_ready = Machine.connect(
+            "mach-timeout", ConnectOptions(target="cloud", base_url=base, api_key="smk_testkey")
+        )
+        timeout_error = None
+        try:
+            never_ready.wait_until_ready(timeout_s=0.025, interval_s=0.005)
+        except SmolError as e:
+            timeout_error = e
+        timeout_message = str(timeout_error)
+        check("readiness timeout reports machine, state, and duration",
+              timeout_error is not None
+              and timeout_error.code == "TIMEOUT"
+              and "mach-timeout" in timeout_message
+              and "0.025s" in timeout_message
+              and "state=started" in timeout_message,
+              timeout_message)
+
+        stopped = Machine.connect(
+            "mach-stopped", ConnectOptions(target="cloud", base_url=base, api_key="smk_testkey")
+        )
+        terminal_error = None
+        try:
+            stopped.wait_until_ready(timeout_s=0.1, interval_s=0.005)
+        except SmolError as e:
+            terminal_error = e
+        terminal_message = str(terminal_error)
+        check("terminal state fails readiness with a useful error",
+              terminal_error is not None
+              and "mach-stopped" in terminal_message
+              and "stopped before becoming ready" in terminal_message,
+              terminal_message)
 
         # --- connect bridge: authed endpoint URL + request to a published port ---
         ep = m.endpoint(80)

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -20,7 +20,15 @@ pub struct CloudMachine {
     // A single null name must not break parsing the whole list.
     #[serde(default)]
     pub name: Option<String>,
+    /// Lifecycle state. In particular, `started` means the VM process launched;
+    /// it does not imply that the guest agent or workload is ready.
     pub state: String,
+    /// True once the guest agent is reachable and any published port accepts
+    /// connections. This, rather than `state == "started"`, means ready for work.
+    #[serde(default)]
+    pub ready: Option<bool>,
+    #[serde(default)]
+    pub ready_at: Option<String>,
     pub source: Option<CloudMachineSource>,
     pub resources: Option<CloudMachineResources>,
     pub network: Option<CloudMachineNetwork>,
@@ -297,6 +305,8 @@ mod tests {
             "id": "mach-xxx",
             "name": "test",
             "state": "started",
+            "ready": false,
+            "readyAt": null,
             "source": {"type": "image", "reference": "alpine"},
             "resources": {"cpus": 1, "memoryMb": 256, "diskGb": null},
             "network": {"mode": "blocked"},
@@ -309,6 +319,8 @@ mod tests {
         assert_eq!(m.id, "mach-xxx");
         assert_eq!(m.name.as_deref(), Some("test"));
         assert_eq!(m.state, "started");
+        assert_eq!(m.ready, Some(false));
+        assert_eq!(m.ready_at, None);
 
         let source = m.source.unwrap();
         assert_eq!(source.source_type, "image");
@@ -333,6 +345,7 @@ mod tests {
         assert_eq!(m.id, "mach-1");
         assert_eq!(m.name.as_deref(), Some("bare"));
         assert_eq!(m.state, "stopped");
+        assert_eq!(m.ready, None);
         assert!(m.source.is_none());
         assert!(m.resources.is_none());
         assert!(m.network.is_none());

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -291,18 +291,28 @@ impl DeployCmd {
         }
 
         let started: cloud::CloudMachine = start_resp.json().await?;
-        eprintln!(
-            "Deployed: {} (id: {}, state: {})",
-            machine.name.as_deref().unwrap_or("-"),
-            machine.id,
-            started.state
-        );
-        // The app URL appears once the node reports the service port, typically
-        // a few seconds after start — poll for it briefly instead of telling the
-        // user to go look for it themselves.
+        if started.state == "started" {
+            eprintln!(
+                "VM launched: {} (id: {}, state: started)",
+                machine.name.as_deref().unwrap_or("-"),
+                machine.id,
+            );
+        } else {
+            eprintln!(
+                "Start accepted: {} (id: {}, state: {})",
+                machine.name.as_deref().unwrap_or("-"),
+                machine.id,
+                started.state
+            );
+        }
+        // `started` only confirms that the VM process launched. Poll the
+        // control plane's readiness signal; for this deployment's published
+        // port, ready also means the port is accepting connections.
+        let mut ready = started.ready == Some(true);
         let mut url = started.url.clone();
-        if url.is_none() {
-            eprintln!("Waiting for the app URL...");
+        let mut last_state = started.state.clone();
+        if !ready || url.is_none() {
+            eprintln!("Waiting until ready (guest agent and published port)...");
             for _ in 0..15 {
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                 let Ok(resp) = http
@@ -313,12 +323,28 @@ impl DeployCmd {
                     continue;
                 };
                 if let Ok(m) = resp.json::<cloud::CloudMachine>().await {
+                    last_state = m.state;
+                    ready = m.ready == Some(true);
                     if m.url.is_some() {
                         url = m.url;
+                    }
+                    if ready && url.is_some() {
+                        break;
+                    }
+                    if matches!(last_state.as_str(), "error" | "stopped" | "deleted") {
                         break;
                     }
                 }
             }
+        }
+        if ready {
+            eprintln!("Ready for work.");
+        } else {
+            eprintln!(
+                "VM launched, but readiness was not confirmed (state: {}). \
+                 Wait for ready=true before exec, connect, or expecting the app to respond.",
+                last_state
+            );
         }
         match url.as_deref() {
             Some(url) => {
@@ -339,8 +365,9 @@ impl DeployCmd {
             None => {
                 let who = machine.name.as_deref().unwrap_or(&machine.id);
                 eprintln!(
-                    "No URL yet (the port may still be starting) — check `smol machine ls`, or reach it now with \
-                     `smol machine exec --cloud --name {who}` / `smol machine shell --cloud --name {who}`."
+                    "No URL yet (the port may still be starting) — check `smol machine ls`. \
+                     After ready=true, use `smol machine exec --cloud --name {who}` / \
+                     `smol machine shell --cloud --name {who}`."
                 );
             }
         }

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -265,7 +265,27 @@ impl StartCmd {
             match resp.status().as_u16() {
                 200 => {
                     let machine: super::cloud::CloudMachine = resp.json().await?;
-                    eprintln!("Machine {}: {}", id, machine.state);
+                    match machine.ready {
+                        Some(true) => {
+                            eprintln!("Machine {}: ready for work", id);
+                        }
+                        Some(false) if machine.state == "started" => {
+                            eprintln!(
+                                "Machine {}: VM launched (state: started); not ready for work yet",
+                                id
+                            );
+                            eprintln!(
+                                "  The guest agent is still starting; wait for ready=true before exec or connect."
+                            );
+                        }
+                        _ if machine.state == "started" => {
+                            eprintln!(
+                                "Machine {}: VM launched (state: started); readiness not reported",
+                                id
+                            );
+                        }
+                        _ => eprintln!("Machine {}: {}", id, machine.state),
+                    }
                     if let Some(url) = machine.url.as_deref() {
                         println!("{url}");
                     }


### PR DESCRIPTION
## Summary
- document that cloud `started` means the VM launched while `ready` means the guest agent and any published port are usable
- add leak-safe Node and Python cloud examples and clarify that create waits while connect requires an explicit readiness wait
- strengthen mock cloud tests for `started`/not-ready polling, create gating, timeout, and terminal-state errors
- distinguish VM launch from readiness in cloud start and deploy progress output

## Test plan
- [x] `cd sdk/node && npm run build:ts && npm run test:cloud && npm run test:unit`
- [x] `cd sdk/python && python3 tests/test_cloud_mock.py && python3 tests/test_async_mock.py && python3 tests/test_unit.py`
- [x] `rustfmt --edition 2021 --check src/commands/start.rs src/commands/deploy.rs`
- [ ] `cargo test cloud_machine_deserializes --lib` (checkout lacks the required sibling `smolvm` path dependency)