### PR TITLE
Add reward_fork to the Python and Node SDKs

### DIFF
--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -8,6 +8,7 @@
  *  a given backend lacks throw `NotSupportedError`.
  */
 
+import { randomUUID } from "node:crypto";
 import { ExecutionError } from "./errors";
 import {
   makeTransport,
@@ -225,5 +226,32 @@ export class Machine {
    *  @returns a `Machine` handle to the running clone. */
   async fork(name: string, ports?: PortSpec[]): Promise<Machine> {
     return new Machine(await this.transport.fork(name, ports));
+  }
+
+  /** Score this machine's state WITHOUT mutating it: fork an ephemeral clone,
+   *  run the grader command in the clone, then destroy it. The result (exit code
+   *  / stdout) is your reward signal; this machine is untouched. This is the RL
+   *  "reward judging without side effects" primitive — grade the end of a rollout,
+   *  or run a verifier — as one call, with the throwaway clone always cleaned up
+   *  even if the grader errors. Requires this machine to be `forkable` (like
+   *  `fork()`); a clone name is generated unless you pass one.
+   *
+   *  @param command  the grader/verifier argv to run in the clone
+   *  @param opts      exec options (env, cwd, timeout, …)
+   *  @param name      optional clone name (default: a generated unique name)
+   *  @returns the grader's `ExecResult` (use `.success` for pass/fail, `.stdout` for a score) */
+  async rewardFork(
+    command: string[],
+    opts?: ExecOptions,
+    name?: string,
+  ): Promise<ExecResult> {
+    const cloneName = name ?? `${this.name}-rf-${randomUUID().slice(0, 8)}`;
+    const clone = await this.fork(cloneName);
+    try {
+      return await clone.exec(command, opts);
+    } finally {
+      // Best-effort teardown — never mask the grader's result/error.
+      await clone.delete().catch(() => {});
+    }
   }
 }

--- a/sdk/node/test/cloud-mock.ts
+++ b/sdk/node/test/cloud-mock.ts
@@ -97,6 +97,24 @@ const server = createServer(async (req, res) => {
   }
   if (method === "GET" && url === "/v1/machines/m2")
     return json(200, { id: "m2", state: "running" });
+  // Clone (fork) exec + delete — reward_fork forks m1 -> m2, grades in m2,
+  // then deletes m2. Distinct stdout proves the GRADER ran in the clone, and
+  // the DELETE proves the throwaway clone is always cleaned up.
+  if (method === "POST" && url === "/v1/machines/m2/exec") {
+    seen.rewardExecBody = JSON.parse((await readBody(req)).toString() || "{}");
+    return json(200, {
+      exitCode: 0,
+      stdout: "reward-clone-exec-ok\n",
+      stderr: "",
+      stdoutTruncated: false,
+      stderrTruncated: false,
+    });
+  }
+  if (method === "DELETE" && url === "/v1/machines/m2") {
+    seen.cloneDeleted = true;
+    res.writeHead(204);
+    return res.end();
+  }
   if (method === "POST" && url === "/v1/machines/m1/exec") {
     seen.execBody = JSON.parse((await readBody(req)).toString() || "{}");
     return json(200, {
@@ -358,6 +376,25 @@ async function main(): Promise<void> {
     "fork returns running clone handle",
     clone.name === "rollout-1" && (await clone.state()) === "running",
     clone.name,
+  );
+
+  // --- reward_fork: grade in a throwaway clone without touching the original ---
+  seen.cloneDeleted = false;
+  const reward = await m.rewardFork(["python", "grade.py"]);
+  check(
+    "reward_fork grades in the CLONE (not the parent)",
+    reward.stdout.trim() === "reward-clone-exec-ok",
+    reward.stdout,
+  );
+  check(
+    "reward_fork sent the grader command to the clone",
+    JSON.stringify(seen.rewardExecBody?.command) ===
+      JSON.stringify(["python", "grade.py"]),
+    JSON.stringify(seen.rewardExecBody),
+  );
+  check(
+    "reward_fork destroys the throwaway clone (cleanup)",
+    seen.cloneDeleted === true,
   );
 
   // Errors surface the server's x-request-id so support can correlate the call

--- a/sdk/python/python/smol/async_machine.py
+++ b/sdk/python/python/smol/async_machine.py
@@ -180,6 +180,19 @@ class AsyncMachine:
         clone = await asyncio.to_thread(self._m.fork, name, ports)
         return AsyncMachine(clone)
 
+    async def reward_fork(
+        self,
+        command: list[str],
+        opts: Optional[ExecOptions] = None,
+        name: Optional[str] = None,
+    ) -> ExecResult:
+        """Score this machine's state WITHOUT mutating it: fork an ephemeral clone,
+        run the grader ``command`` in it, then destroy it. The returned
+        :class:`ExecResult` is your reward signal. RL "reward judging without side
+        effects" as one call; the clone is always cleaned up. Requires this machine
+        to be ``forkable``. See :meth:`Machine.reward_fork`."""
+        return await asyncio.to_thread(self._m.reward_fork, command, opts, name)
+
     # -- async context manager: auto-delete on exit --
     async def __aenter__(self) -> "AsyncMachine":
         return self

--- a/sdk/python/python/smol/machine.py
+++ b/sdk/python/python/smol/machine.py
@@ -12,6 +12,7 @@ Mirrors the Node SDK's ``machine.ts`` (sync, since the embedded engine blocks)::
 
 from __future__ import annotations
 
+import uuid
 from typing import Optional
 
 from .transport import Transport, connect_transport, make_transport
@@ -197,6 +198,38 @@ class Machine:
         :returns: a :class:`Machine` handle to the running clone.
         """
         return Machine(self._t.fork(name, ports))
+
+    def reward_fork(
+        self,
+        command: list[str],
+        opts: Optional[ExecOptions] = None,
+        name: Optional[str] = None,
+    ) -> ExecResult:
+        """Score this machine's state WITHOUT mutating it.
+
+        Forks an ephemeral clone, runs the grader ``command`` in the clone, then
+        destroys it — so grading never touches this machine. The returned
+        :class:`ExecResult` is your reward signal (``.exit_code == 0`` for
+        pass/fail, ``.stdout`` for a parsed score). This is the RL "reward judging
+        without
+        side effects" primitive (grade the end of a rollout, or run a verifier)
+        as one call; the throwaway clone is always cleaned up, even if the grader
+        raises. Requires this machine to be ``forkable`` (like :meth:`fork`).
+
+        :param command: the grader/verifier argv to run in the clone.
+        :param opts: exec options (env, cwd, timeout, …).
+        :param name: optional clone name (default: a generated unique name).
+        :returns: the grader's :class:`ExecResult`.
+        """
+        clone = self.fork(name or f"{self.name}-rf-{uuid.uuid4().hex[:8]}")
+        try:
+            return clone.exec(command, opts)
+        finally:
+            # Best-effort teardown — never mask the grader's result/error.
+            try:
+                clone.delete()
+            except Exception:
+                pass
 
     # -- context manager: auto-delete on exit (ergonomic for ephemeral use) --
     def __enter__(self) -> "Machine":

--- a/sdk/python/tests/test_cloud_mock.py
+++ b/sdk/python/tests/test_cloud_mock.py
@@ -91,6 +91,16 @@ class Handler(BaseHTTPRequestHandler):
                 # can't hold — proves the SDK decodes b64, not the text.
                 "stdoutB64": base64.b64encode(bytes([0x68, 0x69, 0xFF])).decode(),
             }).encode())
+        # Clone exec — reward_fork forks MACHINE_ID -> CLONE_ID, grades in the
+        # clone, then deletes it. Distinct stdout proves the grader ran in the
+        # CLONE, not the parent.
+        if self.path == f"/v1/machines/{CLONE_ID}/exec":
+            captured["reward_exec_body"] = json.loads(self._read() or b"{}")
+            return self._send(200, json.dumps({
+                "stdout": "reward-clone-exec-ok\n", "stderr": "", "exitCode": 0,
+                "durationMs": 5, "machineId": CLONE_ID,
+                "stdoutTruncated": False, "stderrTruncated": False,
+            }).encode())
         if self.path == f"/v1/machines/{MACHINE_ID}/stop":
             return self._send(200, json.dumps({"id": MACHINE_ID, "state": "stopped"}).encode())
         return self._send(404, b"no route")
@@ -135,6 +145,9 @@ class Handler(BaseHTTPRequestHandler):
         if not self._auth_ok():
             return self._send(401, b"bad token")
         if self.path == f"/v1/machines/{MACHINE_ID}":
+            return self._send(204)
+        if self.path == f"/v1/machines/{CLONE_ID}":
+            captured["clone_deleted"] = True
             return self._send(204)
         return self._send(404, b"no route")
 
@@ -258,6 +271,17 @@ def main() -> int:
               str(captured["fork_body"].get("ports")))
         check("fork returns running clone handle", clone.name == "rollout-1" and clone.state() == "started",
               f"{clone.name}/{clone.state()}")
+
+        # reward_fork: grade in a throwaway clone without touching the original.
+        captured["clone_deleted"] = False
+        reward = m.reward_fork(["python", "grade.py"])
+        check("reward_fork grades in the CLONE (not the parent)",
+              reward.stdout.strip() == "reward-clone-exec-ok", reward.stdout)
+        check("reward_fork sent the grader command to the clone",
+              captured.get("reward_exec_body", {}).get("command") == ["python", "grade.py"],
+              str(captured.get("reward_exec_body")))
+        check("reward_fork destroys the throwaway clone (cleanup)",
+              captured.get("clone_deleted") is True)
 
         r = m.exec(["echo", "hello"], )
         check("exec hit POST /exec", f"POST /v1/machines/{MACHINE_ID}/exec" in captured["hits"])


### PR DESCRIPTION
Adds reward_fork to the sync and async Python Machine and the Node Machine: it forks an ephemeral clone, runs the grader command in the clone, and always destroys it, returning the grader's result as the reward signal so scoring a rollout never mutates the machine.