### PR TITLE
Point the client generator at the real repo and fail CI when the client drifts

### DIFF
--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -1,0 +1,131 @@
+name: OpenAPI drift
+
+# Guards the two tracked codegen artifacts against the smolfleet control plane:
+#
+#   sdk/node/openapi/smolfleet.json   (spec snapshot)
+#   sdk/node/generated/smolfleet.ts   (generated types)
+#
+# Both are produced by sdk/node/scripts/gen-openapi.sh from the `smolfleet
+# openapi` subcommand. This job regenerates them and fails if the result differs
+# from what is committed.
+#
+# WHY A SCHEDULE, not just PR triggers: the drift this job exists to catch came
+# from the SERVER, not from this repo — smolfleet renamed /v1/apps/* to
+# /v1/groups/* and the committed client kept the dead paths. A PR trigger here
+# only fires when the SDK changes, so it would never have caught that. The cron
+# is the part that actually closes the hole; the PR trigger just gives fast
+# feedback when someone edits the generator or the artifacts.
+#
+# ACCESS: smol-machines/smolcloud (the control plane) is PRIVATE, so unlike the
+# public smolvm engine the default GITHUB_TOKEN cannot clone it, and fork PRs
+# get no secrets at all. The job therefore needs a PAT in the SMOLCLOUD_TOKEN
+# secret with read access to that repo, and skips loudly (never silently, and
+# never red) when the secret is unavailable.
+
+on:
+  schedule:
+    # 07:00 UTC daily — catches server-side drift with no SDK change involved.
+    - cron: "0 7 * * *"
+  pull_request:
+    paths:
+      - "sdk/node/openapi/**"
+      - "sdk/node/generated/**"
+      - "sdk/node/scripts/gen-openapi.sh"
+      - ".github/workflows/openapi-drift.yml"
+  push:
+    branches: [main]
+    paths:
+      - "sdk/node/openapi/**"
+      - "sdk/node/generated/**"
+      - "sdk/node/scripts/gen-openapi.sh"
+      - ".github/workflows/openapi-drift.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openapi-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    name: Regenerate and compare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # A fork PR (or a repo with the secret unset) cannot reach the private
+      # control plane. Report that as a neutral, visible skip rather than a
+      # failure an outside contributor has no way to fix.
+      - name: Check control-plane access
+        id: access
+        env:
+          SMOLCLOUD_TOKEN: ${{ secrets.SMOLCLOUD_TOKEN }}
+        run: |
+          if [ -n "$SMOLCLOUD_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=OpenAPI drift not checked::SMOLCLOUD_TOKEN is unavailable (fork PR or unset secret), so the generated client was NOT verified against the control plane. A maintainer run on the base repo — or the nightly schedule — covers this."
+          fi
+
+      - name: Checkout smolcloud (control plane)
+        if: steps.access.outputs.available == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: smol-machines/smolcloud
+          token: ${{ secrets.SMOLCLOUD_TOKEN }}
+          path: smolcloud
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.access.outputs.available == 'true'
+
+      - name: Cache cargo
+        if: steps.access.outputs.available == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            smolcloud/target/
+          key: smolfleet-openapi-${{ hashFiles('smolcloud/Cargo.lock') }}
+          restore-keys: smolfleet-openapi-
+
+      # Debug, not release: the emitted spec is identical and this is only a
+      # comparison, so there is no reason to pay for an optimized build.
+      - name: Build smolfleet
+        if: steps.access.outputs.available == 'true'
+        working-directory: smolcloud
+        run: cargo build --bin smolfleet
+
+      - uses: actions/setup-node@v4
+        if: steps.access.outputs.available == 'true'
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: sdk/node/package-lock.json
+
+      - name: Install SDK dependencies
+        if: steps.access.outputs.available == 'true'
+        working-directory: sdk/node
+        run: npm ci
+
+      - name: Regenerate the client
+        if: steps.access.outputs.available == 'true'
+        working-directory: sdk/node
+        env:
+          SMOLFLEET_BIN: ${{ github.workspace }}/smolcloud/target/debug/smolfleet
+        run: npm run gen:openapi
+
+      - name: Fail if the committed client is stale
+        if: steps.access.outputs.available == 'true'
+        run: |
+          if ! git diff --exit-code -- \
+              sdk/node/openapi/smolfleet.json \
+              sdk/node/generated/smolfleet.ts; then
+            echo "::error title=Generated cloud client is stale::sdk/node/openapi/smolfleet.json and/or sdk/node/generated/smolfleet.ts do not match the current smolfleet API. Regenerate with: cd sdk/node && npm run gen:openapi — then commit the result. The diff above is what changed on the server."
+            exit 1
+          fi
+          echo "Generated cloud client matches the control plane."

--- a/sdk/node/scripts/gen-openapi.sh
+++ b/sdk/node/scripts/gen-openapi.sh
@@ -22,18 +22,28 @@ find_bin() {
   if [[ -n "${SMOLFLEET_BIN:-}" && -x "${SMOLFLEET_BIN}" ]]; then
     echo "$SMOLFLEET_BIN"; return
   fi
-  local repo="$SDK_DIR/../../../smolfleet"
-  for prof in release debug; do
-    if [[ -x "$repo/target/$prof/smolfleet" ]]; then
-      echo "$repo/target/$prof/smolfleet"; return
+  # The control plane lives in the `smolcloud` repo; `smolfleet` is the binary
+  # (and the historical repo name). Check both so a checkout under either name
+  # resolves — an unresolvable path here used to fail silently, which is how the
+  # /v1/apps → /v1/groups rename drifted past the committed client.
+  local siblings="$SDK_DIR/../../.."
+  local repos=("$siblings/smolcloud" "$siblings/smolfleet")
+  local repo
+  for repo in "${repos[@]}"; do
+    for prof in release debug; do
+      if [[ -x "$repo/target/$prof/smolfleet" ]]; then
+        echo "$repo/target/$prof/smolfleet"; return
+      fi
+    done
+  done
+  for repo in "${repos[@]}"; do
+    if [[ -d "$repo" ]]; then
+      echo "building smolfleet (debug) in $repo…" >&2
+      (cd "$repo" && cargo build --bin smolfleet >&2)
+      echo "$repo/target/debug/smolfleet"; return
     fi
   done
-  if [[ -d "$repo" ]]; then
-    echo "building smolfleet (debug)…" >&2
-    (cd "$repo" && cargo build --bin smolfleet >&2)
-    echo "$repo/target/debug/smolfleet"; return
-  fi
-  echo "ERROR: smolfleet binary not found. Set SMOLFLEET_BIN or place the repo at $repo" >&2
+  echo "ERROR: smolfleet binary not found. Set SMOLFLEET_BIN, or place the control-plane repo at one of: ${repos[*]}" >&2
   exit 1
 }
 


### PR DESCRIPTION
**161 lines, no generated code.** An earlier version of this PR also regenerated the two codegen artifacts; [#146](https://github.com/smol-machines/smol/pull/146) did that first and did it better, so that half is dropped and only the two hand-written pieces remain: a 30-line fix to `sdk/node/scripts/gen-openapi.sh` and a 131-line CI workflow.

## Why

Two problems sit underneath the drift #146 cleaned up by hand, and both are still here.

**The generator has never been able to find the control plane.** `find_bin` looks in `../../../smolfleet`. That path has never existed. The repo is `smol-machines/smolcloud`; `smolfleet` is the binary it builds. So auto-discovery always failed and `npm run gen:openapi` only worked if you already knew to pass `SMOLFLEET_BIN`.

**Nothing checks the two artifacts against the server they come from.** That is how `/v1/apps` → `/v1/groups` reached the SDK unnoticed: the committed client kept six paths the server no longer served and missed eleven it had gained. #146 fixed the symptom; nothing stops it recurring.

## How

`find_bin` now checks both names, preferring `smolcloud`, and the error names both candidates instead of one that cannot exist.

`openapi-drift.yml` regenerates the artifacts in CI and fails on any diff.

## Alternatives considered

**A `pull_request`-only trigger** would not have caught the original drift. It originates in `smolcloud`, so no SDK PR would fire it. The **nightly schedule** is the actual gate; the PR trigger is only fast feedback for hand-edits.

**Cloning smolcloud with `GITHUB_TOKEN`** does not work. It is private, unlike the public smolvm engine, and fork PRs get no secrets at all. The job reads a `SMOLCLOUD_TOKEN` PAT and, when absent, emits a `::notice` and passes rather than failing red for a contributor who cannot supply one.

> **Needs a maintainer:** add a `SMOLCLOUD_TOKEN` secret (fine-grained PAT on `smol-machines/smolcloud`, Contents: Read). Until then the job skips. A 6-second pass is the skip path, not a verification.

## Validation

Checked against current `main`, not in the abstract:

- Regenerating with `SMOLFLEET_BIN` **unset** resolves `smolcloud` and reproduces **both** committed artifacts **byte for byte** (smolcloud `7553fed`, smol `5270ad3`). So the drift check is **green on arrival**. It is not going to land red.
- The check fails when a rename is reintroduced, and the generator is byte-deterministic across runs, so the nightly will not flap.
- Node `tsc --noEmit` clean; unit 40, cloud-mock 50 pass.

## One thing worth deciding

If the normal rhythm is *change the server, regenerate the client in the same PR an hour later*, which is exactly what #438/#146 did, one minute apart, then a nightly will sometimes be red in the window between them. That is a real cost, and a check that is red half the morning gets muted. Dropping to PR-trigger-only removes the noise but also removes the case this exists to catch. The schedule is one line either way.


