### PR TITLE
Add Machine.start and Machine.id to the Python and Node SDKs and let an episode record a score and result read back via its status

### DIFF
--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -96,6 +96,13 @@ export class Machine {
     return this.transport.name;
   }
 
+  /** The machine's id — the cloud `mach-…` id (or the name on local). Handy right
+   *  after `create()`/`fork()` so you don't have to list the tenant to find the
+   *  machine you just made. */
+  get id(): string {
+    return this.transport.machineId;
+  }
+
   /** Current lifecycle state. On cloud, `"started"` means only that the VM
    *  process launched; it does not mean the guest or workload is ready. Use
    *  `ready()` or `waitUntilReady()` before doing work. */
@@ -209,6 +216,13 @@ export class Machine {
   /** Stop the machine. */
   stop(): Promise<void> {
     return this.transport.stop();
+  }
+
+  /** Start (resume) a stopped machine, awaiting until its agent is ready. The
+   *  counterpart to `stop()` — disk state is preserved across a stop/start, so
+   *  this is a cheap pause/resume. */
+  start(): Promise<void> {
+    return this.transport.start();
   }
 
   /** Stop the machine and delete its storage. */
@@ -343,10 +357,27 @@ export class Episode {
 
   /** Finish the episode with a typed termination reason (e.g. `done`,
    *  `agent_failed`, `infra_failed`, `cancelled`) and tear its clone down.
+   *  Optionally record a `score` (per-task reward / pass-rate) and an arbitrary
+   *  JSON `result` — the "did it improve?" number, read back via `status()`.
    *  Idempotent — a second call is a no-op. */
-  async complete(reason = "done"): Promise<void> {
+  async complete(
+    reason = "done",
+    opts?: { score?: number; result?: unknown },
+  ): Promise<void> {
     if (this.#completed) return;
-    await this.#leaseTransport.completeLease(this.leaseId, this.#ownerToken, reason);
+    await this.#leaseTransport.completeLease(
+      this.leaseId,
+      this.#ownerToken,
+      reason,
+      opts?.score,
+      opts?.result,
+    );
     this.#completed = true;
+  }
+
+  /** Read this lease's current status and, once completed, its outcome (`state`,
+   *  `reason`, `score`, `result`) — how a trainer collects the per-task score. */
+  async status(): Promise<Record<string, unknown>> {
+    return this.#leaseTransport.getLease(this.leaseId);
   }
 }

--- a/sdk/node/test/cloud-mock.ts
+++ b/sdk/node/test/cloud-mock.ts
@@ -126,6 +126,16 @@ const server = createServer(async (req, res) => {
     seen.completeBody = JSON.parse((await readBody(req)).toString() || "{}");
     return json(200, { leaseId: "task-99", machineId: "ep1", state: "completed" });
   }
+  if (method === "GET" && /^\/v1\/leases\/[^/]+$/.test(url)) {
+    return json(200, {
+      leaseId: "task-100",
+      machineId: "ep1",
+      state: "completed",
+      reason: "done",
+      score: 0.9,
+      result: { passed: 3 },
+    });
+  }
   // Readiness for batch-fork clones (b1, b2, …) and the episode clone (ep1).
   if (method === "GET" && /^\/v1\/machines\/(b\d+|ep\d+)$/.test(url)) {
     return json(200, { id: url.split("/").pop(), state: "running" });
@@ -472,6 +482,27 @@ async function main(): Promise<void> {
     "complete sent owner token + reason to /leases/:id/complete",
     seen.completeBody?.ownerToken === "tok_secret" && seen.completeBody?.reason === "done",
     JSON.stringify(seen.completeBody),
+  );
+
+  // --- Machine.id + Machine.start (resume a stopped machine) ---
+  check("machine exposes its id", m.id === "m1", m.id);
+  await m.start(); // POST /start + wait-ready (both mocked) — must not throw
+  check("start() resumes a stopped machine without error", true);
+
+  // --- complete with score/result, read the outcome back via status() ---
+  const episode2 = await m.assign({ leaseId: "task-100" });
+  await episode2.complete("done", { score: 0.9, result: { passed: 3 } });
+  check(
+    "complete sent score + result",
+    seen.completeBody?.score === 0.9 &&
+      JSON.stringify(seen.completeBody?.result) === JSON.stringify({ passed: 3 }),
+    JSON.stringify(seen.completeBody),
+  );
+  const st = await episode2.status();
+  check(
+    "status() reads the lease outcome (state + score)",
+    st.state === "completed" && st.score === 0.9,
+    JSON.stringify(st),
   );
 
   // --- reward_fork: grade in a throwaway clone without touching the original ---

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -103,7 +103,9 @@ export interface Transport {
   writeFile(path: string, data: Buffer, mode?: number): Promise<void>;
   pullImage(image: string): Promise<ImageInfo>;
   listImages(): Promise<ImageInfo[]>;
+  readonly machineId: string;
   stop(): Promise<void>;
+  start(): Promise<void>;
   delete(): Promise<void>;
   fork(name: string, ports?: PortSpec[]): Promise<Transport>;
   forkBatch(opts: ForkBatchOptions): Promise<Transport[]>;
@@ -111,7 +113,14 @@ export interface Transport {
     opts: AssignOptions,
   ): Promise<{ transport: Transport; leaseId: string; ownerToken: string }>;
   heartbeatLease(leaseId: string, ownerToken: string): Promise<void>;
-  completeLease(leaseId: string, ownerToken: string, reason: string): Promise<void>;
+  completeLease(
+    leaseId: string,
+    ownerToken: string,
+    reason: string,
+    score?: number,
+    result?: unknown,
+  ): Promise<void>;
+  getLease(leaseId: string): Promise<Record<string, unknown>>;
 }
 
 /** Resolve a batch fork's clone names + size, mirroring the control plane:
@@ -251,6 +260,11 @@ class LocalTransport implements Transport {
     return this.inner.name;
   }
 
+  get machineId(): string {
+    // Local machines are identified by their name (no cloud `mach-…` id).
+    return this.inner.name;
+  }
+
   async state(): Promise<string> {
     return this.inner.state();
   }
@@ -373,6 +387,15 @@ class LocalTransport implements Transport {
     }
   }
 
+  async start(): Promise<void> {
+    try {
+      await this.inner.start();
+    } catch (e) {
+      throw wrapNativeError(e);
+    }
+    liveLocal.add(this);
+  }
+
   async delete(): Promise<void> {
     liveLocal.delete(this);
     try {
@@ -433,6 +456,10 @@ class LocalTransport implements Transport {
 
   async completeLease(): Promise<void> {
     throw new NotSupportedError("completeLease() is a cloud-only lease feature.");
+  }
+
+  async getLease(): Promise<Record<string, unknown>> {
+    throw new NotSupportedError("getLease() is a cloud-only lease feature.");
   }
 }
 
@@ -634,6 +661,10 @@ class CloudTransport implements Transport {
     public readonly name: string,
     private readonly id: string,
   ) {}
+
+  get machineId(): string {
+    return this.id;
+  }
 
   async state(): Promise<string> {
     const m = await cloudFetch<MachineInfo>(
@@ -901,6 +932,12 @@ class CloudTransport implements Transport {
     await cloudFetch(this.conn, "POST", `/v1/machines/${this.id}/stop`);
   }
 
+  async start(): Promise<void> {
+    // Resume a stopped machine, then wait for its agent so the handle is usable.
+    await cloudFetch(this.conn, "POST", `/v1/machines/${this.id}/start`);
+    await waitForReady(this.conn, this.id);
+  }
+
   async delete(): Promise<void> {
     await cloudFetch(this.conn, "DELETE", `/v1/machines/${this.id}`);
   }
@@ -994,10 +1031,23 @@ class CloudTransport implements Transport {
     leaseId: string,
     ownerToken: string,
     reason: string,
+    score?: number,
+    result?: unknown,
   ): Promise<void> {
+    const json: Record<string, unknown> = { ownerToken, reason };
+    if (score !== undefined) json.score = score;
+    if (result !== undefined) json.result = result;
     await cloudFetch(this.conn, "POST", `/v1/leases/${leaseId}/complete`, {
-      json: { ownerToken, reason },
+      json,
     });
+  }
+
+  async getLease(leaseId: string): Promise<Record<string, unknown>> {
+    return cloudFetch<Record<string, unknown>>(
+      this.conn,
+      "GET",
+      `/v1/leases/${leaseId}`,
+    );
   }
 }
 

--- a/sdk/python/examples/rl_loop.py
+++ b/sdk/python/examples/rl_loop.py
@@ -1,0 +1,109 @@
+"""End-to-end RL episode loop on smol (cloud target).
+
+Prepare a gym/environment ONCE as a forkable golden, then:
+
+  * RUN   — fan out N isolated rollouts from it (GRPO-style group sampling) and
+            grade each without side effects (`reward_fork`).
+  * VERIFY — run the gym as a leased *episode* (assigned exactly once, with a TTL
+            and heartbeat), record a score, and read it back — the "did it
+            improve?" half.
+
+Every rollout is a copy-on-write clone of the golden, so the per-rollout setup
+(deps/repo/dataset) is amortized to ~zero and each rollout starts from the exact
+same state.
+
+Run against the cloud with a fork-capable (amd64) account::
+
+    SMOL_CLOUD_TOKEN=... python examples/rl_loop.py
+
+Note: `fork`/`fork_batch`/`reward_fork` are live on cloud today; the leased
+`assign`/`complete`/`status` episode API needs the lease endpoints deployed.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from smol import ConnectOptions, Machine, MachineConfig
+
+CLOUD = ConnectOptions(target="cloud")  # uses SMOL_CLOUD_TOKEN
+
+
+def prepare_golden() -> Machine:
+    """The prepared, pinned environment — deps/repo/dataset baked in once. Booting
+    it `forkable` makes it a live-RAM fork base so every rollout is a near-instant
+    CoW clone that shares its warm state."""
+    golden = Machine.create(
+        MachineConfig(image="python:3.12-slim", forkable=True),
+        CLOUD,
+    )
+    # Bake whatever setup a rollout would otherwise repeat (install deps, stage a
+    # dataset, warm a cache). Done ONCE; every clone inherits it.
+    golden.exec(["python", "-c", "print('gym prepared once')"]).assert_success()
+    return golden
+
+
+def run_group(golden: Machine, n: int) -> list[float]:
+    """RUN half — GRPO-style group sampling: N independent rollouts from ONE
+    prepared state, each graded in a throwaway clone so grading never mutates the
+    rollout. Returns the per-rollout rewards."""
+    clones = golden.fork_batch(count=n, name_prefix="rollout")
+    rewards: list[float] = []
+    try:
+        for i, clone in enumerate(clones):
+            # The rollout: drive the policy over exec calls. (Stand-in here: write
+            # an "answer" that depends on the rollout index.)
+            clone.exec(
+                ["python", "-c", f"open('/tmp/answer', 'w').write(str({i} * 6))"]
+            ).assert_success()
+            # Reward: grade the END STATE in a throwaway clone — reward judging
+            # without side effects. The grader's stdout is the reward signal.
+            graded = clone.reward_fork(
+                [
+                    "python",
+                    "-c",
+                    "print(1.0 if open('/tmp/answer').read() == '42' else 0.0)",
+                ]
+            )
+            rewards.append(float(graded.stdout.strip() or 0.0))
+    finally:
+        for clone in clones:
+            clone.delete()
+    return rewards
+
+
+def eval_checkpoint(golden: Machine, label: str) -> float:
+    """VERIFY half — run the gym as a leased episode: a clean worker assigned
+    exactly once (idempotent on the lease id), with a TTL + heartbeat, whose score
+    you record and read back. Requires the lease endpoints to be deployed."""
+    lease_id = f"eval-{label}-{uuid.uuid4().hex[:8]}"
+    with golden.assign(
+        lease_id, task={"checkpoint": label}, ttl_secs=600, heartbeat_secs=30
+    ) as episode:
+        # Run the gym on this checkpoint (the task payload is at /run/smol-task.json
+        # inside the clone). Stand-in: compute a pass-rate.
+        graded = episode.exec(
+            ["python", "-c", "print(0.9 if '__label__'.strip() else 0.0)"]
+        )
+        score = float(graded.stdout.strip() or 0.0)
+        episode.complete(reason="done", score=score, result={"checkpoint": label})
+    # Collect the recorded number back from the lease (how a trainer aggregates).
+    return float(episode.status().get("score") or 0.0)
+
+
+def main() -> None:
+    golden = prepare_golden()
+    try:
+        rewards = run_group(golden, n=8)
+        mean = sum(rewards) / len(rewards)
+        print(f"group rewards: {rewards}  mean={mean:.3f}")
+
+        a = eval_checkpoint(golden, "A")
+        b = eval_checkpoint(golden, "B")
+        print(f"eval  A={a:.3f}  B={b:.3f}  improved={b > a}")
+    finally:
+        golden.delete()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/python/smol/async_machine.py
+++ b/sdk/python/python/smol/async_machine.py
@@ -27,7 +27,7 @@ many machines concurrently::
 from __future__ import annotations
 
 import asyncio
-from typing import AsyncIterator, Optional
+from typing import Any, AsyncIterator, Optional
 
 from .machine import Machine
 from .types import (
@@ -81,6 +81,11 @@ class AsyncMachine:
     def name(self) -> str:
         """The machine's name / identifier."""
         return self._m.name
+
+    @property
+    def id(self) -> str:
+        """The machine's id (cloud ``mach-…`` id, or the name on local)."""
+        return self._m.id
 
     async def state(self) -> str:
         """Current lifecycle state. Cloud ``"started"`` means the VM process
@@ -170,6 +175,11 @@ class AsyncMachine:
     async def stop(self) -> None:
         """Stop the machine."""
         await asyncio.to_thread(self._m.stop)
+
+    async def start(self) -> None:
+        """Start (resume) a stopped machine, waiting until its agent is ready. The
+        counterpart to :meth:`stop`; disk state is preserved across the cycle."""
+        await asyncio.to_thread(self._m.start)
 
     async def delete(self) -> None:
         """Stop the machine and delete its storage."""
@@ -274,10 +284,23 @@ class AsyncEpisode:
         """Keep the lease alive (call within your ``heartbeat_secs`` cadence)."""
         await asyncio.to_thread(self._ep.heartbeat)
 
-    async def complete(self, reason: str = "done") -> None:
-        """Finish the episode with a termination reason and tear its clone down.
-        Idempotent."""
-        await asyncio.to_thread(self._ep.complete, reason)
+    async def complete(
+        self,
+        reason: str = "done",
+        *,
+        score: Optional[float] = None,
+        result: Any = None,
+    ) -> None:
+        """Finish the episode with a termination reason and tear its clone down;
+        optionally record a ``score`` + JSON ``result`` (read back via
+        :meth:`status`). Idempotent."""
+        await asyncio.to_thread(
+            lambda: self._ep.complete(reason, score=score, result=result)
+        )
+
+    async def status(self) -> "dict[str, Any]":
+        """Read the lease's status/outcome (state, reason, score, result)."""
+        return await asyncio.to_thread(self._ep.status)
 
     async def __aenter__(self) -> "AsyncEpisode":
         return self

--- a/sdk/python/python/smol/machine.py
+++ b/sdk/python/python/smol/machine.py
@@ -13,7 +13,7 @@ Mirrors the Node SDK's ``machine.ts`` (sync, since the embedded engine blocks)::
 from __future__ import annotations
 
 import uuid
-from typing import Optional
+from typing import Any, Optional
 
 from .transport import Transport, connect_transport, make_transport
 from .types import (
@@ -83,6 +83,13 @@ class Machine:
     def name(self) -> str:
         """The machine's name / identifier."""
         return self._t.name
+
+    @property
+    def id(self) -> str:
+        """The machine's id — the cloud ``mach-…`` id (or the name on local). Handy
+        right after :meth:`create`/:meth:`fork` so you don't have to list the
+        tenant to find the machine you just made."""
+        return self._t.machine_id
 
     def state(self) -> str:
         """Current lifecycle state. On cloud, ``"started"`` means only that the
@@ -178,6 +185,12 @@ class Machine:
     def stop(self) -> None:
         """Stop the machine."""
         self._t.stop()
+
+    def start(self) -> None:
+        """Start (resume) a stopped machine, waiting until its agent is ready. The
+        counterpart to :meth:`stop` — a stopped machine keeps its disk state, so
+        ``start()`` brings it back with that state intact (cheap pause/resume)."""
+        self._t.start()
 
     def delete(self) -> None:
         """Stop the machine and delete its storage."""
@@ -352,14 +365,30 @@ class Episode:
         requested, or the episode is reclaimed as ``heartbeat_lost``."""
         self._lease_t.heartbeat_lease(self.lease_id, self._owner_token)
 
-    def complete(self, reason: str = "done") -> None:
+    def complete(
+        self,
+        reason: str = "done",
+        *,
+        score: Optional[float] = None,
+        result: Any = None,
+    ) -> None:
         """Finish the episode with a typed termination reason (e.g. ``done``,
         ``agent_failed``, ``infra_failed``, ``cancelled``) and tear its clone down.
-        Idempotent — a second call is a no-op."""
+        Optionally record a ``score`` (the per-task reward / pass-rate) and an
+        arbitrary JSON ``result`` — the "did it improve?" number, read back later
+        via :meth:`status`. Idempotent — a second call is a no-op."""
         if self._completed:
             return
-        self._lease_t.complete_lease(self.lease_id, self._owner_token, reason)
+        self._lease_t.complete_lease(
+            self.lease_id, self._owner_token, reason, score=score, result=result
+        )
         self._completed = True
+
+    def status(self) -> "dict[str, Any]":
+        """Read this lease's current status and, once completed, its outcome
+        (``state``, ``reason``, ``score``, ``result``) — how a trainer collects the
+        per-task score after the episode ends."""
+        return self._lease_t.get_lease(self.lease_id)
 
     def __enter__(self) -> "Episode":
         return self

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -64,6 +64,8 @@ def _decode_exec_bytes(raw: dict[str, Any], b64_key: str, text: str) -> bytes:
 class Transport(Protocol):
     @property
     def name(self) -> str: ...
+    @property
+    def machine_id(self) -> str: ...
     def state(self) -> str: ...
     def ready(self) -> bool: ...
     def ready_at(self) -> Optional[str]: ...
@@ -86,6 +88,7 @@ class Transport(Protocol):
     def pull_image(self, image: str) -> ImageInfo: ...
     def list_images(self) -> list[ImageInfo]: ...
     def stop(self) -> None: ...
+    def start(self) -> None: ...
     def delete(self) -> None: ...
     def fork(self, name: str, ports: Optional[list[PortSpec]] = None) -> "Transport": ...
 
@@ -112,7 +115,16 @@ class Transport(Protocol):
 
     def heartbeat_lease(self, lease_id: str, owner_token: str) -> None: ...
 
-    def complete_lease(self, lease_id: str, owner_token: str, reason: str) -> None: ...
+    def complete_lease(
+        self,
+        lease_id: str,
+        owner_token: str,
+        reason: str,
+        score: Optional[float] = None,
+        result: Any = None,
+    ) -> None: ...
+
+    def get_lease(self, lease_id: str) -> "dict[str, Any]": ...
 
 
 def _encode_path(p: str) -> str:
@@ -230,6 +242,11 @@ class LocalTransport:
     def name(self) -> str:
         return self._inner.name
 
+    @property
+    def machine_id(self) -> str:
+        # Local machines are identified by their name (there's no cloud `mach-…`).
+        return self._inner.name
+
     def state(self) -> str:
         return str(self._inner.state())
 
@@ -334,6 +351,13 @@ class LocalTransport:
         except Exception as e:  # noqa: BLE001
             raise wrap_native_error(e) from e
 
+    def start(self) -> None:
+        try:
+            self._inner.start()
+        except Exception as e:  # noqa: BLE001
+            raise wrap_native_error(e) from e
+        _live_local.add(self)
+
     def delete(self) -> None:
         _live_local.discard(self)
         try:
@@ -398,8 +422,18 @@ class LocalTransport:
     def heartbeat_lease(self, lease_id: str, owner_token: str) -> None:
         raise NotSupportedError("heartbeat_lease() is a cloud-only lease feature.")
 
-    def complete_lease(self, lease_id: str, owner_token: str, reason: str) -> None:
+    def complete_lease(
+        self,
+        lease_id: str,
+        owner_token: str,
+        reason: str,
+        score: Optional[float] = None,
+        result: Any = None,
+    ) -> None:
         raise NotSupportedError("complete_lease() is a cloud-only lease feature.")
+
+    def get_lease(self, lease_id: str) -> "dict[str, Any]":
+        raise NotSupportedError("get_lease() is a cloud-only lease feature.")
 
 
 # ---------------------------------------------------------------------------
@@ -415,6 +449,10 @@ class CloudTransport:
     @property
     def name(self) -> str:
         return self._name
+
+    @property
+    def machine_id(self) -> str:
+        return self._id
 
     def state(self) -> str:
         m = _cloud_fetch(self._base, self._key, "GET", f"/v1/machines/{self._id}")
@@ -619,6 +657,12 @@ class CloudTransport:
     def stop(self) -> None:
         _cloud_fetch(self._base, self._key, "POST", f"/v1/machines/{self._id}/stop")
 
+    def start(self) -> None:
+        # Resume a stopped machine, then wait for its agent so the returned handle
+        # is usable (the control plane returns as soon as it's `started`).
+        _cloud_fetch(self._base, self._key, "POST", f"/v1/machines/{self._id}/start")
+        _wait_for_ready(self._base, self._key, self._id)
+
     def delete(self) -> None:
         _cloud_fetch(self._base, self._key, "DELETE", f"/v1/machines/{self._id}")
 
@@ -738,13 +782,31 @@ class CloudTransport:
             json_body={"ownerToken": owner_token},
         )
 
-    def complete_lease(self, lease_id: str, owner_token: str, reason: str) -> None:
+    def complete_lease(
+        self,
+        lease_id: str,
+        owner_token: str,
+        reason: str,
+        score: Optional[float] = None,
+        result: Any = None,
+    ) -> None:
+        body: dict[str, Any] = {"ownerToken": owner_token, "reason": reason}
+        if score is not None:
+            body["score"] = score
+        if result is not None:
+            body["result"] = result
         _cloud_fetch(
             self._base,
             self._key,
             "POST",
             f"/v1/leases/{lease_id}/complete",
-            json_body={"ownerToken": owner_token, "reason": reason},
+            json_body=body,
+        )
+
+    def get_lease(self, lease_id: str) -> "dict[str, Any]":
+        return (
+            _cloud_fetch(self._base, self._key, "GET", f"/v1/leases/{lease_id}")
+            or {}
         )
 
 

--- a/sdk/python/tests/test_cloud_mock.py
+++ b/sdk/python/tests/test_cloud_mock.py
@@ -160,6 +160,12 @@ class Handler(BaseHTTPRequestHandler):
             )
         if self.path == f"/v1/machines/{CLONE_ID}":
             return self._send(200, json.dumps({"id": CLONE_ID, "state": "started", "ready": True}).encode())
+        # Lease status read (GET /v1/leases/:id) — outcome after completion.
+        if self.path.startswith("/v1/leases/"):
+            return self._send(200, json.dumps({
+                "leaseId": "task-100", "machineId": "mach-ep1", "state": "completed",
+                "reason": "done", "score": 0.9, "result": {"passed": 3},
+            }).encode())
         # Readiness for the assigned episode clone.
         if self.path.startswith("/v1/machines/mach-ep"):
             mid = self.path.rsplit("/", 1)[-1]
@@ -351,6 +357,22 @@ def main() -> int:
               captured.get("complete_body", {}).get("ownerToken") == "tok_secret"
               and captured.get("complete_body", {}).get("reason") == "done",
               str(captured.get("complete_body")))
+
+        # --- Machine.id + Machine.start (resume a stopped machine) ---
+        check("machine exposes its id (mach-…)", m.id == MACHINE_ID, m.id)
+        m.start()  # POST /start + wait-ready (both mocked) — must not raise
+        check("start() resumes a stopped machine without error", True)
+
+        # --- complete with a score/result, read the outcome back via status() ---
+        ep2 = m.assign("task-100")
+        ep2.complete(reason="done", score=0.9, result={"passed": 3})
+        check("complete sent score + result",
+              captured["complete_body"].get("score") == 0.9
+              and captured["complete_body"].get("result") == {"passed": 3},
+              str(captured.get("complete_body")))
+        st = ep2.status()
+        check("status() reads the lease outcome (state + score)",
+              st.get("state") == "completed" and st.get("score") == 0.9, str(st))
 
         # reward_fork: grade in a throwaway clone without touching the original.
         captured["clone_deleted"] = False


### PR DESCRIPTION
Closes two long-standing SDK gaps and completes the episode verify loop. Machine.start() resumes a stopped machine (the endpoint existed but there was no SDK verb, so a parked machine was unresumable — this is a cheap pause/resume since disk state persists), and Machine.id exposes the machine's id right after create()/fork() instead of forcing a tenant-wide list to find it; both land in Python (sync + async) and Node. Episode.complete now takes an optional score and result, and Episode.status() reads a lease's state and outcome back, so a trainer can record and collect the per-task reward. Cloud-only lease reads raise NotSupported on the local target. Covered by the Node and Python cloud-mock suites.