### PR TITLE
Add a cloud deploy --command flag to override an image's entrypoint on start

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,6 +1,7 @@
 //! smol deploy — deploy a .smolmachine artifact to smolfleet.
 
 use super::cloud;
+use crate::commands::pack::split_command;
 use clap::Args;
 use std::path::PathBuf;
 
@@ -77,6 +78,12 @@ pub struct DeployCmd {
     /// host at deploy time (repeatable)
     #[arg(long = "secret-file", value_name = "GUEST_VAR=/abs/path")]
     pub secret_file: Vec<String>,
+
+    /// Command to run on start, overriding the source image's own entrypoint/cmd
+    /// so an off-the-shelf image can be told what to serve (e.g.
+    /// `--command "python3 -m http.server 8080"`). Shell-split into argv.
+    #[arg(long, value_name = "CMD")]
+    pub command: Option<String>,
 }
 
 /// Sync-resolved inputs for the push step. Resolved outside the runtime so
@@ -224,7 +231,7 @@ impl DeployCmd {
         )?);
         let env: std::collections::BTreeMap<String, String> = env_pairs.into_iter().collect();
 
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "name": name,
             "source": source,
             "resources": {
@@ -240,6 +247,11 @@ impl DeployCmd {
             "ports": [{ "port": self.port }],
             "public": self.public,
         });
+        // Optional command override, shell-split into argv. Omitted when unset so
+        // the machine runs the source image's/artifact's own entrypoint (default).
+        if let Some(cmd) = &self.command {
+            body["command"] = serde_json::json!(split_command(cmd));
+        }
 
         eprintln!("Deploying {} to {}...", reference, endpoint);
 

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -579,7 +579,7 @@ struct PackConfig {
 /// argv vector (`["python3", "-m", "http.server", "8080"]`) instead of a single
 /// token the guest would try to exec as one binary name (which fails ENOENT and
 /// leaves the workload dead). A single-word value returns unchanged.
-fn split_command(s: &str) -> Vec<String> {
+pub(crate) fn split_command(s: &str) -> Vec<String> {
     let mut args = Vec::new();
     let mut cur = String::new();
     let mut has_token = false;


### PR DESCRIPTION
`smol cloud deploy` had no way to tell a raw image what to run, so deploying an off-the-shelf image whose default CMD isn't a server started nothing on the published port; this adds `--command "…"` (shell-split into argv, reusing pack's splitter) sent as the machine's command override.