### PR TITLE
Let a cloud command keep running after the terminal goes away

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.7.0"
+version = "1.6.13"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.7.0"
+version = "1.6.13"
 dependencies = [
  "async-stream",
  "axum",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.7.0"
+version = "1.6.13"
 dependencies = [
  "libc",
  "libloading",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.7.0"
+version = "1.6.13"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.7.0"
+version = "1.6.13"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.7.0"
+version = "1.6.13"
 dependencies = [
  "base64",
  "serde",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.7.0"
+version = "1.6.13"
 dependencies = [
  "bytes",
  "dirs",

--- a/build.rs
+++ b/build.rs
@@ -255,7 +255,10 @@ fn link_libkrun() {
             if lib_path.exists() {
                 let canonical = std::fs::canonicalize(dir_str)
                     .unwrap_or_else(|_| std::path::PathBuf::from(dir_str));
-                println!("cargo:warning=Using bundled libkrun from {}", canonical.display());
+                println!(
+                    "cargo:warning=Using bundled libkrun from {}",
+                    canonical.display()
+                );
                 println!("cargo:rustc-link-search=native={}", canonical.display());
                 link_krun();
                 // Relative rpaths for portable distribution layout
@@ -265,7 +268,10 @@ fn link_libkrun() {
                 println!("cargo:rustc-link-arg=-Wl,-rpath,{}", canonical.display());
                 // Embed the lib dir so the launcher can preload libkrunfw at runtime.
                 // This is read by launcher.rs via option_env!("SMOLVM_BUNDLED_LIB_DIR").
-                println!("cargo:rustc-env=SMOLVM_BUNDLED_LIB_DIR={}", canonical.display());
+                println!(
+                    "cargo:rustc-env=SMOLVM_BUNDLED_LIB_DIR={}",
+                    canonical.display()
+                );
                 return;
             }
         }

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -131,7 +131,9 @@ pub async fn device_flow(no_browser: bool) -> Result<TokenResponse> {
         bail!("device authorization failed ({}): {}", status, body);
     }
 
-    let device_auth: DeviceAuthResponse = resp.json().await
+    let device_auth: DeviceAuthResponse = resp
+        .json()
+        .await
         .context("failed to parse device authorization response")?;
 
     // Step 2: Display instructions
@@ -179,7 +181,9 @@ pub async fn device_flow(no_browser: bool) -> Result<TokenResponse> {
             .context("failed to poll token endpoint")?;
 
         if resp.status().is_success() {
-            let token_resp: TokenResponse = resp.json().await
+            let token_resp: TokenResponse = resp
+                .json()
+                .await
                 .context("failed to parse token response")?;
             return Ok(token_resp);
         }
@@ -428,7 +432,10 @@ mod tests {
         apply_refreshed_smolmachines_tokens(&mut settings, &new);
 
         assert_eq!(settings.cloud.api_key.as_deref(), Some("synced_jwt"));
-        assert_eq!(settings.cloud.refresh_token.as_deref(), Some("synced_refresh"));
+        assert_eq!(
+            settings.cloud.refresh_token.as_deref(),
+            Some("synced_refresh")
+        );
         assert!(settings.cloud.token_expires_at.is_some());
 
         let entry = settings

--- a/src/commands/auth_status.rs
+++ b/src/commands/auth_status.rs
@@ -69,7 +69,11 @@ impl AuthStatusCmd {
 
         // API keys are opaque (`smk_…`); a user session is an Auth0 JWT.
         let is_api_key = key.starts_with("smk_");
-        let kind = if is_api_key { "API key" } else { "user session" };
+        let kind = if is_api_key {
+            "API key"
+        } else {
+            "user session"
+        };
 
         match fetch_me(&endpoint, key) {
             Ok(me) => {

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -689,19 +689,22 @@ impl CloudCmd {
                 let machine = a.name.clone().unwrap_or_else(|| "default".to_string());
                 let log = a.log.clone().unwrap_or_else(|| default_log_path(&machine));
                 let log_q = shell_quote(&log);
-                // --follow needs a PTY: tail -f never exits, so without one the
-                // exec would sit on its timeout and print nothing until then.
-                let (program, tty) = if a.follow {
-                    (format!("tail -n {} -f {log_q}", a.tail), true)
+                // --follow streams: `tail -f` never exits, so a buffered exec
+                // would print nothing until its timeout. Use the streaming
+                // transport, NOT the interactive one — the PTY endpoint takes a
+                // single executable and joins argv into it, so a command with
+                // arguments is looked up as one long filename and fails.
+                let program = if a.follow {
+                    format!("tail -n {} -f {log_q}", a.tail)
                 } else {
-                    (format!("cat {log_q}"), false)
+                    format!("cat {log_q}")
                 };
                 crate::commands::exec::ExecCmd {
                     name: a.name,
                     command: vec!["/bin/sh".to_string(), "-c".to_string(), program],
-                    interactive: a.follow,
-                    tty,
-                    stream: false,
+                    interactive: false,
+                    tty: false,
+                    stream: a.follow,
                     env: vec![],
                     workdir: None,
                     secret_env: vec![],

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -482,6 +482,9 @@ pub enum CloudSubcommand {
     /// Scale a machine on smolfleet
     Scale(crate::commands::scale::ScaleCmd),
 
+    /// Read back the output of a detached run (`smol cloud exec --detach`)
+    Logs(CloudLogsArgs),
+
     /// Open an interactive shell on a deployed cloud machine
     #[command(visible_alias = "sh")]
     Shell {
@@ -536,9 +539,12 @@ pub struct CloudExportArgs {
 impl CloudExportArgs {
     /// The machine name, from `-n/--name` or the positional.
     fn machine(&self) -> Result<String> {
-        self.name_flag.clone().or_else(|| self.name.clone()).ok_or_else(|| {
-            anyhow::anyhow!("a machine name is required, e.g. `smol cloud export -n myapp`")
-        })
+        self.name_flag
+            .clone()
+            .or_else(|| self.name.clone())
+            .ok_or_else(|| {
+                anyhow::anyhow!("a machine name is required, e.g. `smol cloud export -n myapp`")
+            })
     }
 }
 
@@ -557,9 +563,12 @@ pub struct CloudShareArgs {
 impl CloudShareArgs {
     /// The machine name, from `-n/--name` or the positional.
     fn machine(&self) -> Result<String> {
-        self.name_flag.clone().or_else(|| self.name.clone()).ok_or_else(|| {
-            anyhow::anyhow!("a machine name is required, e.g. `smol cloud share -n myapp`")
-        })
+        self.name_flag
+            .clone()
+            .or_else(|| self.name.clone())
+            .ok_or_else(|| {
+                anyhow::anyhow!("a machine name is required, e.g. `smol cloud share -n myapp`")
+            })
     }
 }
 
@@ -585,6 +594,73 @@ pub struct CloudExecArgs {
     /// Command timeout in seconds (default 600)
     #[arg(long, value_name = "SECONDS")]
     pub timeout: Option<u64>,
+
+    /// Start the command and return immediately, leaving it running in the
+    /// machine. Its output is appended to a log under /workspace, which
+    /// survives stop/start; read it back with `smol cloud logs`.
+    ///
+    /// Long agent runs are the reason this exists: a detached command keeps
+    /// going when the terminal closes, the network drops, or the laptop
+    /// sleeps, none of which a normal exec survives.
+    #[arg(short = 'd', long)]
+    pub detach: bool,
+
+    /// Log file for a detached run (default: /workspace/.smol/logs/<name>.log).
+    #[arg(long, value_name = "PATH", requires = "detach")]
+    pub log: Option<String>,
+}
+
+/// Arguments for `smol cloud logs` (read back a detached run's output).
+#[derive(Args, Debug)]
+pub struct CloudLogsArgs {
+    /// Machine name (default: "default")
+    #[arg(short = 'n', long, value_name = "NAME")]
+    pub name: Option<String>,
+
+    /// Log file to read (default: /workspace/.smol/logs/<name>.log)
+    #[arg(long, value_name = "PATH")]
+    pub log: Option<String>,
+
+    /// Follow the log as it grows, like `tail -f`. Ctrl-C stops watching; the
+    /// detached command keeps running.
+    #[arg(short = 'f', long)]
+    pub follow: bool,
+
+    /// Show only the last N lines (default 200; ignored with --follow)
+    #[arg(long, value_name = "N", default_value_t = 200)]
+    pub tail: u32,
+}
+
+/// Where a detached run's output goes when `--log` is not given. Under
+/// /workspace so it outlives stop/start — /tmp is a tmpfs and is emptied.
+fn default_log_path(machine: &str) -> String {
+    format!("/workspace/.smol/logs/{machine}.log")
+}
+
+/// Single-quote a string for `sh -c`, so a command carrying spaces, quotes or
+/// globs reaches the guest exactly as typed.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+/// The shell program that starts `command` detached and returns at once.
+///
+/// `setsid` puts it in its own session so it is not in the exec's process
+/// group and cannot be signalled when that connection goes away; stdin is
+/// closed and stdout/stderr are appended to `log` so nothing is written to a
+/// terminal that will not exist. The pid is echoed for the caller to report.
+fn detached_program(command: &[String], log: &str) -> String {
+    let cmd = command
+        .iter()
+        .map(|a| shell_quote(a))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let log_q = shell_quote(log);
+    format!(
+        "mkdir -p \"$(dirname {log_q})\" && \
+         {{ setsid nohup {cmd} >> {log_q} 2>&1 < /dev/null & }} && \
+         echo \"$!\""
+    )
 }
 
 impl CloudCmd {
@@ -609,21 +685,67 @@ impl CloudCmd {
                 local: false,
             }
             .run(),
-            CloudSubcommand::Exec(a) => crate::commands::exec::ExecCmd {
-                name: a.name,
-                command: a.command,
-                interactive: false,
-                tty: false,
-                stream: false,
-                env: a.env,
-                workdir: a.workdir,
-                secret_env: vec![],
-                secret_file: vec![],
-                timeout: a.timeout,
-                cloud: true,
-                local: false,
+            CloudSubcommand::Logs(a) => {
+                let machine = a.name.clone().unwrap_or_else(|| "default".to_string());
+                let log = a.log.clone().unwrap_or_else(|| default_log_path(&machine));
+                let log_q = shell_quote(&log);
+                // --follow needs a PTY: tail -f never exits, so without one the
+                // exec would sit on its timeout and print nothing until then.
+                let (program, tty) = if a.follow {
+                    (format!("tail -n {} -f {log_q}", a.tail), true)
+                } else {
+                    (format!("cat {log_q}"), false)
+                };
+                crate::commands::exec::ExecCmd {
+                    name: a.name,
+                    command: vec!["/bin/sh".to_string(), "-c".to_string(), program],
+                    interactive: a.follow,
+                    tty,
+                    stream: false,
+                    env: vec![],
+                    workdir: None,
+                    secret_env: vec![],
+                    secret_file: vec![],
+                    timeout: None,
+                    cloud: true,
+                    local: false,
+                }
+                .run()
             }
-            .run(),
+            CloudSubcommand::Exec(a) => {
+                let detached = a.detach;
+                let machine = a.name.clone().unwrap_or_else(|| "default".to_string());
+                let log = a.log.clone().unwrap_or_else(|| default_log_path(&machine));
+                let command = if detached {
+                    vec![
+                        "/bin/sh".to_string(),
+                        "-c".to_string(),
+                        detached_program(&a.command, &log),
+                    ]
+                } else {
+                    a.command
+                };
+                let result = crate::commands::exec::ExecCmd {
+                    name: a.name,
+                    command,
+                    interactive: false,
+                    tty: false,
+                    stream: false,
+                    env: a.env,
+                    workdir: a.workdir,
+                    secret_env: vec![],
+                    secret_file: vec![],
+                    timeout: a.timeout,
+                    cloud: true,
+                    local: false,
+                }
+                .run();
+                if detached && result.is_ok() {
+                    eprintln!("detached; output is appended to {log} in the machine");
+                    eprintln!("  follow it:  smol cloud logs -n {machine} --follow");
+                }
+                result
+            }
             CloudSubcommand::Export(a) => export_machine(a),
             CloudSubcommand::Share(a) => share_machine(a),
             CloudSubcommand::Unshare(a) => unshare_machine(a),
@@ -637,36 +759,42 @@ impl CloudCmd {
 /// node build + push the artifact; the bytes never transit the control plane.
 fn export_machine(args: CloudExportArgs) -> Result<()> {
     let tag = args.tag.clone();
-    run_cloud_command(Some(args.machine()?), move |http, endpoint, id| async move {
-        eprintln!("Exporting machine (builds + pushes a .smolmachine; the machine must be stopped)...");
-        let resp = http
-            .post(format!("{}/v1/machines/{}/export", endpoint, id))
-            .json(&serde_json::json!({ "tag": tag }))
-            .send()
-            .await?;
-        let resp = check_response(resp, "export machine").await?;
+    run_cloud_command(
+        Some(args.machine()?),
+        move |http, endpoint, id| async move {
+            eprintln!("Exporting machine (builds + pushes a .smolmachine; the machine must be stopped)...");
+            let resp = http
+                .post(format!("{}/v1/machines/{}/export", endpoint, id))
+                .json(&serde_json::json!({ "tag": tag }))
+                .send()
+                .await?;
+            let resp = check_response(resp, "export machine").await?;
 
-        #[derive(serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct ExportResp {
-            reference: String,
-            digest: String,
-            size_bytes: u64,
-            #[serde(default)]
-            platforms: Vec<String>,
-        }
-        let out: ExportResp = resp.json().await?;
+            #[derive(serde::Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            struct ExportResp {
+                reference: String,
+                digest: String,
+                size_bytes: u64,
+                #[serde(default)]
+                platforms: Vec<String>,
+            }
+            let out: ExportResp = resp.json().await?;
 
-        println!("Exported {}", out.reference);
-        println!("  digest    {}", out.digest);
-        println!("  size      {:.1} MiB", out.size_bytes as f64 / (1024.0 * 1024.0));
-        if !out.platforms.is_empty() {
-            println!("  platforms {}", out.platforms.join(", "));
-        }
-        println!();
-        println!("Re-deploy anywhere:  smol cloud deploy {}", out.reference);
-        Ok(())
-    })
+            println!("Exported {}", out.reference);
+            println!("  digest    {}", out.digest);
+            println!(
+                "  size      {:.1} MiB",
+                out.size_bytes as f64 / (1024.0 * 1024.0)
+            );
+            if !out.platforms.is_empty() {
+                println!("  platforms {}", out.platforms.join(", "));
+            }
+            println!();
+            println!("Re-deploy anywhere:  smol cloud deploy {}", out.reference);
+            Ok(())
+        },
+    )
 }
 
 /// `smol cloud share <machine>` — mint a per-machine anonymous share link. The
@@ -674,49 +802,55 @@ fn export_machine(args: CloudExportArgs) -> Result<()> {
 /// machine's published app without a smolmachines account. Re-running mints a
 /// fresh token (the previous link stops working).
 fn share_machine(args: CloudShareArgs) -> Result<()> {
-    run_cloud_command(Some(args.machine()?), move |http, endpoint, id| async move {
-        let resp = http
-            .post(format!("{}/v1/machines/{}/share", endpoint, id))
-            .send()
-            .await?;
-        let resp = check_response(resp, "share machine").await?;
+    run_cloud_command(
+        Some(args.machine()?),
+        move |http, endpoint, id| async move {
+            let resp = http
+                .post(format!("{}/v1/machines/{}/share", endpoint, id))
+                .send()
+                .await?;
+            let resp = check_response(resp, "share machine").await?;
 
-        #[derive(serde::Deserialize)]
-        struct ShareResp {
-            token: String,
-            #[serde(default)]
-            url: Option<String>,
-        }
-        let out: ShareResp = resp.json().await?;
+            #[derive(serde::Deserialize)]
+            struct ShareResp {
+                token: String,
+                #[serde(default)]
+                url: Option<String>,
+            }
+            let out: ShareResp = resp.json().await?;
 
-        match out.url {
-            Some(url) => {
-                println!("Anonymous share link (anyone with this URL can reach the app):");
-                println!("  {url}");
+            match out.url {
+                Some(url) => {
+                    println!("Anonymous share link (anyone with this URL can reach the app):");
+                    println!("  {url}");
+                }
+                None => {
+                    // No apps domain configured or the name isn't DNS-safe — surface
+                    // the raw token so the caller can still attach it as `?t=`.
+                    println!("Share token minted (attach as `?t=` on the app URL):");
+                    println!("  {}", out.token);
+                }
             }
-            None => {
-                // No apps domain configured or the name isn't DNS-safe — surface
-                // the raw token so the caller can still attach it as `?t=`.
-                println!("Share token minted (attach as `?t=` on the app URL):");
-                println!("  {}", out.token);
-            }
-        }
-        println!();
-        println!("Revoke with:  smol cloud unshare");
-        Ok(())
-    })
+            println!();
+            println!("Revoke with:  smol cloud unshare");
+            Ok(())
+        },
+    )
 }
 
 /// `smol cloud unshare <machine>` — revoke the machine's anonymous share link.
 /// The existing URL immediately stops granting access.
 fn unshare_machine(args: CloudShareArgs) -> Result<()> {
-    run_cloud_command(Some(args.machine()?), move |http, endpoint, id| async move {
-        let resp = http
-            .delete(format!("{}/v1/machines/{}/share", endpoint, id))
-            .send()
-            .await?;
-        check_response(resp, "unshare machine").await?;
-        println!("Share link revoked.");
-        Ok(())
-    })
+    run_cloud_command(
+        Some(args.machine()?),
+        move |http, endpoint, id| async move {
+            let resp = http
+                .delete(format!("{}/v1/machines/{}/share", endpoint, id))
+                .send()
+                .await?;
+            check_response(resp, "unshare machine").await?;
+            println!("Share link revoked.");
+            Ok(())
+        },
+    )
 }

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -725,7 +725,14 @@ impl CloudCmd {
                 } else {
                     a.command
                 };
-                let result = crate::commands::exec::ExecCmd {
+                // Say where the output went BEFORE handing off: `ExecCmd::run`
+                // exits the process with the command's status and never returns,
+                // so anything printed after it would never run.
+                if detached {
+                    eprintln!("detached; output is appended to {log} in the machine");
+                    eprintln!("  follow it:  smol cloud logs -n {machine} --follow");
+                }
+                crate::commands::exec::ExecCmd {
                     name: a.name,
                     command,
                     interactive: false,
@@ -739,12 +746,7 @@ impl CloudCmd {
                     cloud: true,
                     local: false,
                 }
-                .run();
-                if detached && result.is_ok() {
-                    eprintln!("detached; output is appended to {log} in the machine");
-                    eprintln!("  follow it:  smol cloud logs -n {machine} --follow");
-                }
-                result
+                .run()
             }
             CloudSubcommand::Export(a) => export_machine(a),
             CloudSubcommand::Share(a) => share_machine(a),

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -765,7 +765,7 @@ impl CloudCmd {
                     interactive: false,
                     tty: false,
                     stream: false,
-                    env: env,
+                    env,
                     workdir: a.workdir,
                     secret_env: a.secret_env,
                     secret_file: a.secret_file,

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -608,6 +608,19 @@ pub struct CloudExecArgs {
     /// Log file for a detached run (default: /workspace/.smol/logs/<name>.log).
     #[arg(long, value_name = "PATH", requires = "detach")]
     pub log: Option<String>,
+
+    /// Inject a secret from a host env var (GUEST_VAR=HOST_VAR), resolved on
+    /// the host for this run and never persisted. This is how an unattended
+    /// agent gets its API key: `--secret-env ANTHROPIC_API_KEY=ANTHROPIC_API_KEY`.
+    /// A detached command inherits it, so the key is never written to the log
+    /// or stored on the machine.
+    #[arg(long = "secret-env", value_name = "GUEST_VAR=HOST_VAR")]
+    pub secret_env: Vec<String>,
+
+    /// Inject a secret from a host file (GUEST_VAR=/abs/path), resolved on the
+    /// host for this run and never persisted.
+    #[arg(long = "secret-file", value_name = "GUEST_VAR=PATH")]
+    pub secret_file: Vec<String>,
 }
 
 /// Arguments for `smol cloud logs` (read back a detached run's output).
@@ -728,6 +741,17 @@ impl CloudCmd {
                 } else {
                     a.command
                 };
+                // Resolve --secret-env/--secret-file HERE and pass them as this
+                // run's env. The cloud transports do not carry secret refs (only
+                // the local path resolves them downstream), so forwarding the
+                // refs alone would drop them silently — an unattended agent
+                // would start with no key and only fail once it called out.
+                let mut env = a.env;
+                env.extend(
+                    crate::commands::common::resolve_cli_secrets(&a.secret_env, &a.secret_file)?
+                        .into_iter()
+                        .map(|(k, v)| format!("{k}={v}")),
+                );
                 // Say where the output went BEFORE handing off: `ExecCmd::run`
                 // exits the process with the command's status and never returns,
                 // so anything printed after it would never run.
@@ -741,10 +765,10 @@ impl CloudCmd {
                     interactive: false,
                     tty: false,
                     stream: false,
-                    env: a.env,
+                    env: env,
                     workdir: a.workdir,
-                    secret_env: vec![],
-                    secret_file: vec![],
+                    secret_env: a.secret_env,
+                    secret_file: a.secret_file,
                     timeout: a.timeout,
                     cloud: true,
                     local: false,

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -118,21 +118,22 @@ pub fn parse_cli_secret_refs(
     use std::collections::BTreeMap;
 
     let mut refs: BTreeMap<String, SecretRef> = BTreeMap::new();
-    let mut add = |flag: &str, spec: &str, make: &dyn Fn(&str) -> SecretRef| -> anyhow::Result<()> {
-        let (key, value) = spec
-            .split_once('=')
-            .ok_or_else(|| anyhow::anyhow!("{flag}: expected KEY=VALUE, got '{spec}'"))?;
-        if key.is_empty() {
-            anyhow::bail!("{flag}: empty secret name in '{spec}'");
-        }
-        let r = make(value);
-        validate_ref(&r, ResolutionScope::TrustedLocal)
-            .map_err(|e| anyhow::anyhow!("{flag}: secret '{key}': {e}"))?;
-        if refs.insert(key.to_string(), r).is_some() {
-            anyhow::bail!("{flag}: secret '{key}' specified more than once");
-        }
-        Ok(())
-    };
+    let mut add =
+        |flag: &str, spec: &str, make: &dyn Fn(&str) -> SecretRef| -> anyhow::Result<()> {
+            let (key, value) = spec
+                .split_once('=')
+                .ok_or_else(|| anyhow::anyhow!("{flag}: expected KEY=VALUE, got '{spec}'"))?;
+            if key.is_empty() {
+                anyhow::bail!("{flag}: empty secret name in '{spec}'");
+            }
+            let r = make(value);
+            validate_ref(&r, ResolutionScope::TrustedLocal)
+                .map_err(|e| anyhow::anyhow!("{flag}: secret '{key}': {e}"))?;
+            if refs.insert(key.to_string(), r).is_some() {
+                anyhow::bail!("{flag}: secret '{key}' specified more than once");
+            }
+            Ok(())
+        };
     for spec in secret_env {
         add("--secret-env", spec, &|v| env_ref(v))?;
     }
@@ -150,8 +151,10 @@ pub fn resolve_cli_secrets(
     secret_file: &[String],
 ) -> anyhow::Result<Vec<(String, String)>> {
     let refs = parse_cli_secret_refs(secret_env, secret_file)?;
-    let resolved =
-        smolvm::secrets::resolve_refs_to_env(&refs, smolvm::secrets::ResolutionScope::TrustedLocal)?;
+    let resolved = smolvm::secrets::resolve_refs_to_env(
+        &refs,
+        smolvm::secrets::ResolutionScope::TrustedLocal,
+    )?;
     Ok(smolvm::secrets::expose_into_env(resolved))
 }
 
@@ -344,7 +347,9 @@ fn resolve_smolmachines_cloud_token(
     let refresh_token = match &cloud.refresh_token {
         Some(rt) => rt.clone(),
         None => {
-            eprintln!("warning: cloud session is expired. Run `smol auth login` to re-authenticate.");
+            eprintln!(
+                "warning: cloud session is expired. Run `smol auth login` to re-authenticate."
+            );
             return Ok(Some(ResolvedCredential::Identity(token)));
         }
     };
@@ -461,7 +466,10 @@ pub fn ensure_connected(name: &str) -> anyhow::Result<(AgentManager, AgentClient
     let manager = get_manager(name)?;
 
     if manager.try_connect_existing().is_none() {
-        anyhow::bail!("machine '{}' is not running. Use 'smol machine start' first.", name);
+        anyhow::bail!(
+            "machine '{}' is not running. Use 'smol machine start' first.",
+            name
+        );
     }
 
     let socket = manager.vsock_socket();

--- a/src/commands/destroy.rs
+++ b/src/commands/destroy.rs
@@ -32,4 +32,3 @@ impl DestroyCmd {
         })
     }
 }
-

--- a/src/commands/down.rs
+++ b/src/commands/down.rs
@@ -39,7 +39,10 @@ impl DownCmd {
                 println!("Stopped machine: {}", name);
             }
             None => {
-                println!("No machine '{}' found (was it started with 'smol file up'?)", name);
+                println!(
+                    "No machine '{}' found (was it started with 'smol file up'?)",
+                    name
+                );
             }
         }
 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -417,7 +417,8 @@ impl ExecCmd {
                                 exit_code = serde_json::from_str::<serde_json::Value>(&payload)
                                     .ok()
                                     .and_then(|v| v.get("exitCode").and_then(|c| c.as_i64()))
-                                    .unwrap_or(0) as i32;
+                                    .unwrap_or(0)
+                                    as i32;
                             }
                             _ => {}
                         }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -25,7 +25,9 @@ impl InitCmd {
             Some("python") => TEMPLATE_PYTHON.to_string(),
             Some("node") => TEMPLATE_NODE.to_string(),
             Some("go") => TEMPLATE_GO.to_string(),
-            Some(name) => anyhow::bail!("unknown template: '{}'. Available: python, node, go", name),
+            Some(name) => {
+                anyhow::bail!("unknown template: '{}'. Available: python, node, go", name)
+            }
             None => {
                 let image = self.image.as_deref().unwrap_or("alpine");
                 format!(

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -53,9 +53,7 @@ impl LoginCmd {
         let rt = tokio::runtime::Runtime::new()?;
         let token_response = rt.block_on(auth::device_flow(self.no_browser))?;
 
-        let expires_at = token_response
-            .expires_in
-            .map(auth::expires_at_from_now);
+        let expires_at = token_response.expires_in.map(auth::expires_at_from_now);
 
         store_token(
             &registry,
@@ -64,7 +62,6 @@ impl LoginCmd {
             expires_at,
         )
     }
-
 }
 
 fn store_token(
@@ -87,7 +84,9 @@ fn store_token(
         // identity_token (the exchange path), exactly like the silent-refresh
         // path does. Storing it as a direct-bearer password (the old behavior)
         // made every push 401 with zot's opaque "UNSUPPORTED" error.
-        settings.machines.set_identity_token(registry, &access_token);
+        settings
+            .machines
+            .set_identity_token(registry, &access_token);
         if let Some(entry) = settings.machines.registries.get_mut(registry) {
             entry.refresh_token = refresh_token.clone();
             entry.expires_at = expires_at;

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -61,7 +61,9 @@ mod tests {
     fn logged_in_to_cloud() -> SmolSettings {
         let mut settings = SmolSettings::default();
         let registry = smolvm::registry::SMOLMACHINES_REGISTRY;
-        settings.machines.set_identity_token(registry, "access-token");
+        settings
+            .machines
+            .set_identity_token(registry, "access-token");
         settings.cloud.api_key = Some("access-token".to_string());
         settings.cloud.refresh_token = Some("refresh-token".to_string());
         settings.cloud.token_expires_at = Some(1700000000);
@@ -71,7 +73,10 @@ mod tests {
     #[test]
     fn logout_clears_parallel_cloud_session() {
         let mut settings = logged_in_to_cloud();
-        assert!(revoke(&mut settings, smolvm::registry::SMOLMACHINES_REGISTRY));
+        assert!(revoke(
+            &mut settings,
+            smolvm::registry::SMOLMACHINES_REGISTRY
+        ));
         // Both stores must be empty — a lingering refresh token is the bug.
         assert!(!settings
             .machines
@@ -88,7 +93,10 @@ mod tests {
         let mut settings = SmolSettings::default();
         settings.cloud.api_key = Some("access-token".to_string());
         settings.cloud.refresh_token = Some("refresh-token".to_string());
-        assert!(revoke(&mut settings, smolvm::registry::SMOLMACHINES_REGISTRY));
+        assert!(revoke(
+            &mut settings,
+            smolvm::registry::SMOLMACHINES_REGISTRY
+        ));
         assert!(settings.cloud.api_key.is_none());
         assert!(settings.cloud.refresh_token.is_none());
     }
@@ -100,13 +108,19 @@ mod tests {
         assert!(revoke(&mut settings, "ghcr.io"));
         // The cloud session belongs to smolmachines, not GHCR.
         assert_eq!(settings.cloud.api_key.as_deref(), Some("access-token"));
-        assert_eq!(settings.cloud.refresh_token.as_deref(), Some("refresh-token"));
+        assert_eq!(
+            settings.cloud.refresh_token.as_deref(),
+            Some("refresh-token")
+        );
     }
 
     #[test]
     fn logout_when_not_logged_in_reports_nothing_cleared() {
         let mut settings = SmolSettings::default();
-        assert!(!revoke(&mut settings, smolvm::registry::SMOLMACHINES_REGISTRY));
+        assert!(!revoke(
+            &mut settings,
+            smolvm::registry::SMOLMACHINES_REGISTRY
+        ));
         assert!(!revoke(&mut settings, "ghcr.io"));
     }
 }

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -121,10 +121,7 @@ impl LogsCmd {
             // lifecycle feed instead.
             let resp = http
                 .get(format!("{}/v1/machines/{}/logs", endpoint, id))
-                .query(&[
-                    ("follow", follow.to_string()),
-                    ("tail", tail.to_string()),
-                ])
+                .query(&[("follow", follow.to_string()), ("tail", tail.to_string())])
                 .send()
                 .await?;
 
@@ -168,8 +165,14 @@ impl LogsCmd {
                         return Ok(());
                     }
                     for event in &events {
-                        let ts = event.get("createdAt").and_then(|v| v.as_str()).unwrap_or("-");
-                        let level = event.get("level").and_then(|v| v.as_str()).unwrap_or("info");
+                        let ts = event
+                            .get("createdAt")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("-");
+                        let level = event
+                            .get("level")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("info");
                         let msg = event.get("message").and_then(|v| v.as_str()).unwrap_or("");
                         println!("{} [{}] {}", ts, level, msg);
                     }
@@ -196,10 +199,11 @@ fn print_console_line(raw: &str) {
     let payload = line.strip_prefix("data: ").unwrap_or(line);
     if let Ok(v) = serde_json::from_str::<serde_json::Value>(payload) {
         // `message` is either top-level or nested under tracing's `fields`.
-        let msg = v
-            .get("message")
-            .and_then(|m| m.as_str())
-            .or_else(|| v.get("fields").and_then(|f| f.get("message")).and_then(|m| m.as_str()));
+        let msg = v.get("message").and_then(|m| m.as_str()).or_else(|| {
+            v.get("fields")
+                .and_then(|f| f.get("message"))
+                .and_then(|m| m.as_str())
+        });
         if let Some(msg) = msg {
             let ts = v.get("timestamp").and_then(|t| t.as_str());
             let level = v.get("level").and_then(|l| l.as_str()).unwrap_or("INFO");

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -69,7 +69,9 @@ impl LsCmd {
                     id_short,
                     truncate(&m.state, 10),
                     m.cpus.map(|c| c.to_string()).unwrap_or_else(|| "-".into()),
-                    m.memory_mib.map(|mb| format!("{mb} MiB")).unwrap_or_else(|| "-".into()),
+                    m.memory_mib
+                        .map(|mb| format!("{mb} MiB"))
+                        .unwrap_or_else(|| "-".into()),
                     truncate(m.source.as_deref().unwrap_or("-"), 22),
                 );
             }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,5 @@
 pub mod auth;
 pub mod auth_status;
-pub mod machines;
 pub mod cloud;
 pub mod common;
 pub mod config;
@@ -21,6 +20,7 @@ pub mod logout;
 pub mod logs;
 pub mod ls;
 pub mod machine;
+pub mod machines;
 pub mod monitor;
 pub mod pack;
 pub mod prune;

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -217,7 +217,9 @@ impl MonitorCmd {
                 let exit_code = manager.child_pid().and_then(smolvm::process::try_wait);
                 println!(
                     "  machine exited (exit code: {})",
-                    exit_code.map(|c| c.to_string()).unwrap_or_else(|| "unknown".into())
+                    exit_code
+                        .map(|c| c.to_string())
+                        .unwrap_or_else(|| "unknown".into())
                 );
 
                 if let Ok(db) = SmolvmDb::open() {

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -96,7 +96,11 @@ impl PruneCmd {
                 // Bare VM: nothing depends on the cache, so purge all.
                 let total_size: u64 = images.iter().map(|i| i.size).sum();
                 if self.dry_run {
-                    println!("Would remove {} images ({})", images.len(), format_bytes(total_size));
+                    println!(
+                        "Would remove {} images ({})",
+                        images.len(),
+                        format_bytes(total_size)
+                    );
                     for image in &images {
                         println!(
                             "  - {} ({}, {} layers)",
@@ -108,14 +112,21 @@ impl PruneCmd {
                 } else {
                     println!("Removing all cached images...");
                     let freed = client.garbage_collect(false, true)?;
-                    println!("Removed {} images, freed {}", images.len(), format_bytes(freed));
+                    println!(
+                        "Removed {} images, freed {}",
+                        images.len(),
+                        format_bytes(freed)
+                    );
                 }
             }
         } else if self.dry_run {
             println!("Scanning for unreferenced layers...");
             let would_free = client.garbage_collect(true, false)?;
             if would_free > 0 {
-                println!("Would free {} of unreferenced layers", format_bytes(would_free));
+                println!(
+                    "Would free {} of unreferenced layers",
+                    format_bytes(would_free)
+                );
             } else {
                 println!("No unreferenced layers to remove.");
             }

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -118,8 +118,7 @@ fn register_in_catalog(
     // platforms, so a later single-arch push doesn't narrow the catalog entry.
     let (digest, platforms) = rt.block_on(async {
         let (bytes, digest) = reg_client.get_manifest_raw(repo, tag).await?;
-        let platforms =
-            index_platforms(&bytes).unwrap_or_else(|| vec![result.platform.clone()]);
+        let platforms = index_platforms(&bytes).unwrap_or_else(|| vec![result.platform.clone()]);
         anyhow::Ok((digest, platforms))
     })?;
 

--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -99,15 +99,27 @@ struct ParsedRef<'a> {
 /// `mach-` is unambiguously cloud even without a prefix.
 fn parse_ref(reference: &str) -> ParsedRef<'_> {
     if let Some(rest) = reference.strip_prefix("local/") {
-        return ParsedRef { forced: Some(Location::Local), bare: rest };
+        return ParsedRef {
+            forced: Some(Location::Local),
+            bare: rest,
+        };
     }
     if let Some(rest) = reference.strip_prefix("cloud/") {
-        return ParsedRef { forced: Some(Location::Cloud), bare: rest };
+        return ParsedRef {
+            forced: Some(Location::Cloud),
+            bare: rest,
+        };
     }
     if reference.starts_with("mach-") {
-        return ParsedRef { forced: Some(Location::Cloud), bare: reference };
+        return ParsedRef {
+            forced: Some(Location::Cloud),
+            bare: reference,
+        };
     }
-    ParsedRef { forced: None, bare: reference }
+    ParsedRef {
+        forced: None,
+        bare: reference,
+    }
 }
 
 /// Enumerate local machines from the on-disk config. Synchronous, never fails
@@ -197,7 +209,10 @@ pub fn list_all(target: Target) -> Result<Listing> {
         cloud_available = false;
     }
 
-    Ok(Listing { machines, cloud_available })
+    Ok(Listing {
+        machines,
+        cloud_available,
+    })
 }
 
 /// Resolve a user reference to exactly one machine under `target`.
@@ -249,7 +264,10 @@ pub fn resolve(reference: &str, target: Target) -> Result<MachineRef> {
         1 => Ok(hits.pop().unwrap()),
         _ => {
             // Ambiguous only when the hits straddle both backends; qualify.
-            let locals = hits.iter().filter(|m| m.location == Location::Local).count();
+            let locals = hits
+                .iter()
+                .filter(|m| m.location == Location::Local)
+                .count();
             let clouds = hits.len() - locals;
             if locals > 0 && clouds > 0 {
                 bail!(
@@ -473,7 +491,10 @@ mod tests {
             (Location::Cloud, "mach-abc123".to_string())
         );
         // No reference → local default, offline.
-        assert_eq!(locate(None, Target::Auto).unwrap(), (Location::Local, "default".to_string()));
+        assert_eq!(
+            locate(None, Target::Auto).unwrap(),
+            (Location::Local, "default".to_string())
+        );
     }
 
     #[test]
@@ -506,7 +527,10 @@ mod tests {
             (Location::Cloud, "mach-abc123".to_string())
         );
         // No reference → local default, offline.
-        assert_eq!(route(None, Target::Auto).unwrap(), (Location::Local, "default".to_string()));
+        assert_eq!(
+            route(None, Target::Auto).unwrap(),
+            (Location::Local, "default".to_string())
+        );
     }
 
     #[test]

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -200,7 +200,10 @@ impl UpCmd {
                 if let Some(mr) = r.max_retries {
                     record.restart.max_retries = mr;
                 }
-                if let Some(secs) = r.max_backoff.as_deref().and_then(smolfile::parse_duration_secs)
+                if let Some(secs) = r
+                    .max_backoff
+                    .as_deref()
+                    .and_then(smolfile::parse_duration_secs)
                 {
                     record.restart.max_backoff_secs = secs;
                 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -109,7 +109,10 @@ impl UpdateCmd {
                 .ports
                 .iter()
                 .filter(|&&(h, g)| {
-                    !self.remove_port.iter().any(|rm| rm.host == h && rm.guest == g)
+                    !self
+                        .remove_port
+                        .iter()
+                        .any(|rm| rm.host == h && rm.guest == g)
                 })
                 .map(|&(h, g)| PortMapping::new(h, g))
                 .collect();
@@ -121,15 +124,19 @@ impl UpdateCmd {
                     final_ports.push(*p);
                 }
             }
-            PortMapping::check_duplicates(&final_ports)
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            PortMapping::check_duplicates(&final_ports).map_err(|e| anyhow::anyhow!("{e}"))?;
         }
 
         // Expand physical disks before the DB write so a failure leaves the
         // record untouched.
         let mut changes: Vec<String> = Vec::new();
         if self.storage.is_some() || self.overlay.is_some() {
-            changes.extend(expand_disks(&self.name, &record, self.storage, self.overlay)?);
+            changes.extend(expand_disks(
+                &self.name,
+                &record,
+                self.storage,
+                self.overlay,
+            )?);
         }
 
         db.update_vm(&self.name, |r| {
@@ -158,7 +165,11 @@ impl UpdateCmd {
             }
             for m in &new_mounts {
                 let tuple = m.to_storage_tuple();
-                if !r.mounts.iter().any(|(s, t, _)| *s == tuple.0 && *t == tuple.1) {
+                if !r
+                    .mounts
+                    .iter()
+                    .any(|(s, t, _)| *s == tuple.0 && *t == tuple.1)
+                {
                     changes.push(format!(
                         "  added volume: {}:{}{}",
                         tuple.0,
@@ -262,12 +273,16 @@ fn expand_disks(
 
     if let Some(s) = new_storage_gb {
         if s < cur_storage {
-            anyhow::bail!("storage disk cannot be shrunk from {cur_storage} GiB to {s} GiB (expand only)");
+            anyhow::bail!(
+                "storage disk cannot be shrunk from {cur_storage} GiB to {s} GiB (expand only)"
+            );
         }
     }
     if let Some(o) = new_overlay_gb {
         if o < cur_overlay {
-            anyhow::bail!("overlay disk cannot be shrunk from {cur_overlay} GiB to {o} GiB (expand only)");
+            anyhow::bail!(
+                "overlay disk cannot be shrunk from {cur_overlay} GiB to {o} GiB (expand only)"
+            );
         }
     }
 


### PR DESCRIPTION
Adds `smol cloud exec --detach` to start a command that survives a closed terminal or a sleeping laptop, and `smol cloud logs` to read or follow its output.