### PR TITLE
Add a batch fork verb to the Python and Node SDKs to clone a forkable machine into many rollouts in one call

### DIFF
--- a/sdk/node/index.ts
+++ b/sdk/node/index.ts
@@ -25,6 +25,7 @@ export type {
   ResourceSpec,
   MountSpec,
   PortSpec,
+  ForkBatchOptions,
   ExecOptions,
   ExecResult,
   ImageInfo,

--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -21,6 +21,7 @@ import type {
   ExecEvent,
   ExecOptions,
   ExecResult,
+  ForkBatchOptions,
   ImageInfo,
   MachineConfig,
   PortEndpoint,
@@ -226,6 +227,26 @@ export class Machine {
    *  @returns a `Machine` handle to the running clone. */
   async fork(name: string, ports?: PortSpec[]): Promise<Machine> {
     return new Machine(await this.transport.fork(name, ports));
+  }
+
+  /** Fork this forkable machine into MANY clones in one call — the RL fan-out
+   *  primitive (GRPO group sampling / eval-task fan-out). Each clone is a live-RAM
+   *  CoW fork off this golden, like `fork()`. On the cloud target the batch is
+   *  transactional (all-or-nothing: if any clone fails, the whole batch is rolled
+   *  back), so you get all N branches or none. Provide either `count` (clones
+   *  auto-named `{namePrefix}-{n}`) or explicit `names`. Requires this machine to
+   *  be `forkable`.
+   *
+   *  @param opts  batch size (`count` or `names`), optional `namePrefix`/`ports`
+   *  @returns the clones, in request order
+   *
+   *  ```ts
+   *  const clones = await golden.forkBatch({ count: 32, namePrefix: "rollout" });
+   *  await Promise.all(clones.map((c) => c.exec(["python", "rollout.py"])));
+   *  ``` */
+  async forkBatch(opts: ForkBatchOptions): Promise<Machine[]> {
+    const clones = await this.transport.forkBatch(opts);
+    return clones.map((t) => new Machine(t));
   }
 
   /** Score this machine's state WITHOUT mutating it: fork an ephemeral clone,

--- a/sdk/node/test/cloud-mock.ts
+++ b/sdk/node/test/cloud-mock.ts
@@ -81,6 +81,27 @@ const server = createServer(async (req, res) => {
       ports: seen.forkBody.ports ?? [],
     });
   }
+  if (method === "POST" && url === "/v1/machines/m1/fork-batch") {
+    seen.forkBatchBody = JSON.parse((await readBody(req)).toString() || "{}");
+    const n = seen.forkBatchBody.count ?? seen.forkBatchBody.names?.length ?? 0;
+    const prefix = seen.forkBatchBody.namePrefix ?? "golden";
+    const clones = Array.from({ length: n }, (_, i) => ({
+      id: `b${i + 1}`,
+      name: seen.forkBatchBody.names?.[i] ?? `${prefix}-${i + 1}`,
+      state: "started",
+      source: { type: "image", reference: "alpine" },
+      resources: { cpus: 2, memoryMb: 1024 },
+      network: { mode: "open" },
+      env: {},
+      ephemeral: false,
+      ports: seen.forkBatchBody.ports ?? [],
+    }));
+    return json(201, { clones });
+  }
+  // Readiness for batch-fork clones (b1, b2, …).
+  if (method === "GET" && /^\/v1\/machines\/b\d+$/.test(url)) {
+    return json(200, { id: url.split("/").pop(), state: "running" });
+  }
   if (method === "GET" && url === "/v1/machines/m1")
     return json(200, readinessResponse("m1", 2));
   if (method === "GET" && url === "/v1/machines/m-wait")
@@ -376,6 +397,22 @@ async function main(): Promise<void> {
     "fork returns running clone handle",
     clone.name === "rollout-1" && (await clone.state()) === "running",
     clone.name,
+  );
+
+  // --- fork-batch: fan out N RL rollouts in one transactional call ---
+  const batch = await m.forkBatch({ count: 3, namePrefix: "rollout" });
+  check(
+    "forkBatch hit POST /fork-batch with the size spec",
+    seen.forkBatchBody?.count === 3 &&
+      seen.forkBatchBody?.namePrefix === "rollout",
+    JSON.stringify(seen.forkBatchBody),
+  );
+  check(
+    "forkBatch returns N clone handles in request order",
+    batch.length === 3 &&
+      batch[0].name === "rollout-1" &&
+      batch[2].name === "rollout-3",
+    batch.map((c) => c.name).join(","),
   );
 
   // --- reward_fork: grade in a throwaway clone without touching the original ---

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -26,6 +26,7 @@ import type {
   ConnectOptions,
   ExecEvent,
   ExecOptions,
+  ForkBatchOptions,
   ImageInfo,
   MachineConfig,
   PortEndpoint,
@@ -104,6 +105,23 @@ export interface Transport {
   stop(): Promise<void>;
   delete(): Promise<void>;
   fork(name: string, ports?: PortSpec[]): Promise<Transport>;
+  forkBatch(opts: ForkBatchOptions): Promise<Transport[]>;
+}
+
+/** Resolve a batch fork's clone names + size, mirroring the control plane:
+ *  explicit `names` win, otherwise `count` clones are named `{prefix}-{n}`.
+ *  Used by the local target (the cloud target lets the server resolve). */
+function resolveBatchNames(
+  opts: ForkBatchOptions,
+  defaultPrefix: string,
+): string[] {
+  if (opts.names && opts.names.length > 0) return opts.names;
+  const count = opts.count ?? 0;
+  if (count < 1) {
+    throw new Error("forkBatch requires `count` >= 1 or a non-empty `names`");
+  }
+  const prefix = opts.namePrefix ?? defaultPrefix;
+  return Array.from({ length: count }, (_, i) => `${prefix}-${i + 1}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -371,6 +389,24 @@ class LocalTransport implements Transport {
     } catch (e) {
       throw wrapNativeError(e);
     }
+  }
+
+  async forkBatch(opts: ForkBatchOptions): Promise<Transport[]> {
+    // No control plane locally, so fan out sequential single forks off the same
+    // golden (each is CoW O(metadata) after the first freeze) and clean up what
+    // succeeded if any fork fails — best-effort local mirror of the cloud
+    // target's all-or-nothing transaction.
+    const names = resolveBatchNames(opts, "fork");
+    const forks: Transport[] = [];
+    try {
+      for (const name of names) {
+        forks.push(await this.fork(name, opts.ports));
+      }
+    } catch (e) {
+      await Promise.all(forks.map((f) => f.delete().catch(() => {})));
+      throw e;
+    }
+    return forks;
   }
 }
 
@@ -862,6 +898,30 @@ class CloudTransport implements Transport {
     const cloneName = clone.name ?? name;
     await waitForReady(this.conn, cloneId);
     return new CloudTransport(this.conn, cloneName, cloneId);
+  }
+
+  async forkBatch(opts: ForkBatchOptions): Promise<Transport[]> {
+    // One transactional call: the control plane forks all clones (or none) off
+    // the golden. Send the size spec raw so the server resolves names uniformly.
+    const portBody = (opts.ports ?? []).map((p) => ({
+      port: p.guest,
+      hostPort: p.host,
+    }));
+    const body: Record<string, unknown> = { ports: portBody };
+    if (opts.names && opts.names.length > 0) body.names = opts.names;
+    if (opts.count !== undefined) body.count = opts.count;
+    if (opts.namePrefix !== undefined) body.namePrefix = opts.namePrefix;
+    const resp = await cloudFetch<{ clones: MachineInfo[] }>(
+      this.conn,
+      "POST",
+      `/v1/machines/${this.id}/fork-batch`,
+      { json: body },
+    );
+    const clones = resp.clones ?? [];
+    // Clones come back already forked/started; wait for each in parallel so every
+    // returned handle is usable.
+    await Promise.all(clones.map((c) => waitForReady(this.conn, c.id)));
+    return clones.map((c) => new CloudTransport(this.conn, c.name ?? c.id, c.id));
   }
 }
 

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -60,6 +60,22 @@ export interface PortSpec {
   guest: number;
 }
 
+/** Options for forking a forkable golden into many clones at once — the RL
+ *  fan-out primitive (GRPO group sampling / eval-task fan-out). Provide either
+ *  `count` (clones auto-named `{namePrefix}-{n}`) or explicit `names`. */
+export interface ForkBatchOptions {
+  /** Number of clones to fork (1..=64). Ignored when `names` is set. */
+  count?: number;
+  /** Explicit clone names; its length is the batch size when set. */
+  names?: string[];
+  /** Prefix for auto-named clones when `count` is used (default: the golden's
+   *  name on the cloud target, else `"fork"`). */
+  namePrefix?: string;
+  /** Inbound port forwards applied to every clone. Empty = each clone gets fresh
+   *  host ports so clones don't collide. */
+  ports?: PortSpec[];
+}
+
 /** Configuration for creating a machine. */
 export interface MachineConfig {
   /** Machine name (auto-generated if omitted). */

--- a/sdk/python/python/smol/async_machine.py
+++ b/sdk/python/python/smol/async_machine.py
@@ -180,6 +180,26 @@ class AsyncMachine:
         clone = await asyncio.to_thread(self._m.fork, name, ports)
         return AsyncMachine(clone)
 
+    async def fork_batch(
+        self,
+        count: Optional[int] = None,
+        *,
+        names: Optional[list[str]] = None,
+        name_prefix: Optional[str] = None,
+        ports: Optional[list[PortSpec]] = None,
+    ) -> "list[AsyncMachine]":
+        """Fork this forkable machine into MANY clones in one call — the RL fan-out
+        primitive (GRPO group sampling / eval-task fan-out). Transactional on the
+        cloud target (all-or-nothing). See :meth:`Machine.fork_batch`."""
+        clones = await asyncio.to_thread(
+            self._m.fork_batch,
+            count,
+            names=names,
+            name_prefix=name_prefix,
+            ports=ports,
+        )
+        return [AsyncMachine(c) for c in clones]
+
     async def reward_fork(
         self,
         command: list[str],

--- a/sdk/python/python/smol/machine.py
+++ b/sdk/python/python/smol/machine.py
@@ -199,6 +199,38 @@ class Machine:
         """
         return Machine(self._t.fork(name, ports))
 
+    def fork_batch(
+        self,
+        count: Optional[int] = None,
+        *,
+        names: Optional[list[str]] = None,
+        name_prefix: Optional[str] = None,
+        ports: Optional[list[PortSpec]] = None,
+    ) -> "list[Machine]":
+        """Fork this forkable machine into MANY clones in one call — the RL
+        fan-out primitive (GRPO group sampling / eval-task fan-out). Each clone is
+        a live-RAM CoW fork off this golden, like :meth:`fork`. On the cloud target
+        the batch is transactional (all-or-nothing: if any clone fails, the whole
+        batch is rolled back), so you get all N branches or none. Requires this
+        machine to be ``forkable``.
+
+        Provide either ``count`` (clones auto-named ``{name_prefix}-{n}``) or
+        explicit ``names``.
+
+        :param count: number of clones to fork (ignored when ``names`` is given).
+        :param names: explicit clone names; its length is the batch size.
+        :param name_prefix: prefix for auto-named clones (default: the golden's
+            name on the cloud target, else ``"fork"``).
+        :param ports: optional pinned inbound port forwards applied to every clone.
+        :returns: the clones, in request order.
+        """
+        return [
+            Machine(t)
+            for t in self._t.fork_batch(
+                count, names=names, name_prefix=name_prefix, ports=ports
+            )
+        ]
+
     def reward_fork(
         self,
         command: list[str],

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -89,6 +89,15 @@ class Transport(Protocol):
     def delete(self) -> None: ...
     def fork(self, name: str, ports: Optional[list[PortSpec]] = None) -> "Transport": ...
 
+    def fork_batch(
+        self,
+        count: Optional[int] = None,
+        *,
+        names: Optional[list[str]] = None,
+        name_prefix: Optional[str] = None,
+        ports: Optional[list[PortSpec]] = None,
+    ) -> "list[Transport]": ...
+
 
 def _encode_path(p: str) -> str:
     """Percent-encode each segment but keep ``/`` (smolfleet files route is a
@@ -326,6 +335,32 @@ class LocalTransport:
             raise wrap_native_error(e) from e
         # LocalTransport.__init__ registers the clone for atexit cleanup.
         return LocalTransport(clone_inner)
+
+    def fork_batch(
+        self,
+        count: Optional[int] = None,
+        *,
+        names: Optional[list[str]] = None,
+        name_prefix: Optional[str] = None,
+        ports: Optional[list[PortSpec]] = None,
+    ) -> "list[Transport]":
+        # No control plane locally: fan out sequential single forks off the same
+        # golden (each CoW O(metadata) after the first freeze), cleaning up what
+        # succeeded on failure — best-effort local mirror of the cloud target's
+        # all-or-nothing transaction.
+        resolved = _resolve_batch_names(count, names, name_prefix, "fork")
+        forks: list[Transport] = []
+        try:
+            for n in resolved:
+                forks.append(self.fork(n, ports))
+        except Exception:
+            for f in forks:
+                try:
+                    f.delete()
+                except Exception:
+                    pass
+            raise
+        return forks
 
 
 # ---------------------------------------------------------------------------
@@ -566,6 +601,63 @@ class CloudTransport:
         clone_name = clone.get("name") or name
         _wait_for_ready(self._base, self._key, clone_id)
         return CloudTransport(self._base, self._key, clone_id, clone_name)
+
+    def fork_batch(
+        self,
+        count: Optional[int] = None,
+        *,
+        names: Optional[list[str]] = None,
+        name_prefix: Optional[str] = None,
+        ports: Optional[list[PortSpec]] = None,
+    ) -> "list[CloudTransport]":
+        # One transactional call: the control plane forks all clones (or none)
+        # off the golden. Send the size spec raw so the server resolves names
+        # uniformly with the single-fork path.
+        port_body = [{"port": p.guest, "hostPort": p.host} for p in (ports or [])]
+        body: dict[str, Any] = {"ports": port_body}
+        if names:
+            body["names"] = names
+        if count is not None:
+            body["count"] = count
+        if name_prefix is not None:
+            body["namePrefix"] = name_prefix
+        resp = (
+            _cloud_fetch(
+                self._base,
+                self._key,
+                "POST",
+                f"/v1/machines/{self._id}/fork-batch",
+                json_body=body,
+            )
+            or {}
+        )
+        clones = resp.get("clones") or []
+        transports = [
+            CloudTransport(self._base, self._key, c["id"], c.get("name") or c["id"])
+            for c in clones
+        ]
+        # Clones come back already forked/started; wait for each so every returned
+        # handle is usable.
+        for t in transports:
+            _wait_for_ready(self._base, self._key, t._id)
+        return transports
+
+
+def _resolve_batch_names(
+    count: Optional[int],
+    names: Optional[list[str]],
+    name_prefix: Optional[str],
+    default_prefix: str,
+) -> list[str]:
+    """Resolve a batch fork's clone names + size, mirroring the control plane:
+    explicit ``names`` win, otherwise ``count`` clones are named ``{prefix}-{n}``.
+    Used by the local target (the cloud target lets the server resolve)."""
+    if names:
+        return names
+    if not count or count < 1:
+        raise ValueError("fork_batch requires `count` >= 1 or a non-empty `names`")
+    prefix = name_prefix or default_prefix
+    return [f"{prefix}-{i}" for i in range(1, count + 1)]
 
 
 def _cloud_fetch(

--- a/sdk/python/tests/test_cloud_mock.py
+++ b/sdk/python/tests/test_cloud_mock.py
@@ -81,6 +81,23 @@ class Handler(BaseHTTPRequestHandler):
                 "env": {}, "ephemeral": False, "ports": captured["fork_body"].get("ports") or [],
                 "createdAt": "2026-05-30T00:00:00Z", "updatedAt": "2026-05-30T00:00:00Z",
             }).encode())
+        if self.path == f"/v1/machines/{MACHINE_ID}/fork-batch":
+            captured["fork_batch_body"] = json.loads(self._read() or b"{}")
+            body = captured["fork_batch_body"]
+            names = body.get("names")
+            n = body.get("count") or len(names or [])
+            prefix = body.get("namePrefix") or "golden"
+            clones = []
+            for i in range(n):
+                clones.append({
+                    "id": f"mach-b{i + 1}",
+                    "name": names[i] if names else f"{prefix}-{i + 1}",
+                    "source": {"type": "image", "reference": "alpine:3.20"}, "state": "started",
+                    "resources": {"cpus": 2, "memoryMb": 1024}, "network": {"mode": "open"},
+                    "env": {}, "ephemeral": False, "ports": body.get("ports") or [],
+                    "createdAt": "2026-05-30T00:00:00Z", "updatedAt": "2026-05-30T00:00:00Z",
+                })
+            return self._send(201, json.dumps({"clones": clones}).encode())
         if self.path == f"/v1/machines/{MACHINE_ID}/exec":
             captured["exec_body"] = json.loads(self._read() or b"{}")
             return self._send(200, json.dumps({
@@ -122,6 +139,10 @@ class Handler(BaseHTTPRequestHandler):
             )
         if self.path == f"/v1/machines/{CLONE_ID}":
             return self._send(200, json.dumps({"id": CLONE_ID, "state": "started", "ready": True}).encode())
+        # Readiness for batch-fork clones (mach-b1, mach-b2, …).
+        if self.path.startswith("/v1/machines/mach-b"):
+            mid = self.path.rsplit("/", 1)[-1]
+            return self._send(200, json.dumps({"id": mid, "state": "started", "ready": True}).encode())
         # The connect bridge: GET /v1/machines/:id/connect/:port[/rest]. Echo the
         # path + auth so the SDK's endpoint()/request() wiring can be asserted.
         if self.path.startswith(f"/v1/machines/{MACHINE_ID}/connect/"):
@@ -271,6 +292,18 @@ def main() -> int:
               str(captured["fork_body"].get("ports")))
         check("fork returns running clone handle", clone.name == "rollout-1" and clone.state() == "started",
               f"{clone.name}/{clone.state()}")
+
+        # --- fork_batch: fan out N RL rollouts in one transactional call ---
+        batch = m.fork_batch(count=3, name_prefix="rollout")
+        check("fork_batch hit POST /fork-batch",
+              f"POST /v1/machines/{MACHINE_ID}/fork-batch" in captured["hits"])
+        check("fork_batch sent the size spec",
+              captured["fork_batch_body"].get("count") == 3
+              and captured["fork_batch_body"].get("namePrefix") == "rollout",
+              str(captured.get("fork_batch_body")))
+        check("fork_batch returns N clones in request order",
+              len(batch) == 3 and batch[0].name == "rollout-1" and batch[2].name == "rollout-3",
+              ",".join(c.name for c in batch))
 
         # reward_fork: grade in a throwaway clone without touching the original.
         captured["clone_deleted"] = False


### PR DESCRIPTION
Fanning out N rollouts from a forkable golden meant N separate fork() calls; this adds fork_batch (Python, sync + async) and forkBatch (Node) so an RL loop clones a golden into many isolated rollouts in one call — the GRPO group-sampling / eval-task fan-out primitive. On the cloud target it hits the single transactional /fork-batch endpoint (all-or-nothing); on the local target it fans out single forks off the same golden with best-effort cleanup, keeping the same API on both. Provide either count (clones auto-named {prefix}-{n}) or explicit names; clones come back in request order. Covered by the Node and Python cloud-mock suites.