### PR TITLE
Add an episode assign verb to the Python and Node SDKs to lease, heartbeat, and complete an RL episode on a forkable golden

### DIFF
--- a/sdk/node/index.ts
+++ b/sdk/node/index.ts
@@ -17,7 +17,7 @@
  * cloud — same API, backend selected via ConnectOptions / SMOL_CLOUD_TOKEN.
  */
 
-export { Machine } from './machine';
+export { Machine, Episode } from './machine';
 export { SmolError, NotSupportedError, InvalidConfigError, ExecutionError } from './errors';
 export type {
   MachineConfig,
@@ -26,6 +26,7 @@ export type {
   MountSpec,
   PortSpec,
   ForkBatchOptions,
+  AssignOptions,
   ExecOptions,
   ExecResult,
   ImageInfo,

--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -17,6 +17,7 @@ import {
   type Transport,
 } from "./transport";
 import type {
+  AssignOptions,
   ConnectOptions,
   ExecEvent,
   ExecOptions,
@@ -249,6 +250,30 @@ export class Machine {
     return clones.map((t) => new Machine(t));
   }
 
+  /** Assign an RL episode: fork + provision a clone of this forkable golden under
+   *  an idempotent lease, returned only once fully installed — with lifecycle
+   *  control (`Episode.heartbeat()` / `Episode.complete()`). The scheduler's "give
+   *  me one clean worker for this task, exactly once" call. **Cloud target only.**
+   *
+   *  Idempotent on `opts.leaseId`: a retried assign with the same key returns the
+   *  SAME episode instead of a second fork. `task` is staged into the clone at
+   *  `/run/smol-task.json`, `secrets` at `/run/smol-secrets.json`, and `files` at
+   *  their paths — all before the episode is handed back. Always `complete()` the
+   *  episode (e.g. in a `finally`) so its clone is reclaimed.
+   *
+   *  ```ts
+   *  const ep = await golden.assign({ leaseId: "task-42", task: { seed: 7 } });
+   *  try {
+   *    await ep.exec(["python", "rollout.py"]);
+   *  } finally {
+   *    await ep.complete("done");
+   *  }
+   *  ``` */
+  async assign(opts: AssignOptions): Promise<Episode> {
+    const { transport, leaseId, ownerToken } = await this.transport.assign(opts);
+    return new Episode(new Machine(transport), leaseId, ownerToken, this.transport);
+  }
+
   /** Score this machine's state WITHOUT mutating it: fork an ephemeral clone,
    *  run the grader command in the clone, then destroy it. The result (exit code
    *  / stdout) is your reward signal; this machine is untouched. This is the RL
@@ -274,5 +299,54 @@ export class Machine {
       // Best-effort teardown — never mask the grader's result/error.
       await clone.delete().catch(() => {});
     }
+  }
+}
+
+/** A leased RL episode: a freshly-provisioned clone plus its lease. Created by
+ *  `Machine.assign()`. Always `complete()` it (e.g. in a `finally`) so the clone
+ *  is reclaimed — the RL "one clean worker per task, guaranteed reclaimed"
+ *  pattern. Cloud target only. */
+export class Episode {
+  readonly #machine: Machine;
+  readonly leaseId: string;
+  readonly #ownerToken: string;
+  readonly #leaseTransport: Transport;
+  #completed = false;
+
+  constructor(
+    machine: Machine,
+    leaseId: string,
+    ownerToken: string,
+    leaseTransport: Transport,
+  ) {
+    this.#machine = machine;
+    this.leaseId = leaseId;
+    this.#ownerToken = ownerToken;
+    this.#leaseTransport = leaseTransport;
+  }
+
+  /** The episode's provisioned clone. */
+  get machine(): Machine {
+    return this.#machine;
+  }
+
+  /** Run a command in the episode's machine (shortcut for `.machine.exec`). */
+  async exec(command: string[], opts?: ExecOptions): Promise<ExecResult> {
+    return this.#machine.exec(command, opts);
+  }
+
+  /** Keep the lease alive. Call within the `heartbeatSecs` cadence you requested,
+   *  or the episode is reclaimed as `heartbeat_lost`. */
+  async heartbeat(): Promise<void> {
+    await this.#leaseTransport.heartbeatLease(this.leaseId, this.#ownerToken);
+  }
+
+  /** Finish the episode with a typed termination reason (e.g. `done`,
+   *  `agent_failed`, `infra_failed`, `cancelled`) and tear its clone down.
+   *  Idempotent — a second call is a no-op. */
+  async complete(reason = "done"): Promise<void> {
+    if (this.#completed) return;
+    await this.#leaseTransport.completeLease(this.leaseId, this.#ownerToken, reason);
+    this.#completed = true;
   }
 }

--- a/sdk/node/test/cloud-mock.ts
+++ b/sdk/node/test/cloud-mock.ts
@@ -98,8 +98,36 @@ const server = createServer(async (req, res) => {
     }));
     return json(201, { clones });
   }
-  // Readiness for batch-fork clones (b1, b2, …).
-  if (method === "GET" && /^\/v1\/machines\/b\d+$/.test(url)) {
+  if (method === "POST" && url === "/v1/machines/m1/assign") {
+    seen.assignBody = JSON.parse((await readBody(req)).toString() || "{}");
+    return json(201, {
+      leaseId: seen.assignBody.leaseId,
+      machineId: "ep1",
+      ownerToken: "tok_secret",
+      state: "ready",
+      machine: {
+        id: "ep1",
+        name: "ep-1",
+        state: "started",
+        source: { type: "image", reference: "alpine" },
+        resources: { cpus: 2, memoryMb: 1024 },
+        network: { mode: "open" },
+        env: {},
+        ephemeral: false,
+        ports: [],
+      },
+    });
+  }
+  if (method === "POST" && /^\/v1\/leases\/[^/]+\/heartbeat$/.test(url)) {
+    seen.heartbeatBody = JSON.parse((await readBody(req)).toString() || "{}");
+    return json(200, { leaseId: "task-99", machineId: "ep1", state: "ready" });
+  }
+  if (method === "POST" && /^\/v1\/leases\/[^/]+\/complete$/.test(url)) {
+    seen.completeBody = JSON.parse((await readBody(req)).toString() || "{}");
+    return json(200, { leaseId: "task-99", machineId: "ep1", state: "completed" });
+  }
+  // Readiness for batch-fork clones (b1, b2, …) and the episode clone (ep1).
+  if (method === "GET" && /^\/v1\/machines\/(b\d+|ep\d+)$/.test(url)) {
     return json(200, { id: url.split("/").pop(), state: "running" });
   }
   if (method === "GET" && url === "/v1/machines/m1")
@@ -413,6 +441,37 @@ async function main(): Promise<void> {
       batch[0].name === "rollout-1" &&
       batch[2].name === "rollout-3",
     batch.map((c) => c.name).join(","),
+  );
+
+  // --- assign: lease an RL episode, heartbeat, complete ---
+  const episode = await m.assign({
+    leaseId: "task-99",
+    task: { seed: 7 },
+    secrets: { KEY: "v" },
+  });
+  check(
+    "assign hit POST /assign with leaseId + task + secrets",
+    seen.assignBody?.leaseId === "task-99" &&
+      JSON.stringify(seen.assignBody?.task) === JSON.stringify({ seed: 7 }) &&
+      JSON.stringify(seen.assignBody?.secrets) === JSON.stringify({ KEY: "v" }),
+    JSON.stringify(seen.assignBody),
+  );
+  check(
+    "episode exposes the provisioned clone",
+    episode.machine.name === "ep-1",
+    episode.machine.name,
+  );
+  await episode.heartbeat();
+  check(
+    "heartbeat sent the owner token to /leases/:id/heartbeat",
+    seen.heartbeatBody?.ownerToken === "tok_secret",
+    JSON.stringify(seen.heartbeatBody),
+  );
+  await episode.complete("done");
+  check(
+    "complete sent owner token + reason to /leases/:id/complete",
+    seen.completeBody?.ownerToken === "tok_secret" && seen.completeBody?.reason === "done",
+    JSON.stringify(seen.completeBody),
   );
 
   // --- reward_fork: grade in a throwaway clone without touching the original ---

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -26,6 +26,7 @@ import type {
   ConnectOptions,
   ExecEvent,
   ExecOptions,
+  AssignOptions,
   ForkBatchOptions,
   ImageInfo,
   MachineConfig,
@@ -106,6 +107,11 @@ export interface Transport {
   delete(): Promise<void>;
   fork(name: string, ports?: PortSpec[]): Promise<Transport>;
   forkBatch(opts: ForkBatchOptions): Promise<Transport[]>;
+  assign(
+    opts: AssignOptions,
+  ): Promise<{ transport: Transport; leaseId: string; ownerToken: string }>;
+  heartbeatLease(leaseId: string, ownerToken: string): Promise<void>;
+  completeLease(leaseId: string, ownerToken: string, reason: string): Promise<void>;
 }
 
 /** Resolve a batch fork's clone names + size, mirroring the control plane:
@@ -407,6 +413,26 @@ class LocalTransport implements Transport {
       throw e;
     }
     return forks;
+  }
+
+  async assign(): Promise<{
+    transport: Transport;
+    leaseId: string;
+    ownerToken: string;
+  }> {
+    throw new NotSupportedError(
+      "assign() is a cloud feature: episode leases (idempotent assignment, " +
+        "heartbeat, TTL reclaim) live in the control plane. On the local target " +
+        "use fork()/forkBatch() directly.",
+    );
+  }
+
+  async heartbeatLease(): Promise<void> {
+    throw new NotSupportedError("heartbeatLease() is a cloud-only lease feature.");
+  }
+
+  async completeLease(): Promise<void> {
+    throw new NotSupportedError("completeLease() is a cloud-only lease feature.");
   }
 }
 
@@ -922,6 +948,56 @@ class CloudTransport implements Transport {
     // returned handle is usable.
     await Promise.all(clones.map((c) => waitForReady(this.conn, c.id)));
     return clones.map((c) => new CloudTransport(this.conn, c.name ?? c.id, c.id));
+  }
+
+  async assign(
+    opts: AssignOptions,
+  ): Promise<{ transport: Transport; leaseId: string; ownerToken: string }> {
+    // One idempotent call: the control plane forks + provisions ONE clone and
+    // returns it only once fully installed, plus the owner token. Files are
+    // base64-encoded for a binary-safe hop.
+    const body: Record<string, unknown> = { leaseId: opts.leaseId };
+    if (opts.task !== undefined) body.task = opts.task;
+    if (opts.files) {
+      body.files = Object.entries(opts.files).map(([path, content]) => ({
+        path,
+        contentB64: Buffer.from(content).toString("base64"),
+      }));
+    }
+    if (opts.secrets) body.secrets = opts.secrets;
+    if (opts.ports) {
+      body.ports = opts.ports.map((p) => ({ port: p.guest, hostPort: p.host }));
+    }
+    if (opts.ttlSecs !== undefined) body.ttlSecs = opts.ttlSecs;
+    if (opts.heartbeatSecs !== undefined) body.heartbeatSecs = opts.heartbeatSecs;
+    const resp = await cloudFetch<{
+      machineId: string;
+      ownerToken: string;
+      machine: MachineInfo;
+    }>(this.conn, "POST", `/v1/machines/${this.id}/assign`, { json: body });
+    await waitForReady(this.conn, resp.machineId);
+    const transport = new CloudTransport(
+      this.conn,
+      resp.machine?.name ?? resp.machineId,
+      resp.machineId,
+    );
+    return { transport, leaseId: opts.leaseId, ownerToken: resp.ownerToken };
+  }
+
+  async heartbeatLease(leaseId: string, ownerToken: string): Promise<void> {
+    await cloudFetch(this.conn, "POST", `/v1/leases/${leaseId}/heartbeat`, {
+      json: { ownerToken },
+    });
+  }
+
+  async completeLease(
+    leaseId: string,
+    ownerToken: string,
+    reason: string,
+  ): Promise<void> {
+    await cloudFetch(this.conn, "POST", `/v1/leases/${leaseId}/complete`, {
+      json: { ownerToken, reason },
+    });
   }
 }
 

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -76,6 +76,26 @@ export interface ForkBatchOptions {
   ports?: PortSpec[];
 }
 
+/** Options for assigning an RL episode — fork + provision one clone of a forkable
+ *  golden under an idempotent lease. Cloud target only. */
+export interface AssignOptions {
+  /** Caller-chosen idempotency key; a retried assign returns the same episode. */
+  leaseId: string;
+  /** JSON-serializable task payload, staged into the clone at
+   *  `/run/smol-task.json` before it's handed back. */
+  task?: unknown;
+  /** Files to stage into the clone: `{ guestPath: content }`. */
+  files?: Record<string, Uint8Array>;
+  /** Per-episode secrets, staged at `/run/smol-secrets.json`; never persisted. */
+  secrets?: Record<string, string>;
+  /** Optional pinned inbound port forwards. */
+  ports?: PortSpec[];
+  /** Lease time-to-live in seconds; the clone is reclaimed past it. */
+  ttlSecs?: number;
+  /** Expected heartbeat cadence in seconds; reclaimed if missed. */
+  heartbeatSecs?: number;
+}
+
 /** Configuration for creating a machine. */
 export interface MachineConfig {
   /** Machine name (auto-generated if omitted). */

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -45,8 +45,8 @@ from .errors import (
     SmolError,
     wrap_native_error,
 )
-from .async_machine import AsyncMachine
-from .machine import Machine
+from .async_machine import AsyncEpisode, AsyncMachine
+from .machine import Episode, Machine
 from .types import (
     ConnectOptions,
     ExecOptions,
@@ -64,6 +64,8 @@ __version__ = "1.7.0"
 __all__ = [
     "Machine",
     "AsyncMachine",
+    "Episode",
+    "AsyncEpisode",
     "MachineConfig",
     "ResourceSpec",
     "MountSpec",

--- a/sdk/python/python/smol/async_machine.py
+++ b/sdk/python/python/smol/async_machine.py
@@ -200,6 +200,33 @@ class AsyncMachine:
         )
         return [AsyncMachine(c) for c in clones]
 
+    async def assign(
+        self,
+        lease_id: str,
+        *,
+        task: object = None,
+        files: Optional[dict[str, bytes]] = None,
+        secrets: Optional[dict[str, str]] = None,
+        ports: Optional[list[PortSpec]] = None,
+        ttl_secs: Optional[int] = None,
+        heartbeat_secs: Optional[int] = None,
+    ) -> "AsyncEpisode":
+        """Assign an RL episode (cloud target only): fork + provision a clone under
+        an idempotent lease. See :meth:`Machine.assign`. Returns an
+        :class:`AsyncEpisode` usable as an async context manager for guaranteed
+        teardown."""
+        ep = await asyncio.to_thread(
+            self._m.assign,
+            lease_id,
+            task=task,
+            files=files,
+            secrets=secrets,
+            ports=ports,
+            ttl_secs=ttl_secs,
+            heartbeat_secs=heartbeat_secs,
+        )
+        return AsyncEpisode(AsyncMachine(ep.machine), ep)
+
     async def reward_fork(
         self,
         command: list[str],
@@ -219,3 +246,44 @@ class AsyncMachine:
 
     async def __aexit__(self, *exc: object) -> None:
         await self.delete()
+
+
+class AsyncEpisode:
+    """Async view of a leased RL episode (see :class:`smol.Episode`). Created by
+    :meth:`AsyncMachine.assign`; use as an async context manager for guaranteed
+    teardown."""
+
+    def __init__(self, machine: "AsyncMachine", episode: object) -> None:
+        self._machine = machine
+        self._ep = episode  # the underlying sync smol.Episode
+
+    @property
+    def machine(self) -> "AsyncMachine":
+        """The episode's provisioned clone."""
+        return self._machine
+
+    @property
+    def lease_id(self) -> str:
+        return self._ep.lease_id
+
+    async def exec(self, command: list[str], opts: Optional[ExecOptions] = None) -> ExecResult:
+        """Run a command in the episode's machine."""
+        return await self._machine.exec(command, opts)
+
+    async def heartbeat(self) -> None:
+        """Keep the lease alive (call within your ``heartbeat_secs`` cadence)."""
+        await asyncio.to_thread(self._ep.heartbeat)
+
+    async def complete(self, reason: str = "done") -> None:
+        """Finish the episode with a termination reason and tear its clone down.
+        Idempotent."""
+        await asyncio.to_thread(self._ep.complete, reason)
+
+    async def __aenter__(self) -> "AsyncEpisode":
+        return self
+
+    async def __aexit__(self, exc_type: object, *_: object) -> None:
+        try:
+            await self.complete("done" if exc_type is None else "agent_failed")
+        except Exception:
+            pass

--- a/sdk/python/python/smol/machine.py
+++ b/sdk/python/python/smol/machine.py
@@ -231,6 +231,53 @@ class Machine:
             )
         ]
 
+    def assign(
+        self,
+        lease_id: str,
+        *,
+        task: object = None,
+        files: Optional[dict[str, bytes]] = None,
+        secrets: Optional[dict[str, str]] = None,
+        ports: Optional[list[PortSpec]] = None,
+        ttl_secs: Optional[int] = None,
+        heartbeat_secs: Optional[int] = None,
+    ) -> "Episode":
+        """Assign an RL episode: fork + provision a clone of this forkable golden
+        under an idempotent lease, and get it back only once fully installed —
+        with lifecycle control (:meth:`Episode.heartbeat`, :meth:`Episode.complete`).
+        The scheduler's "give me one clean worker for this task, exactly once"
+        call. **Cloud target only** (leases live in the control plane).
+
+        Idempotent on ``lease_id``: a retried ``assign`` with the same key returns
+        the SAME episode instead of forking a second one. The ``task`` payload is
+        staged into the clone at ``/run/smol-task.json``, ``secrets`` at
+        ``/run/smol-secrets.json``, and ``files`` at their given paths — all before
+        the episode is handed back, so a returned :class:`Episode` is always fully
+        provisioned. Use it as a context manager to guarantee teardown::
+
+            with golden.assign("task-42", task={"seed": 7}) as ep:
+                ep.exec(["python", "rollout.py"])   # clone auto-completed on exit
+
+        :param lease_id: caller-chosen idempotency key.
+        :param task: JSON-serializable task payload.
+        :param files: ``{guest_path: bytes}`` to stage into the clone.
+        :param secrets: ``{name: value}`` staged as a JSON file, never persisted.
+        :param ports: optional pinned inbound port forwards.
+        :param ttl_secs: lease time-to-live; the clone is reclaimed past it.
+        :param heartbeat_secs: expected heartbeat cadence; reclaimed if missed.
+        :returns: an :class:`Episode` handle.
+        """
+        clone_t, lid, owner_token = self._t.assign(
+            lease_id,
+            task=task,
+            files=files,
+            secrets=secrets,
+            ports=ports,
+            ttl_secs=ttl_secs,
+            heartbeat_secs=heartbeat_secs,
+        )
+        return Episode(Machine(clone_t), lid, owner_token, self._t)
+
     def reward_fork(
         self,
         command: list[str],
@@ -269,3 +316,58 @@ class Machine:
 
     def __exit__(self, *exc: object) -> None:
         self.delete()
+
+
+class Episode:
+    """A leased RL episode: a freshly-provisioned clone plus its lease. Created by
+    :meth:`Machine.assign`. Use it as a context manager so the clone is always torn
+    down when the block exits (even on error) — the RL "one clean worker per task,
+    guaranteed reclaimed" pattern. Cloud target only.
+    """
+
+    def __init__(
+        self,
+        machine: Machine,
+        lease_id: str,
+        owner_token: str,
+        lease_transport: "Transport",
+    ) -> None:
+        self._machine = machine
+        self.lease_id = lease_id
+        self._owner_token = owner_token
+        self._lease_t = lease_transport
+        self._completed = False
+
+    @property
+    def machine(self) -> Machine:
+        """The episode's provisioned clone."""
+        return self._machine
+
+    def exec(self, command: list[str], opts: Optional[ExecOptions] = None) -> ExecResult:
+        """Run a command in the episode's machine (shortcut for ``.machine.exec``)."""
+        return self._machine.exec(command, opts)
+
+    def heartbeat(self) -> None:
+        """Keep the lease alive. Call within the ``heartbeat_secs`` cadence you
+        requested, or the episode is reclaimed as ``heartbeat_lost``."""
+        self._lease_t.heartbeat_lease(self.lease_id, self._owner_token)
+
+    def complete(self, reason: str = "done") -> None:
+        """Finish the episode with a typed termination reason (e.g. ``done``,
+        ``agent_failed``, ``infra_failed``, ``cancelled``) and tear its clone down.
+        Idempotent — a second call is a no-op."""
+        if self._completed:
+            return
+        self._lease_t.complete_lease(self.lease_id, self._owner_token, reason)
+        self._completed = True
+
+    def __enter__(self) -> "Episode":
+        return self
+
+    def __exit__(self, exc_type: object, *_: object) -> None:
+        # Always release the episode; a clean exit is `done`, an exception is
+        # `agent_failed` so a trainer can tell task failure from infra failure.
+        try:
+            self.complete("done" if exc_type is None else "agent_failed")
+        except Exception:
+            pass

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -98,6 +98,22 @@ class Transport(Protocol):
         ports: Optional[list[PortSpec]] = None,
     ) -> "list[Transport]": ...
 
+    def assign(
+        self,
+        lease_id: str,
+        *,
+        task: Any = None,
+        files: Optional[dict[str, bytes]] = None,
+        secrets: Optional[dict[str, str]] = None,
+        ports: Optional[list[PortSpec]] = None,
+        ttl_secs: Optional[int] = None,
+        heartbeat_secs: Optional[int] = None,
+    ) -> "tuple[Transport, str, str]": ...
+
+    def heartbeat_lease(self, lease_id: str, owner_token: str) -> None: ...
+
+    def complete_lease(self, lease_id: str, owner_token: str, reason: str) -> None: ...
+
 
 def _encode_path(p: str) -> str:
     """Percent-encode each segment but keep ``/`` (smolfleet files route is a
@@ -361,6 +377,29 @@ class LocalTransport:
                     pass
             raise
         return forks
+
+    def assign(
+        self,
+        lease_id: str,
+        *,
+        task: Any = None,
+        files: Optional[dict[str, bytes]] = None,
+        secrets: Optional[dict[str, str]] = None,
+        ports: Optional[list[PortSpec]] = None,
+        ttl_secs: Optional[int] = None,
+        heartbeat_secs: Optional[int] = None,
+    ) -> "tuple[Transport, str, str]":
+        raise NotSupportedError(
+            "assign() is a cloud feature: episode leases (idempotent assignment, "
+            "heartbeat, TTL reclaim) live in the control plane. On the local target "
+            "use fork()/fork_batch() directly."
+        )
+
+    def heartbeat_lease(self, lease_id: str, owner_token: str) -> None:
+        raise NotSupportedError("heartbeat_lease() is a cloud-only lease feature.")
+
+    def complete_lease(self, lease_id: str, owner_token: str, reason: str) -> None:
+        raise NotSupportedError("complete_lease() is a cloud-only lease feature.")
 
 
 # ---------------------------------------------------------------------------
@@ -641,6 +680,72 @@ class CloudTransport:
         for t in transports:
             _wait_for_ready(self._base, self._key, t._id)
         return transports
+
+    def assign(
+        self,
+        lease_id: str,
+        *,
+        task: Any = None,
+        files: Optional[dict[str, bytes]] = None,
+        secrets: Optional[dict[str, str]] = None,
+        ports: Optional[list[PortSpec]] = None,
+        ttl_secs: Optional[int] = None,
+        heartbeat_secs: Optional[int] = None,
+    ) -> "tuple[CloudTransport, str, str]":
+        # One idempotent call: the control plane forks + provisions ONE clone and
+        # returns it only once fully installed, plus the owner token. Files are
+        # base64-encoded for a binary-safe hop.
+        body: dict[str, Any] = {"leaseId": lease_id}
+        if task is not None:
+            body["task"] = task
+        if files:
+            body["files"] = [
+                {"path": p, "contentB64": base64.b64encode(c).decode()}
+                for p, c in files.items()
+            ]
+        if secrets:
+            body["secrets"] = secrets
+        if ports:
+            body["ports"] = [{"port": p.guest, "hostPort": p.host} for p in ports]
+        if ttl_secs is not None:
+            body["ttlSecs"] = ttl_secs
+        if heartbeat_secs is not None:
+            body["heartbeatSecs"] = heartbeat_secs
+        resp = (
+            _cloud_fetch(
+                self._base,
+                self._key,
+                "POST",
+                f"/v1/machines/{self._id}/assign",
+                json_body=body,
+            )
+            or {}
+        )
+        machine_id = resp["machineId"]
+        owner_token = resp["ownerToken"]
+        info = resp.get("machine") or {}
+        clone_name = info.get("name") or machine_id
+        clone = CloudTransport(self._base, self._key, machine_id, clone_name)
+        _wait_for_ready(self._base, self._key, machine_id)
+        return (clone, lease_id, owner_token)
+
+    def heartbeat_lease(self, lease_id: str, owner_token: str) -> None:
+        _cloud_fetch(
+            self._base,
+            self._key,
+            "POST",
+            f"/v1/leases/{lease_id}/heartbeat",
+            json_body={"ownerToken": owner_token},
+        )
+
+    def complete_lease(self, lease_id: str, owner_token: str, reason: str) -> None:
+        _cloud_fetch(
+            self._base,
+            self._key,
+            "POST",
+            f"/v1/leases/{lease_id}/complete",
+            json_body={"ownerToken": owner_token, "reason": reason},
+        )
 
 
 def _resolve_batch_names(

--- a/sdk/python/tests/test_cloud_mock.py
+++ b/sdk/python/tests/test_cloud_mock.py
@@ -98,6 +98,27 @@ class Handler(BaseHTTPRequestHandler):
                     "createdAt": "2026-05-30T00:00:00Z", "updatedAt": "2026-05-30T00:00:00Z",
                 })
             return self._send(201, json.dumps({"clones": clones}).encode())
+        if self.path == f"/v1/machines/{MACHINE_ID}/assign":
+            captured["assign_body"] = json.loads(self._read() or b"{}")
+            return self._send(201, json.dumps({
+                "leaseId": captured["assign_body"].get("leaseId"),
+                "machineId": "mach-ep1", "ownerToken": "tok_secret", "state": "ready",
+                "machine": {
+                    "id": "mach-ep1", "name": "ep-1",
+                    "source": {"type": "image", "reference": "alpine:3.20"}, "state": "started",
+                    "resources": {"cpus": 2, "memoryMb": 1024}, "network": {"mode": "open"},
+                    "env": {}, "ephemeral": False, "ports": [],
+                    "createdAt": "2026-05-30T00:00:00Z", "updatedAt": "2026-05-30T00:00:00Z",
+                },
+            }).encode())
+        if self.path.startswith("/v1/leases/") and self.path.endswith("/heartbeat"):
+            captured["heartbeat_body"] = json.loads(self._read() or b"{}")
+            return self._send(200, json.dumps(
+                {"leaseId": "task-99", "machineId": "mach-ep1", "state": "ready"}).encode())
+        if self.path.startswith("/v1/leases/") and self.path.endswith("/complete"):
+            captured["complete_body"] = json.loads(self._read() or b"{}")
+            return self._send(200, json.dumps(
+                {"leaseId": "task-99", "machineId": "mach-ep1", "state": "completed"}).encode())
         if self.path == f"/v1/machines/{MACHINE_ID}/exec":
             captured["exec_body"] = json.loads(self._read() or b"{}")
             return self._send(200, json.dumps({
@@ -139,6 +160,10 @@ class Handler(BaseHTTPRequestHandler):
             )
         if self.path == f"/v1/machines/{CLONE_ID}":
             return self._send(200, json.dumps({"id": CLONE_ID, "state": "started", "ready": True}).encode())
+        # Readiness for the assigned episode clone.
+        if self.path.startswith("/v1/machines/mach-ep"):
+            mid = self.path.rsplit("/", 1)[-1]
+            return self._send(200, json.dumps({"id": mid, "state": "started", "ready": True}).encode())
         # Readiness for batch-fork clones (mach-b1, mach-b2, …).
         if self.path.startswith("/v1/machines/mach-b"):
             mid = self.path.rsplit("/", 1)[-1]
@@ -304,6 +329,28 @@ def main() -> int:
         check("fork_batch returns N clones in request order",
               len(batch) == 3 and batch[0].name == "rollout-1" and batch[2].name == "rollout-3",
               ",".join(c.name for c in batch))
+
+        # --- assign: lease an RL episode, heartbeat, auto-complete on context exit ---
+        with m.assign("task-99", task={"seed": 7}, secrets={"KEY": "v"}) as ep:
+            check("assign hit POST /assign", f"POST /v1/machines/{MACHINE_ID}/assign" in captured["hits"])
+            check("assign sent leaseId + task + secrets",
+                  captured["assign_body"].get("leaseId") == "task-99"
+                  and captured["assign_body"].get("task") == {"seed": 7}
+                  and captured["assign_body"].get("secrets") == {"KEY": "v"},
+                  str(captured.get("assign_body")))
+            check("episode exposes the provisioned clone", ep.machine.name == "ep-1", ep.machine.name)
+            ep.heartbeat()
+            check("heartbeat hit POST /leases/:id/heartbeat",
+                  "POST /v1/leases/task-99/heartbeat" in captured["hits"])
+            check("heartbeat sent the owner token",
+                  captured.get("heartbeat_body", {}).get("ownerToken") == "tok_secret",
+                  str(captured.get("heartbeat_body")))
+        check("complete hit POST /leases/:id/complete on context exit",
+              "POST /v1/leases/task-99/complete" in captured["hits"])
+        check("complete sent owner token + 'done' reason on clean exit",
+              captured.get("complete_body", {}).get("ownerToken") == "tok_secret"
+              and captured.get("complete_body", {}).get("reason") == "done",
+              str(captured.get("complete_body")))
 
         # reward_fork: grade in a throwaway clone without touching the original.
         captured["clone_deleted"] = False


### PR DESCRIPTION
Completes the RL episode contract in the SDK: golden.assign(leaseId, task, files, secrets, ...) forks and provisions a clone under an idempotent lease and returns an Episode handle with heartbeat() and complete(reason). The scheduler calls this instead of raw HTTP — one clean worker per task, exactly once, with lifecycle control and guaranteed teardown. Shipped in Python (sync Episode + async AsyncEpisode, sync as a context manager that auto-completes) and Node (Episode). It is cloud-only, raising NotSupported on the local target (leases live in the control plane), matching how the SDK already gates cloud-only features. Covered by the Node and Python cloud-mock suites.