### PR TITLE
Confirm the guest agent directly so create no longer hangs on a no-port machine whose ready flag never flips

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -66,6 +66,8 @@ jobs:
         run: python tests/test_unit.py
       - name: Cloud-transport tests (mock /v1 server; pure Python)
         run: python tests/test_cloud_mock.py
+      - name: Cloud no-port readiness probe (mock /v1 server; pure Python)
+        run: python tests/test_cloud_ready_no_ports.py
       - name: Async-transport tests (AsyncMachine vs mock /v1; pure Python)
         run: python tests/test_async_mock.py
 

--- a/sdk/node/test/cloud-ready-no-ports.ts
+++ b/sdk/node/test/cloud-ready-no-ports.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression: a cloud machine with NO published port never flips the `ready`
+ * flag on control planes that gate readiness on a port accepting a connection.
+ * create() must not hang the full timeout — it confirms the guest agent is
+ * reachable (a trivial exec) and returns.
+ *
+ *   npx tsx test/cloud-ready-no-ports.ts
+ */
+
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Machine } from '../index';
+
+let passed = 0;
+let failed = 0;
+const check = (label: string, ok: boolean, detail = '') => {
+  if (ok) { passed++; console.log(`  ✓ ${label}`); }
+  else { failed++; console.error(`  ✗ ${label}${detail ? ` — ${detail}` : ''}`); }
+};
+
+const seen = { execProbe: false };
+const server = createServer((req, res) => {
+  const url = req.url ?? '';
+  const method = req.method ?? 'GET';
+  const json = (code: number, obj: unknown) => {
+    res.writeHead(code, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(obj));
+  };
+  if (method === 'POST' && url === '/v1/machines') return json(201, { id: 'mX', name: 'np', state: 'stopped', ports: [] });
+  if (method === 'POST' && url === '/v1/machines/mX/start') return json(200, { state: 'starting' });
+  if (method === 'POST' && url === '/v1/machines/mX/exec') { seen.execProbe = true; return json(200, { exitCode: 0, stdout: '', stderr: '' }); }
+  // started, but `ready` STAYS false and there are no ports.
+  if (method === 'GET' && url === '/v1/machines/mX') return json(200, { id: 'mX', state: 'started', ready: false, ports: [] });
+  if (method === 'DELETE' && url === '/v1/machines/mX') { res.writeHead(204); return res.end(); }
+  res.writeHead(404); res.end('no route');
+});
+
+async function main(): Promise<void> {
+  console.log('smol SDK cloud no-port readiness test (mock /v1)\n');
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const port = (server.address() as AddressInfo).port;
+  const conn = { target: 'cloud' as const, baseUrl: `http://127.0.0.1:${port}`, apiKey: 'smk_t' };
+
+  // Bound it so a regression to the hang fails fast instead of blocking CI 120s.
+  const created = await Promise.race([
+    Machine.create({ image: 'alpine' }, conn).then((m) => ({ m }), (err) => ({ err })),
+    new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), 20_000)),
+  ]);
+
+  check('create() returned (did not hang on the never-flipping ready flag)', typeof created === 'object' && 'm' in created,
+    created === 'timeout' ? 'still hanging' : String((created as { err?: unknown }).err));
+  check('readiness was confirmed via the agent exec probe', seen.execProbe);
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  server.close();
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((e) => { console.error('crashed:', e); server.close(); process.exit(1); });

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -387,6 +387,10 @@ const DEFAULT_CLOUD_URL = "https://api.smolmachines.com";
 
 /** Default per-request timeout for cloud calls (ms). Override via opts.timeoutMs. */
 const CLOUD_TIMEOUT_MS = 30_000;
+// Grace before falling back to the guest-agent probe for a machine with no
+// published port: give `ready` time to flip first, so the probe stays a last
+// resort and never preempts a machine legitimately about to become ready.
+const NO_PORT_READY_PROBE_GRACE_MS = 2_000;
 
 /** Extra slack added on top of a command's own timeout when sizing the exec
  *  request timeout (ms), covering network round-trip and server-side overhead so
@@ -505,7 +509,8 @@ async function waitForReady(
   timeoutMs = 120_000,
   intervalMs = 1_000,
 ): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
+  const start = Date.now();
+  const deadline = start + timeoutMs;
   for (;;) {
     let m: MachineInfo | undefined;
     try {
@@ -541,11 +546,13 @@ async function waitForReady(
     // A machine with NO published port never flips `ready` on control planes
     // whose readiness gates on a port accepting a connection — it would hang the
     // full timeout on the most basic create (a compute sandbox you only exec
-    // into). Confirm the guest agent is reachable directly (a trivial exec) and
-    // treat that as ready.
+    // into). After a grace (so `ready` can flip first and this never preempts a
+    // machine legitimately about to become ready), confirm the guest agent is
+    // reachable directly (a trivial exec) and treat that as ready.
     if (
       (state === "started" || state === "running") &&
       !m?.ports?.length &&
+      Date.now() - start >= NO_PORT_READY_PROBE_GRACE_MS &&
       (await agentReachable(conn, id))
     )
       return;

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -52,6 +52,7 @@ type MachineInfo = Schemas["MachineInfo"] & {
   ready?: boolean;
   readyAt?: string | null;
   url?: string | null;
+  ports?: { port: number; hostPort?: number | null }[] | null;
 };
 
 /** Raw exec result (the ergonomic wrapper is added in machine.ts). */
@@ -471,6 +472,23 @@ async function cloudFetch<T = unknown>(
   return (ct.includes("application/json") ? await res.json() : undefined) as T;
 }
 
+/** Best-effort readiness probe: a trivial in-guest exec that only succeeds once
+ *  the agent is up. Used for machines with no published port, where `ready`
+ *  never flips on control planes that gate readiness on a port accepting a
+ *  connection. Any failure (agent not up yet, transient) → not ready; the
+ *  caller keeps polling until this passes or the deadline hits. */
+async function agentReachable(conn: CloudConn, id: string): Promise<boolean> {
+  try {
+    await cloudFetch(conn, "POST", `/v1/machines/${id}/exec`, {
+      json: { command: ["sh", "-c", "true"] },
+      timeoutMs: 15_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Poll a cloud machine until it is READY to do work; throw on error state or
  *  timeout. Mirrors the Python SDK's `_wait_for_ready`. Auth/not-found errors are
  *  fatal (re-thrown immediately); other errors are treated as transient booting.
@@ -519,6 +537,17 @@ async function waitForReady(
     }
     // Back-compat: `ready` absent entirely → old server, gate on state.
     if (m && m.ready === undefined && (state === "started" || state === "running"))
+      return;
+    // A machine with NO published port never flips `ready` on control planes
+    // whose readiness gates on a port accepting a connection — it would hang the
+    // full timeout on the most basic create (a compute sandbox you only exec
+    // into). Confirm the guest agent is reachable directly (a trivial exec) and
+    // treat that as ready.
+    if (
+      (state === "started" || state === "running") &&
+      !m?.ports?.length &&
+      (await agentReachable(conn, id))
+    )
       return;
     if (Date.now() >= deadline) {
       throw new SmolError(

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -37,6 +37,11 @@ from .types import (
 
 DEFAULT_CLOUD_URL = "https://api.smolmachines.com"
 CLOUD_TIMEOUT_S = 30.0
+# Grace before falling back to the guest-agent probe for a machine with no
+# published port: give the `ready` flag time to flip first, so the probe stays a
+# last resort and never preempts a machine that is legitimately about to become
+# ready (e.g. a published port that is still coming up).
+_NO_PORT_READY_PROBE_GRACE_S = 2.0
 # Extra slack added on top of a command's own timeout when sizing the exec HTTP
 # read timeout, covering network round-trip and server-side overhead so the
 # client never aborts before the server has had a chance to finish the command.
@@ -689,7 +694,8 @@ def _wait_for_ready(
     teardown race (works on a slow cold start, times out on a warm one). Older
     control planes omit ``ready``; there we fall back to the coarse
     ``started``/``running`` state so this never hangs against them."""
-    deadline = time.monotonic() + timeout_s
+    start = time.monotonic()
+    deadline = start + timeout_s
     while True:
         m: Optional[dict] = None
         try:
@@ -717,9 +723,13 @@ def _wait_for_ready(
         # the full timeout on the most basic create (a compute sandbox you only
         # exec into). Confirm the guest agent is reachable directly (a trivial
         # exec) and treat that as ready.
-        if state in ("started", "running") and not m.get("ports"):
-            if _agent_reachable(base_url, api_key, machine_id):
-                return
+        if (
+            state in ("started", "running")
+            and not m.get("ports")
+            and time.monotonic() - start >= _NO_PORT_READY_PROBE_GRACE_S
+            and _agent_reachable(base_url, api_key, machine_id)
+        ):
+            return
         if time.monotonic() >= deadline:
             raise SmolError("TIMEOUT", f"machine {machine_id} not ready after {timeout_s}s (state={state})")
         time.sleep(interval_s)

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -653,6 +653,26 @@ def _cli_config_api_key() -> Optional[str]:
     return None
 
 
+def _agent_reachable(base_url: str, api_key: str, machine_id: str) -> bool:
+    """Best-effort readiness probe: a trivial in-guest exec that only succeeds
+    once the agent is up. Used for machines with no published port, where the
+    ``ready`` flag never flips on control planes that gate readiness on a port
+    accepting a connection. Any failure (agent not up yet, transient) → not
+    ready; the caller keeps polling until this passes or the deadline hits."""
+    try:
+        _cloud_fetch(
+            base_url,
+            api_key,
+            "POST",
+            f"/v1/machines/{machine_id}/exec",
+            json_body={"command": ["sh", "-c", "true"]},
+            timeout=15.0,
+        )
+        return True
+    except SmolError:
+        return False
+
+
 def _wait_for_ready(
     base_url: str,
     api_key: str,
@@ -692,6 +712,14 @@ def _wait_for_ready(
         # Back-compat: `ready` absent entirely → old server, gate on state.
         if "ready" not in m and state in ("started", "running"):
             return
+        # A machine with NO published port never flips `ready` on control planes
+        # whose readiness gates on a port accepting a connection — it would hang
+        # the full timeout on the most basic create (a compute sandbox you only
+        # exec into). Confirm the guest agent is reachable directly (a trivial
+        # exec) and treat that as ready.
+        if state in ("started", "running") and not m.get("ports"):
+            if _agent_reachable(base_url, api_key, machine_id):
+                return
         if time.monotonic() >= deadline:
             raise SmolError("TIMEOUT", f"machine {machine_id} not ready after {timeout_s}s (state={state})")
         time.sleep(interval_s)

--- a/sdk/python/tests/test_cloud_ready_no_ports.py
+++ b/sdk/python/tests/test_cloud_ready_no_ports.py
@@ -1,0 +1,103 @@
+"""Regression: a cloud machine with NO published port never flips the `ready`
+flag on control planes that gate readiness on a port accepting a connection.
+`create()` must not hang the full timeout — it confirms the guest agent is
+reachable (a trivial exec) and returns. This is the SDK's most basic call
+(a compute sandbox you only exec into)."""
+
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+from smol import ConnectOptions, Machine, MachineConfig  # noqa: E402
+
+MID = "mach-noport"
+seen = {"exec_probe": False}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):  # silence
+        pass
+
+    def _send(self, code: int, body: bytes = b""):
+        self.send_response(code)
+        if body:
+            self.send_header("content-type", "application/json")
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def do_POST(self):
+        if self.path == "/v1/machines":
+            n = int(self.headers.get("content-length", 0))
+            self.rfile.read(n)
+            # No ports on the record.
+            return self._send(201, json.dumps({"id": MID, "name": "np", "state": "stopped", "ports": []}).encode())
+        if self.path == f"/v1/machines/{MID}/start":
+            return self._send(200, json.dumps({"id": MID, "state": "starting"}).encode())
+        if self.path == f"/v1/machines/{MID}/exec":
+            # The readiness probe: agent reachable → 200.
+            seen["exec_probe"] = True
+            n = int(self.headers.get("content-length", 0))
+            self.rfile.read(n)
+            return self._send(200, json.dumps({"exitCode": 0, "stdout": "", "stderr": ""}).encode())
+        return self._send(404)
+
+    def do_GET(self):
+        if self.path == f"/v1/machines/{MID}":
+            # started, but `ready` STAYS false and there are no ports.
+            return self._send(200, json.dumps({"id": MID, "state": "started", "ready": False, "ports": []}).encode())
+        return self._send(404)
+
+    def do_DELETE(self):
+        return self._send(204)
+
+
+def main() -> int:
+    srv = HTTPServer(("127.0.0.1", 0), Handler)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+
+    passed = failed = 0
+
+    def check(name, cond, detail=""):
+        nonlocal passed, failed
+        if cond:
+            passed += 1
+            print(f"  ok {name}")
+        else:
+            failed += 1
+            print(f"  FAIL {name} {detail}")
+
+    result = {}
+
+    def do_create():
+        try:
+            result["m"] = Machine.create(
+                MachineConfig(image="alpine"),
+                ConnectOptions(target="cloud", base_url=base, api_key="smk_t"),
+            )
+        except Exception as e:  # noqa: BLE001
+            result["err"] = e
+
+    # Bound it so a regression to the hang fails fast instead of blocking CI 120s.
+    t = threading.Thread(target=do_create, daemon=True)
+    t.start()
+    t.join(timeout=20)
+
+    check("create() returned (did not hang on the never-flipping ready flag)", not t.is_alive() and "m" in result,
+          "still running" if t.is_alive() else str(result.get("err")))
+    check("readiness was confirmed via the agent exec probe", seen["exec_probe"])
+
+    srv.shutdown()
+    print(f"\n{passed} passed, {failed} failed")
+    print("RESULT=PASS" if failed == 0 else "RESULT=FAIL")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A cloud machine with no published port never flips its readiness flag on control planes that gate readiness on a port accepting a connection, so create() (and fork()) would block the full 120s timeout and then delete the machine on the most basic call; the readiness wait now confirms the guest agent is reachable via a trivial exec for such machines and returns as soon as it responds.