### PR TITLE
Wire local image forks through the CLI and SDKs

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -119,6 +119,7 @@ jobs:
           unset SMOLVM_BOOT_BINARY SMOLVM_LIB_DIR SMOLVM_AGENT_ROOTFS SMOLVM_AGENT_ROOTFS_TAR LD_LIBRARY_PATH
           bun test/e2e.ts
           bun test/bun-package-e2e.ts
+          bun test/fork-service-e2e.ts
 
   python-check:
     name: Python · unit + cloud-mock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.6.13"
+version = "1.7.5"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.6.13"
+version = "1.7.5"
 dependencies = [
  "async-stream",
  "axum",
@@ -2338,6 +2338,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures-util",
+ "getrandom 0.3.4",
  "hex",
  "humantime",
  "ipnet",
@@ -2349,6 +2350,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "pkg-config",
+ "reqwest",
  "rusqlite",
  "rustls",
  "rustls-pemfile",
@@ -2383,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.6.13"
+version = "1.7.5"
 dependencies = [
  "libc",
  "libloading",
@@ -2391,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.6.13"
+version = "1.7.5"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2404,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.6.13"
+version = "1.7.5"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2423,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.6.13"
+version = "1.7.5"
 dependencies = [
  "base64",
  "serde",
@@ -2433,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.6.13"
+version = "1.7.5"
 dependencies = [
  "bytes",
  "dirs",

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "async-stream",
  "axum",
@@ -2278,6 +2278,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures-util",
+ "getrandom 0.3.4",
  "hex",
  "humantime",
  "ipnet",
@@ -2289,6 +2290,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "pkg-config",
+ "reqwest",
  "rusqlite",
  "rustls",
  "rustls-pemfile",
@@ -2323,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "libc",
  "libloading",
@@ -2331,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2344,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2363,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "base64",
  "serde",
@@ -2373,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "bytes",
  "dirs",

--- a/sdk/node/binding.d.ts
+++ b/sdk/node/binding.d.ts
@@ -20,6 +20,10 @@ export interface MachineConfig {
   name: string
   /** OCI image to boot, when creating an image-backed machine. */
   image?: string
+  /** Environment for the image workload launched at machine start. */
+  env?: Array<EnvVar>
+  /** Working directory for the image workload. */
+  workdir?: string
   /** Host directories to mount into the VM. */
   mounts?: Array<HostMountConfig>
   /** Port mappings from host to guest. */
@@ -35,7 +39,7 @@ export interface HostMountConfig {
   source: string
   /** Absolute path inside the guest. */
   target: string
-  /** Mount as read-only (default: true). */
+  /** Mount as read-only (default: false — writable, matching the CLI). */
   readOnly?: boolean
 }
 /** A port mapping from host to guest. */
@@ -61,7 +65,11 @@ export interface VmResourcesConfig {
   gpu?: boolean
   /** GPU VRAM in MiB (default: engine default when GPU is enabled). */
   gpuVramMib?: number
-  /** Run the guest's unmodified CUDA/PyTorch code on the host's NVIDIA GPU by remoting CUDA calls over vsock (distinct from `gpu`, which is Vulkan). Local target only (default: false). */
+  /**
+   * Run the guest's unmodified CUDA/PyTorch code on the host's NVIDIA GPU by
+   * remoting CUDA calls over vsock (distinct from `gpu`, which is Vulkan; no
+   * CUDA toolkit needed in the image). Local target only (default: false).
+   */
   cuda?: boolean
 }
 /** Options for executing a command. */
@@ -147,6 +155,10 @@ export declare class NapiMachine {
   get isRunning(): boolean
   /** Get the current machine state: "stopped", "starting", "running", or "stopping". */
   state(): string
+  /** Return the host port forwarding to a published guest port. */
+  hostPort(guestPort: number): number | null
+  /** Return every published guest port. */
+  guestPorts(): Array<number>
   /**
    * Start the machine VM. Boots via fork + libkrun, waits for agent ready,
    * then connects the vsock client.

--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -133,18 +133,15 @@ export class Machine {
     return this.transport.waitUntilReady(opts);
   }
 
-  /** An authenticated endpoint (URL + headers) to reach a PUBLISHED guest port
-   *  through the control plane's connect bridge — no Cloudflare/localhost.run
-   *  tunnel, no public exposure, no egress allow-list. Have the in-VM worker
-   *  LISTEN on the port and connect *inbound*: plug `wsUrl` into a WebSocket
-   *  client (passing `headers`) or `httpUrl` into `fetch`. The machine must
-   *  publish the port (`ports: [{ guest }]` at create). (cloud) */
+  /** An endpoint (URL + any required headers) for a PUBLISHED guest port.
+   *  Local machines resolve to their current localhost host-port mapping;
+   *  cloud machines use the authenticated connect bridge. */
   endpoint(port: number, path?: string): PortEndpoint {
     return this.transport.endpoint(port, path);
   }
 
-  /** Convenience: an authenticated HTTP request to a published guest port via
-   *  the connect bridge. Returns the raw `fetch` `Response`. (cloud)
+  /** Convenience HTTP request to a published guest port. Returns the raw
+   *  `fetch` `Response` on local and cloud targets.
    *
    *  @param port  a published GUEST port the in-VM service listens on
    *  @param path  optional path on that service (e.g. `"healthz"`)

--- a/sdk/node/native.ts
+++ b/sdk/node/native.ts
@@ -44,6 +44,8 @@ export interface NativeResources {
 export interface NativeMachineConfig {
   name: string;
   image?: string | undefined;
+  env?: NativeEnvVar[] | undefined;
+  workdir?: string | undefined;
   mounts?: NativeHostMount[] | undefined;
   ports?: NativePortMapping[] | undefined;
   resources?: NativeResources | undefined;
@@ -81,6 +83,8 @@ export interface NapiMachine {
   readonly pid?: number;
   readonly isRunning: boolean;
   state(): string;
+  hostPort(guestPort: number): number | null;
+  guestPorts(): number[];
   start(): Promise<void>;
   startForkable(): Promise<void>;
   fork(name: string, ports?: NativePortMapping[]): Promise<NapiMachine>;

--- a/sdk/node/src/machine.rs
+++ b/sdk/node/src/machine.rs
@@ -75,6 +75,13 @@ impl NapiMachine {
             .map(|r| r.to_vm_resources())
             .unwrap_or_default();
 
+        let env = config
+            .env
+            .unwrap_or_default()
+            .into_iter()
+            .map(|item| (item.key, item.value))
+            .collect();
+        let workdir = config.workdir;
         let spec = MachineSpec {
             name: config.name.clone(),
             mounts,
@@ -85,7 +92,10 @@ impl NapiMachine {
             runtime_managed: false,
         };
 
-        runtime().into_napi()?.create_machine(spec).into_napi()?;
+        runtime()
+            .into_napi()?
+            .create_machine_with_workload(spec, env, workdir)
+            .into_napi()?;
 
         Ok(Self { name: config.name })
     }
@@ -165,6 +175,21 @@ impl NapiMachine {
         runtime()
             .map(|runtime| runtime.state(&self.name))
             .unwrap_or_else(|_| "stopped".to_string())
+    }
+
+    /// Return the host port forwarding to a published guest port.
+    #[napi]
+    pub fn host_port(&self, guest_port: u16) -> napi::Result<Option<u16>> {
+        runtime()
+            .into_napi()?
+            .host_port(&self.name, guest_port)
+            .into_napi()
+    }
+
+    /// Return every published guest port.
+    #[napi]
+    pub fn guest_ports(&self) -> napi::Result<Vec<u16>> {
+        runtime().into_napi()?.guest_ports(&self.name).into_napi()
     }
 
     /// Start the machine VM. Boots via fork + libkrun, waits for agent ready,

--- a/sdk/node/src/types.rs
+++ b/sdk/node/src/types.rs
@@ -34,6 +34,10 @@ pub struct MachineConfig {
     pub name: String,
     /// OCI image to boot, when creating an image-backed machine.
     pub image: Option<String>,
+    /// Environment for the image workload launched at machine start.
+    pub env: Option<Vec<EnvVar>>,
+    /// Working directory for the image workload.
+    pub workdir: Option<String>,
     /// Host directories to mount into the VM.
     pub mounts: Option<Vec<HostMountConfig>>,
     /// Port mappings from host to guest.

--- a/sdk/node/test/fork-service-e2e.ts
+++ b/sdk/node/test/fork-service-e2e.ts
@@ -1,0 +1,90 @@
+/** Real local-service fork smoke test.
+ *
+ * Verifies that an image's default workload starts automatically, local ports
+ * are discoverable, auto-remapped clone ports become ready, and clone execs use
+ * the golden's inherited container overlay while preserving sibling isolation.
+ */
+
+import { createServer } from "node:net";
+import { Machine } from "../index";
+
+async function availablePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to allocate a local port"));
+        return;
+      }
+      const port = address.port;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+  });
+}
+
+async function page(machine: Machine): Promise<string> {
+  const response = await machine.fetch(80);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return await response.text();
+}
+
+async function main(): Promise<void> {
+  const suffix = `${process.pid}-${Date.now()}`;
+  const golden = await Machine.create({
+    name: `sdk-golden-${suffix}`,
+    image: "nginx:1.27-alpine",
+    ports: [{ host: await availablePort(), guest: 80 }],
+    resources: { cpus: 2, memoryMb: 1024, network: true },
+    persistent: true,
+    forkable: true,
+  });
+  const clones: Machine[] = [];
+
+  try {
+    if (!(await page(golden)).includes("Welcome to nginx")) {
+      throw new Error("golden image workload did not serve its default page");
+    }
+    const cloneOne = await golden.fork(`sdk-clone-one-${suffix}`);
+    clones.push(cloneOne);
+    const cloneTwo = await golden.fork(`sdk-clone-two-${suffix}`);
+    clones.push(cloneTwo);
+
+    if (cloneOne.endpoint(80).httpUrl === cloneTwo.endpoint(80).httpUrl) {
+      throw new Error("auto-remapped clones received the same host port");
+    }
+    await cloneOne.writeFile(
+      "/usr/share/nginx/html/index.html",
+      Buffer.from("clone-one"),
+    );
+    if (
+      (await cloneOne.readFile("/usr/share/nginx/html/index.html")).toString() !==
+      "clone-one"
+    ) {
+      throw new Error("clone file APIs did not use the inherited image overlay");
+    }
+
+    if ((await page(cloneOne)).trim() !== "clone-one") {
+      throw new Error("clone file write did not mutate its inherited image overlay");
+    }
+    if (!(await page(cloneTwo)).includes("Welcome to nginx")) {
+      throw new Error("clone overlay mutation leaked into a sibling");
+    }
+    await cloneTwo.stop();
+    await cloneTwo.start();
+    if (!(await page(cloneTwo)).includes("Welcome to nginx")) {
+      throw new Error("image workload did not relaunch after clone restart");
+    }
+    console.log("fork-service-e2e: passed");
+  } finally {
+    await Promise.allSettled(clones.map((clone) => clone.delete()));
+    await golden.delete();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/sdk/node/test/unit.ts
+++ b/sdk/node/test/unit.ts
@@ -90,6 +90,15 @@ check('omits the base image when unset', () => {
   const cfg = toNativeConfig('m', {});
   assert.strictEqual(cfg.image, undefined);
 });
+check('forwards image workload env and workdir to the local engine', () => {
+  const cfg = toNativeConfig('m', {
+    image: 'example/service:latest',
+    env: { SESSION: 'golden' },
+    workdir: '/workspace',
+  });
+  assert.deepStrictEqual(cfg.env, [{ key: 'SESSION', value: 'golden' }]);
+  assert.strictEqual(cfg.workdir, '/workspace');
+});
 
 check('rollout adapter digest matches the engine contract', () => {
   const dir = mkdtempSync(join(tmpdir(), 'smol-rollout-unit-'));

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -8,6 +8,7 @@
  */
 
 import { readFileSync } from "node:fs";
+import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
@@ -136,6 +137,32 @@ function resolveBatchNames(
   return Array.from({ length: count }, (_, i) => `${prefix}-${i + 1}`);
 }
 
+function localTcpReady(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host: "127.0.0.1", port });
+    let settled = false;
+    let connected = false;
+    const finish = (ready: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(ready);
+    };
+    socket.setTimeout(250);
+    socket.once("timeout", () => finish(connected));
+    // The host forwarder listens before the guest service does, so a completed
+    // host connect alone is a false-positive: the relay immediately resets it
+    // when nothing is bound in the guest. A connection that remains stable for
+    // this short window proves the guest listener is actually accepting.
+    socket.once("connect", () => {
+      connected = true;
+      socket.setTimeout(100);
+      socket.once("close", () => finish(false));
+    });
+    socket.once("error", () => finish(false));
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
@@ -202,6 +229,10 @@ export function toNativeConfig(
   return {
     name,
     image: config.image,
+    env:
+      config.env &&
+      Object.entries(config.env).map(([key, value]) => ({ key, value })),
+    workdir: config.workdir,
     persistent: config.persistent,
     mounts: config.mounts?.map((m) => ({
       source: m.source,
@@ -281,8 +312,15 @@ class LocalTransport implements Transport {
   }
 
   async ready(): Promise<boolean> {
-    // A local machine is created already started; "running" means usable.
-    return (await this.inner.state()) === "running";
+    if ((await this.inner.state()) !== "running") return false;
+    const mappings = this.inner
+      .guestPorts()
+      .map((guest) => this.inner.hostPort(guest));
+    if (mappings.some((host) => host == null)) return false;
+    const ready = await Promise.all(
+      mappings.map((host) => localTcpReady(host as number)),
+    );
+    return ready.every(Boolean);
   }
 
   async readyAt(): Promise<string | null> {
@@ -290,15 +328,33 @@ class LocalTransport implements Transport {
     return null;
   }
 
-  async waitUntilReady(_opts?: WaitReadyOptions): Promise<void> {
-    // Local create()/start() awaits the boot, so the machine is already ready.
+  async waitUntilReady(opts?: WaitReadyOptions): Promise<void> {
+    const timeoutMs = opts?.timeoutMs ?? 120_000;
+    const intervalMs = opts?.intervalMs ?? 1_000;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() <= deadline) {
+      if (await this.ready()) return;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    throw new SmolError(
+      "TIMEOUT",
+      `machine '${this.name}' did not become ready within ${timeoutMs}ms`,
+    );
   }
 
-  endpoint(_port: number, _path?: string): PortEndpoint {
-    throw new NotSupportedError(
-      "endpoint() is a cloud connect-bridge feature; the local target has no " +
-        "control plane. Publish a port and reach it on the host directly.",
-    );
+  endpoint(port: number, path = ""): PortEndpoint {
+    const hostPort = this.inner.hostPort(port);
+    if (hostPort == null) {
+      throw new InvalidConfigError(
+        `guest port ${port} is not published by local machine '${this.name}'`,
+      );
+    }
+    const suffix = path ? `/${path.replace(/^\/+/, "")}` : "";
+    return {
+      httpUrl: `http://127.0.0.1:${hostPort}${suffix}`,
+      wsUrl: `ws://127.0.0.1:${hostPort}${suffix}`,
+      headers: {},
+    };
   }
 
   async url(): Promise<string | null> {
@@ -405,6 +461,7 @@ class LocalTransport implements Transport {
       throw wrapNativeError(e);
     }
     liveLocal.add(this);
+    await this.waitUntilReady();
   }
 
   async delete(): Promise<void> {
@@ -423,10 +480,13 @@ class LocalTransport implements Transport {
       host: p.host,
       guest: p.guest,
     }));
+    let clone: LocalTransport | undefined;
     try {
-      const cloneInner = await this.inner.fork(name, nativePorts);
-      return new LocalTransport(cloneInner); // ctor registers for cleanup
+      clone = new LocalTransport(await this.inner.fork(name, nativePorts));
+      await clone.waitUntilReady();
+      return clone; // ctor registers for cleanup
     } catch (e) {
+      await clone?.delete().catch(() => {});
       throw wrapNativeError(e);
     }
   }
@@ -1279,23 +1339,13 @@ export async function makeTransport(
     return new CloudTransport(cloudConn, name, id);
   }
 
-  // Local embedded engine.
-  // Machine-level env/workdir configure the machine's WORKLOAD (init commands
-  // and the image entrypoint) — a cloud concept; the embedded engine runs no
-  // workload at create, and its create spec has no field for them. Reject
-  // rather than silently drop (mirrors the mounts-on-cloud gate above).
-  if (
-    (config.env && Object.keys(config.env).length) ||
-    config.workdir !== undefined
-  ) {
-    throw new NotSupportedError(
-      "machine-level env/workdir apply to the machine's workload and are cloud-only; " +
-        "on the local target pass { env, workdir } per exec instead.",
-    );
-  }
+  // Local embedded engine. Image machines launch their default workload before
+  // create resolves, with env/workdir applied just like the cloud target.
   const name = config.name ?? generateName();
+  let transport: LocalTransport | undefined;
   try {
     const inner = new (getNapiMachine())(toNativeConfig(name, config));
+    transport = new LocalTransport(inner);
     // A forkable golden boots with memfd-backed guest RAM + a control socket so
     // it can be cloned with Machine.fork (local live-RAM fork).
     if (config.forkable) {
@@ -1303,8 +1353,10 @@ export async function makeTransport(
     } else {
       await inner.start();
     }
-    return new LocalTransport(inner);
+    await transport.waitUntilReady();
+    return transport;
   } catch (e) {
+    await transport?.delete().catch(() => {});
     throw wrapNativeError(e);
   }
 }
@@ -1326,7 +1378,9 @@ export async function connectTransport(
   if (!useCloud) {
     // Local: start-or-reconnect to the named machine via the native engine.
     try {
-      return new LocalTransport(getNapiMachine().connect(id));
+      const transport = new LocalTransport(getNapiMachine().connect(id));
+      await transport.waitUntilReady();
+      return transport;
     } catch (e) {
       throw wrapNativeError(e);
     }

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -125,11 +125,10 @@ export interface MachineConfig {
   /** Start as a live-RAM fork base (cloud) so the machine can be cloned with
    *  `Machine.fork`. The golden and its clones are pinned to one node. */
   forkable?: boolean;
-  /** Environment variables for the machine's workload (init commands and the
-   *  entrypoint), set at create. (cloud) */
+  /** Environment variables for the image workload launched at create. */
   env?: Record<string, string>;
-  /** Working directory for the machine's workload, set at create. Overrides
-   *  the image's own workdir. (cloud) */
+  /** Working directory for the image workload, set at create. Overrides
+   *  the image's own workdir. */
   workdir?: string;
 }
 
@@ -200,10 +199,9 @@ export interface WaitReadyOptions {
   intervalMs?: number;
 }
 
-/** An authenticated way to reach a PUBLISHED guest port through the control
- *  plane's connect bridge — no tunnel, no public exposure. Returned by
- *  `Machine.endpoint(port)`. Plug `wsUrl` into a WebSocket client or `httpUrl`
- *  into `fetch`, passing `headers` so the request authenticates. */
+/** A way to reach a PUBLISHED guest port. Local endpoints use the current
+ *  localhost host-port mapping; cloud endpoints use the authenticated connect
+ *  bridge. */
 export interface PortEndpoint {
   /** `https://…/v1/machines/:id/connect/:port[/path]` — for HTTP requests. */
   httpUrl: string;

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "async-stream",
  "axum",
@@ -2278,6 +2278,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures-util",
+ "getrandom 0.3.4",
  "hex",
  "humantime",
  "ipnet",
@@ -2289,6 +2290,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "pkg-config",
+ "reqwest",
  "rusqlite",
  "rustls",
  "rustls-pemfile",
@@ -2323,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "libc",
  "libloading",
@@ -2331,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2344,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2363,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "base64",
  "serde",
@@ -2373,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.7.0"
+version = "1.7.5"
 dependencies = [
  "bytes",
  "dirs",

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -17,6 +17,7 @@ import atexit
 import base64
 import json
 import os
+import socket
 import time
 import urllib.error
 import urllib.request
@@ -166,6 +167,10 @@ def _native_config(name: str, config: MachineConfig) -> dict:
     cfg: dict[str, Any] = {"name": name, "persistent": config.persistent}
     if config.image is not None:
         cfg["image"] = config.image
+    if config.env:
+        cfg["env"] = dict(config.env)
+    if config.workdir is not None:
+        cfg["workdir"] = config.workdir
     if config.mounts:
         cfg["mounts"] = [
             {"source": m.source, "target": m.target, "read_only": m.effective_read_only}
@@ -253,21 +258,52 @@ class LocalTransport:
         return str(self._inner.state())
 
     def ready(self) -> bool:
-        # A local machine is created already started; "running" means usable.
-        return str(self._inner.state()) == "running"
+        if str(self._inner.state()) != "running":
+            return False
+        for guest_port in self._inner.guest_ports():
+            host_port = self._inner.host_port(guest_port)
+            if host_port is None:
+                return False
+            try:
+                with socket.create_connection(("127.0.0.1", host_port), timeout=0.25) as probe:
+                    # The host forwarder accepts before a guest listener exists.
+                    # An unavailable guest immediately resets/closes the relay;
+                    # a connection stable for 100ms proves it is really ready.
+                    probe.settimeout(0.1)
+                    try:
+                        if probe.recv(1, socket.MSG_PEEK) == b"":
+                            return False
+                    except TimeoutError:
+                        pass
+            except OSError:
+                return False
+        return True
 
     def ready_at(self) -> Optional[str]:
         # No readiness timestamp for the embedded engine.
         return None
 
     def wait_until_ready(self, timeout_s: float = 120.0, interval_s: float = 1.0) -> None:
-        # Local create()/start() blocks on the boot, so it is already ready.
-        return None
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() <= deadline:
+            if self.ready():
+                return
+            time.sleep(interval_s)
+        raise SmolError(
+            "TIMEOUT", f"machine '{self.name}' did not become ready within {timeout_s:g}s"
+        )
 
     def endpoint(self, port: int, path: Optional[str] = None) -> PortEndpoint:
-        raise NotSupportedError(
-            "endpoint() is a cloud connect-bridge feature; the local target has "
-            "no control plane. Publish a port and reach it on the host directly."
+        host_port = self._inner.host_port(port)
+        if host_port is None:
+            raise InvalidConfigError(
+                f"guest port {port} is not published by local machine '{self.name}'"
+            )
+        suffix = f"/{(path or '').lstrip('/')}" if path else ""
+        return PortEndpoint(
+            http_url=f"http://127.0.0.1:{host_port}{suffix}",
+            ws_url=f"ws://127.0.0.1:{host_port}{suffix}",
+            headers={},
         )
 
     def request(
@@ -278,10 +314,13 @@ class LocalTransport:
         data: Optional[bytes] = None,
         timeout_s: float = CLOUD_TIMEOUT_S,
     ) -> bytes:
-        raise NotSupportedError(
-            "request() is a cloud connect-bridge feature; the local target has "
-            "no control plane. Publish a port and reach it on the host directly."
-        )
+        ep = self.endpoint(port, path)
+        request = urllib.request.Request(ep.http_url, data=data, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=timeout_s) as response:
+                return response.read()
+        except (urllib.error.URLError, OSError) as error:
+            raise SmolError("NETWORK_ERROR", str(error)) from error
 
     def url(self) -> Optional[str]:
         # Local machines have no public ingress URL — that's a cloud feature.
@@ -359,6 +398,7 @@ class LocalTransport:
         except Exception as e:  # noqa: BLE001
             raise wrap_native_error(e) from e
         _live_local.add(self)
+        self.wait_until_ready()
 
     def delete(self) -> None:
         _live_local.discard(self)
@@ -376,7 +416,16 @@ class LocalTransport:
         except Exception as e:  # noqa: BLE001
             raise wrap_native_error(e) from e
         # LocalTransport.__init__ registers the clone for atexit cleanup.
-        return LocalTransport(clone_inner)
+        clone = LocalTransport(clone_inner)
+        try:
+            clone.wait_until_ready()
+        except BaseException:
+            try:
+                clone.delete()
+            except Exception:  # noqa: BLE001 - preserve the readiness failure
+                pass
+            raise
+        return clone
 
     def fork_batch(
         self,
@@ -1185,30 +1234,31 @@ def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None)
             raise
         return CloudTransport(base_url, api_key, machine_id, name)
 
-    # Local embedded engine via the native extension.
-    # Machine-level env/workdir configure the machine's WORKLOAD (init commands
-    # and the image entrypoint) — a cloud concept; the embedded engine runs no
-    # workload at create, and its create spec has no field for them. Reject
-    # rather than silently drop (mirrors the mounts-on-cloud gate above).
-    if config.env or config.workdir is not None:
-        raise NotSupportedError(
-            "machine-level env/workdir apply to the machine's workload and are "
-            "cloud-only; on the local target pass ExecOptions(env=..., "
-            "workdir=...) per command instead."
-        )
+    # Local embedded engine. Image machines launch their default workload before
+    # create returns, with env/workdir applied just like the cloud target.
     native = _load_native()
     name = config.name or _generate_name()
+    transport: Optional[LocalTransport] = None
     try:
         inner = native.Machine(_native_config(name, config))
+        transport = LocalTransport(inner)
         # A forkable golden boots with memfd-backed guest RAM + a control socket
         # so it can be cloned with Machine.fork (local live-RAM fork).
         if config.forkable:
             inner.start_forkable()
         else:
             inner.start()
-    except Exception as e:  # noqa: BLE001
-        raise wrap_native_error(e) from e
-    return LocalTransport(inner)
+        transport.wait_until_ready()
+        return transport
+    except BaseException as e:
+        if transport is not None:
+            try:
+                transport.delete()
+            except Exception:  # noqa: BLE001 - preserve the start/readiness failure
+                pass
+        if isinstance(e, Exception):
+            raise wrap_native_error(e) from e
+        raise
 
 
 def connect_transport(machine_id: str, conn: Optional[ConnectOptions] = None) -> Transport:
@@ -1226,7 +1276,9 @@ def connect_transport(machine_id: str, conn: Optional[ConnectOptions] = None) ->
         # Local: start-or-reconnect to the named machine via the native engine.
         native = _load_native()
         try:
-            return LocalTransport(native.Machine.connect(machine_id))
+            transport = LocalTransport(native.Machine.connect(machine_id))
+            transport.wait_until_ready()
+            return transport
         except Exception as e:  # noqa: BLE001
             raise wrap_native_error(e) from e
     # As in make_transport: the CLI-login fallback applies only once the cloud

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -100,11 +100,10 @@ class MachineConfig:
     """Start as a live-RAM fork base (cloud) so the machine can be cloned with
     :meth:`Machine.fork`. The golden and its clones are pinned to one node."""
     env: Optional[dict[str, str]] = None
-    """Environment variables for the machine's workload (init commands and the
-    entrypoint), set at create. Cloud target only."""
+    """Environment variables for the image workload launched at create."""
     workdir: Optional[str] = None
-    """Working directory for the machine's workload, set at create. Overrides
-    the image's own workdir. Cloud target only."""
+    """Working directory for the image workload, set at create. Overrides the
+    image's own workdir."""
 
 
 @dataclass
@@ -178,10 +177,8 @@ class ConnectOptions:
 
 @dataclass
 class PortEndpoint:
-    """An authenticated way to reach a PUBLISHED guest port through the control
-    plane's connect bridge — no tunnel, no public exposure. Returned by
-    :meth:`Machine.endpoint`. Plug ``ws_url`` into a WebSocket client or
-    ``http_url`` into an HTTP client, sending ``headers`` so it authenticates."""
+    """A way to reach a PUBLISHED guest port. Local endpoints use the current
+    localhost host-port mapping; cloud endpoints use the authenticated bridge."""
 
     http_url: str
     """``https://…/v1/machines/:id/connect/:port[/path]`` — for HTTP requests."""

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -352,6 +352,21 @@ impl Machine {
             }
         }
 
+        let mut env = Vec::new();
+        if let Some(value) = config.get_item("env")? {
+            if !value.is_none() {
+                let values = value.downcast::<PyDict>()?;
+                for (key, value) in values.iter() {
+                    env.push((key.extract()?, value.extract()?));
+                }
+            }
+        }
+        let workdir = config
+            .get_item("workdir")?
+            .filter(|value| !value.is_none())
+            .map(|value| value.extract())
+            .transpose()?;
+
         let spec = MachineSpec {
             name: name.clone(),
             mounts,
@@ -361,7 +376,10 @@ impl Machine {
             persistent,
             runtime_managed: false,
         };
-        runtime().map_err(err)?.create_machine(spec).map_err(err)?;
+        runtime()
+            .map_err(err)?
+            .create_machine_with_workload(spec, env, workdir)
+            .map_err(err)?;
         Ok(Self { name })
     }
 
@@ -381,6 +399,17 @@ impl Machine {
 
     fn state(&self) -> PyResult<String> {
         Ok(runtime().map_err(err)?.state(&self.name))
+    }
+
+    fn host_port(&self, guest_port: u16) -> PyResult<Option<u16>> {
+        runtime()
+            .map_err(err)?
+            .host_port(&self.name, guest_port)
+            .map_err(err)
+    }
+
+    fn guest_ports(&self) -> PyResult<Vec<u16>> {
+        runtime().map_err(err)?.guest_ports(&self.name).map_err(err)
     }
 
     fn start(&self) -> PyResult<()> {

--- a/sdk/python/tests/test_fork_service_e2e.py
+++ b/sdk/python/tests/test_fork_service_e2e.py
@@ -1,0 +1,49 @@
+"""Real local image-workload and fork smoke test."""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+
+from smol import Machine, MachineConfig, PortSpec, ResourceSpec
+
+
+def available_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def test_forked_image_workload_ports_and_overlays() -> None:
+    suffix = f"{os.getpid()}-{time.time_ns()}"
+    golden = Machine.create(
+        MachineConfig(
+            name=f"py-golden-{suffix}",
+            image="nginx:1.27-alpine",
+            ports=[PortSpec(host=available_port(), guest=80)],
+            resources=ResourceSpec(cpus=2, memory_mb=1024, network=True),
+            persistent=True,
+            forkable=True,
+        )
+    )
+    clones: list[Machine] = []
+    try:
+        assert b"Welcome to nginx" in golden.request(80)
+        first = golden.fork(f"py-clone-one-{suffix}")
+        clones.append(first)
+        second = golden.fork(f"py-clone-two-{suffix}")
+        clones.append(second)
+
+        assert first.endpoint(80).http_url != second.endpoint(80).http_url
+        first.write_file("/usr/share/nginx/html/index.html", b"clone-one")
+        assert first.read_file("/usr/share/nginx/html/index.html") == b"clone-one"
+        assert first.request(80).strip() == b"clone-one"
+        assert b"Welcome to nginx" in second.request(80)
+        second.stop()
+        second.start()
+        assert b"Welcome to nginx" in second.request(80)
+    finally:
+        for clone in clones:
+            clone.delete()
+        golden.delete()

--- a/sdk/python/tests/test_unit.py
+++ b/sdk/python/tests/test_unit.py
@@ -144,6 +144,17 @@ def test_native_config_omits_image_when_unset():
     assert "image" not in _native_config("m", MachineConfig())
 
 
+def test_native_config_forwards_image_workload_env_and_workdir():
+    cfg = MachineConfig(
+        image="example/service:latest",
+        env={"SESSION": "golden"},
+        workdir="/workspace",
+    )
+    native = _native_config("m", cfg)
+    assert native["env"] == {"SESSION": "golden"}
+    assert native["workdir"] == "/workspace"
+
+
 def test_rollout_adapter_digest_matches_engine_contract():
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)

--- a/src/commands/cp.rs
+++ b/src/commands/cp.rs
@@ -9,6 +9,7 @@
 
 use super::{cloud, common};
 use clap::Args;
+use smolvm::agent::RunConfig;
 
 #[derive(Args, Debug)]
 pub struct CpCmd {
@@ -60,6 +61,26 @@ impl CpCmd {
 
         let (manager, mut client) = common::ensure_connected(&handle)?;
         manager.detach();
+
+        // Image machines expose their container rootfs through a persistent
+        // overlay. A fork clone inherits that overlay from its golden, so enter
+        // the inherited owner before file operations instead of addressing a
+        // new, empty overlay under the clone's name. A no-op container run both
+        // mounts the overlay and makes it active for the subsequent file RPCs.
+        if let Some(record) = smolvm::db::SmolvmDb::open()
+            .ok()
+            .and_then(|db| db.get_vm(&handle).ok().flatten())
+        {
+            if let Some(image) = record.image.as_ref() {
+                let owner =
+                    smolvm::workload::persistent_overlay_owner(&handle, record.golden.as_deref());
+                client.run_non_interactive(
+                    RunConfig::new(image, vec!["/bin/true".to_string()])
+                        .with_persistent_overlay(Some(owner)),
+                )?;
+            }
+        }
+
         if is_upload {
             // Stream the file in chunks so large files don't get read entirely
             // into memory or exceed the protocol frame cap.

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -6,6 +6,16 @@ use smolvm::agent::{AgentManager, ExecEvent, RunConfig};
 use smolvm::db::SmolvmDb;
 use std::time::Duration;
 
+fn persistent_overlay_owner(
+    machine_name: &str,
+    record: Option<&smolvm::config::VmRecord>,
+) -> String {
+    smolvm::workload::persistent_overlay_owner(
+        machine_name,
+        record.and_then(|record| record.golden.as_deref()),
+    )
+}
+
 /// Windows stand-in for a SIGWINCH stream: `recv()` never completes, so the
 /// terminal-resize select arm stays inert (Windows has no resize signal).
 #[cfg(not(unix))]
@@ -139,6 +149,7 @@ impl ExecCmd {
         // Computed before the streaming branch so streamed execs on an image
         // machine also run in the persistent container overlay (see below).
         let record_image = record.as_ref().and_then(|r| r.image.clone());
+        let overlay_owner = persistent_overlay_owner(&name, record.as_ref());
 
         // Bind each of the machine's mounts into the exec's container:
         // (tag, guest_target, read_only), tag `smolvm{i}` in the VM's virtiofs
@@ -195,7 +206,7 @@ impl ExecCmd {
                     .with_workdir(self.workdir.clone())
                     .with_timeout(timeout)
                     .with_mounts(mount_bindings.clone())
-                    .with_persistent_overlay(Some(name.clone()));
+                    .with_persistent_overlay(Some(overlay_owner.clone()));
                 client.run_streaming_with(config, on_event)?;
             } else {
                 // Bare VM: stream directly against the guest.
@@ -217,7 +228,7 @@ impl ExecCmd {
                     .with_timeout(timeout)
                     .with_tty(self.tty)
                     .with_mounts(mount_bindings.clone())
-                    .with_persistent_overlay(Some(name.clone()));
+                    .with_persistent_overlay(Some(overlay_owner.clone()));
                 let exit_code = client.run_interactive(config)?;
                 manager.detach();
                 std::process::exit(exit_code);
@@ -228,7 +239,7 @@ impl ExecCmd {
                 .with_workdir(self.workdir.clone())
                 .with_timeout(timeout)
                 .with_mounts(mount_bindings)
-                .with_persistent_overlay(Some(name.clone()));
+                .with_persistent_overlay(Some(overlay_owner));
             let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
             print_and_exit(
                 &manager,
@@ -614,7 +625,7 @@ fn exec_exit_code(result: &serde_json::Value) -> i32 {
 
 #[cfg(test)]
 mod exec_exit_code_tests {
-    use super::exec_exit_code;
+    use super::{exec_exit_code, persistent_overlay_owner};
     use serde_json::json;
 
     #[test]
@@ -630,5 +641,15 @@ mod exec_exit_code_tests {
         // GAP3 fix (was unwrap_or(1), breaking $? on a succeeding command).
         assert_eq!(exec_exit_code(&json!({"stdout": "ok\n"})), 0);
         assert_eq!(exec_exit_code(&json!({})), 0);
+    }
+
+    #[test]
+    fn clone_exec_uses_the_inherited_golden_overlay() {
+        let mut record =
+            smolvm::config::VmRecord::new("clone".into(), 1, 512, vec![], vec![], false);
+        record.golden = Some("golden".into());
+
+        assert_eq!(persistent_overlay_owner("clone", Some(&record)), "golden");
+        assert_eq!(persistent_overlay_owner("ordinary", None), "ordinary");
     }
 }

--- a/src/commands/fork.rs
+++ b/src/commands/fork.rs
@@ -1,20 +1,7 @@
 //! smol machine fork — clone a running, forkable machine (copy-on-write RAM + disks).
-//!
-//! Mirrors the engine's `machine fork` (src/cli/vm_common.rs::fork_vm) over the
-//! public `smolvm` library, matching smol's existing pattern of reimplementing
-//! engine flows rather than calling binary-internal helpers. The golden must
-//! have been started forkable (`smol machine start --forkable`), which leaves a control
-//! socket the engine uses to freeze it and write a snapshot.
 
 use clap::Args;
-use smolvm::agent::{resolve_disk_image, vm_data_dir, AgentClient, AgentManager, LaunchFeatures};
-use smolvm::config::RecordState;
 use smolvm::data::network::PortMapping;
-use smolvm::db::SmolvmDb;
-use smolvm::platform::uds::UdsStream;
-use std::io::{Read, Write};
-use std::path::Path;
-use std::time::Duration;
 
 #[derive(Args, Debug)]
 pub struct ForkCmd {
@@ -35,9 +22,7 @@ pub struct ForkCmd {
     #[arg(short = 'p', long = "port", value_parser = PortMapping::parse, value_name = "HOST:GUEST")]
     pub port: Vec<PortMapping>,
 
-    /// Fork on the cloud control plane (live-RAM CoW clone on the golden's node)
-    /// instead of locally. The golden must have been started `--forkable --cloud`.
-    /// Usually unnecessary — the golden's location is resolved automatically.
+    /// Fork on the cloud control plane instead of locally.
     #[arg(long)]
     pub cloud: bool,
 
@@ -46,34 +31,38 @@ pub struct ForkCmd {
     pub local: bool,
 
     /// Share the golden's loaded CUDA weights with this clone instead of
-    /// copying them — sibling clones then keep ONE copy of the base model in
-    /// VRAM. Correct when the base stays frozen (LoRA/QLoRA fine-tuning,
-    /// inference); use a plain fork when the clone trains the base weights.
+    /// copying them. Use only when base weights remain frozen.
     #[arg(long)]
     pub share_weights: bool,
+}
+
+fn cloud_fork_body(
+    clone_name: &str,
+    ports: &[PortMapping],
+    share_weights: bool,
+) -> serde_json::Value {
+    let ports: Vec<serde_json::Value> = ports
+        .iter()
+        .map(|port| serde_json::json!({ "port": port.guest, "hostPort": port.host }))
+        .collect();
+    serde_json::json!({
+        "name": clone_name,
+        "ports": ports,
+        "shareWeights": share_weights,
+    })
 }
 
 impl ForkCmd {
     pub fn run(mut self) -> anyhow::Result<()> {
         use super::resolve::{self, Location, Target};
 
-        // The clone lands wherever its golden lives: resolve the golden's
-        // location (+ optional --local/--cloud), then route.
         let target = Target::from_flags(self.local, self.cloud)?;
         let (location, golden_handle) = resolve::route(Some(&self.golden), target)?;
+        self.golden = golden_handle;
         if location == Location::Cloud {
             return self.run_cloud();
         }
-        // Use the prefix-stripped handle as the local golden reference.
-        self.golden = golden_handle;
-        let golden = &self.golden;
-        let clone = &self.name;
 
-        smolvm::data::validate_vm_name(clone, "clone name")
-            .map_err(|e| anyhow::anyhow!("clone name: {e}"))?;
-
-        // A clone boots from a copy-on-write MAP_PRIVATE mapping of the golden's
-        // RAM, not a fresh memfd, so it cannot itself be re-forked.
         if self.forkable {
             anyhow::bail!(
                 "nested fork is not supported: a clone cannot be re-forked, so \
@@ -81,168 +70,27 @@ impl ForkCmd {
             );
         }
 
-        let db = SmolvmDb::open()?;
-        let golden_rec = db
-            .get_vm(golden)?
-            .ok_or_else(|| anyhow::anyhow!("machine '{golden}' not found"))?;
-
-        // The golden must be alive and forkable. Probe the control socket (after
-        // its first fork the golden is frozen, so an agent ping would fail, but
-        // STATUS still answers).
-        let ctl = vm_data_dir(golden).join("control.sock");
-        if !ctl.exists() {
-            anyhow::bail!(
-                "golden '{golden}' is not running forkable; start it with \
-                 `smol machine start --forkable --name {golden}`"
-            );
-        }
-        let status = control_socket_cmd(&ctl, "STATUS").map_err(|e| {
-            anyhow::anyhow!(
-                "golden '{golden}' control socket not responding ({e}); start it with \
-                 `smol machine start --forkable --name {golden}`"
-            )
-        })?;
-        if !status.starts_with("OK") {
-            anyhow::bail!("golden '{golden}' is not ready to fork: {status}");
-        }
-        if db.get_vm(clone)?.is_some() {
-            anyhow::bail!("machine '{clone}' already exists");
-        }
-
-        // Clone dir must be PRISTINE at disk-clone time: a leftover directory
-        // (orphan of a crashed fork) holds stale qcow2 overlays that make
-        // krun_create_disk_overlay refuse with rc=-5. The DB check above
-        // guarantees no live clone owns this name, so clearing is safe.
-        let clone_dir = vm_data_dir(clone);
-        if clone_dir.exists() {
-            std::fs::remove_dir_all(&clone_dir)?;
-        }
-        std::fs::create_dir_all(&clone_dir)?;
-        // The snapshot lives under the GOLDEN's dir (gdir/fork-snapshots/<clone>),
-        // matching the engine: the frozen golden VMM writes the checkpoint AND
-        // pre-creates disk overlays NEXT TO the snapshot dir — putting it inside
-        // the clone dir made those collide with clone_disks below (rc=-5), and a
-        // Landlock-confined golden could not write outside its own dir anyway.
-        let gdir = vm_data_dir(golden);
-        let snapshot_dir = gdir.join("fork-snapshots").join(clone);
-        std::fs::create_dir_all(&snapshot_dir)?;
-
-        // Clone the golden's config, clear running-state, and remap inbound
-        // ports to fresh host ports (TSI gives each clone outbound for free;
-        // only inbound must be made distinct so clones don't collide).
-        let mut clone_rec = golden_rec.clone();
-        clone_rec.name = clone.clone();
-        clone_rec.pid = None;
-        clone_rec.pid_start_time = None;
         let pinned = PortMapping::to_tuples(&self.port);
-        if !pinned.is_empty() {
-            clone_rec.ports = pinned;
-            for (h, g) in &clone_rec.ports {
-                eprintln!("  port {h}->{g} (pinned)");
-            }
-        } else if !clone_rec.ports.is_empty() {
-            let mut remapped = Vec::with_capacity(clone_rec.ports.len());
-            for (golden_host, guest) in &clone_rec.ports {
-                match alloc_free_host_port() {
-                    Some(h) => {
-                        eprintln!(
-                            "  port {golden_host}->{guest} (golden) remapped to {h}->{guest} (clone)"
-                        );
-                        remapped.push((h, *guest));
-                    }
-                    None => eprintln!(
-                        "  warning: could not allocate a host port for guest port {guest}; dropping it"
-                    ),
-                }
-            }
-            clone_rec.ports = remapped;
+        let db = smolvm::db::SmolvmDb::open()?;
+        let runtime = smolvm::embedded::EmbeddedRuntime::with_db(db.clone());
+        runtime.fork_machine_detached(&self.golden, &self.name, &pinned, self.share_weights)?;
+
+        let clone = db
+            .get_vm(&self.name)?
+            .ok_or_else(|| anyhow::anyhow!("clone record disappeared after fork"))?;
+        for (host, guest) in &clone.ports {
+            eprintln!("  port {host}->{guest}");
         }
-        clone_rec.golden = Some(golden.clone());
-        db.insert_vm(clone, &clone_rec)?;
-
-        // Freeze the golden and write its snapshot (checkpoint + memfd manifest).
-        eprintln!("Freezing golden '{golden}' as fork base...");
-        let reply = match control_socket_cmd(&ctl, &format!("FORK {}", snapshot_dir.display())) {
-            Ok(r) => r,
-            Err(e) => {
-                rollback(&db, clone, &clone_dir);
-                return Err(e);
-            }
-        };
-        if !reply.starts_with("OK") {
-            rollback(&db, clone, &clone_dir);
-            anyhow::bail!("golden FORK failed: {reply}");
-        }
-
-        // Give the clone its own copy-on-write disks over the (now frozen) golden.
-        if let Err(e) = clone_disks(&gdir, &clone_dir) {
-            rollback(&db, clone, &clone_dir);
-            return Err(e);
-        }
-
-        // Boot the clone from the snapshot (env-driven restore) instead of cold
-        // booting — no init/image steps; it restores the golden's live state.
-        let mounts = clone_rec.host_mounts();
-        let ports = clone_rec.port_mappings();
-        let resources = clone_rec.vm_resources();
-        let features = LaunchFeatures {
-            dns_filter_hosts: clone_rec.dns_filter_hosts.clone(),
-            // Boot the clone from the golden's snapshot (restore live RAM) — MUST
-            // go on the features: the manager forwards SMOLVM_SNAPSHOT_DIR to the
-            // boot subprocess from `features`, not from a (non-inherited) process
-            // env. Without this the clone cold-boots and loses the warm RAM.
-            snapshot_dir: Some(snapshot_dir.clone()),
-            cuda_share_weights: self.share_weights,
-            // `smol machine fork` detaches the clone to persist; opt out of the boot
-            // subprocess's parent-death watchdog (see start.rs) so it survives
-            // this command's exit.
-            watch_parent: Some(false),
-            ..Default::default()
-        };
-        let manager = match AgentManager::for_vm_with_sizes(
-            clone,
-            clone_rec.storage_gb,
-            clone_rec.overlay_gb,
-        ) {
-            Ok(m) => m,
-            Err(e) => {
-                rollback(&db, clone, &clone_dir);
-                return Err(anyhow::anyhow!("create agent manager: {e}"));
-            }
-        };
-        eprintln!("Booting clone '{clone}' from snapshot...");
-        let launched = manager.ensure_running_with_full_config(mounts, ports, resources, features);
-        if let Err(e) = launched {
-            rollback(&db, clone, &clone_dir);
-            return Err(anyhow::anyhow!("boot clone: {e}"));
-        }
-
-        let pid = manager.child_pid();
-        let pid_start_time = pid.and_then(smolvm::process::process_start_time);
-        if let Err(e) = db.update_vm(clone, |r| {
-            r.state = RecordState::Running;
-            r.pid = pid;
-            r.pid_start_time = pid_start_time;
-        }) {
-            eprintln!("Warning: failed to persist clone state: {e}");
-        }
-
-        // A clone inherits the golden's hostname, machine-id and RNG state;
-        // rejuvenate so the streams diverge (best-effort).
-        rejuvenate_clone(clone, manager.vsock_socket());
-
-        manager.detach();
         eprintln!(
-            "Forked '{golden}' -> '{clone}' (PID {}). Golden stays frozen as the fork base \
+            "Forked '{}' -> '{}' (PID {}). Golden stays frozen as the fork base \
              (do not start it again while clones exist).",
-            pid.unwrap_or(0)
+            self.golden,
+            self.name,
+            clone.pid.unwrap_or(0)
         );
         Ok(())
     }
 
-    /// Cloud fork: POST `/v1/machines/{golden}/fork` to the control plane, which
-    /// pins the live-RAM CoW clone to the golden's node. `--golden` resolves to
-    /// the source machine id; the clone name + pinned ports go in the body.
     fn run_cloud(self) -> anyhow::Result<()> {
         if self.forkable {
             anyhow::bail!(
@@ -251,19 +99,14 @@ impl ForkCmd {
             );
         }
         let clone_name = self.name.clone();
-        // The control plane's MachinePort is { port: <guest>, hostPort: <host?> }.
-        let ports: Vec<serde_json::Value> = self
-            .port
-            .iter()
-            .map(|p| serde_json::json!({ "port": p.guest, "hostPort": p.host }))
-            .collect();
+        let body = cloud_fork_body(&clone_name, &self.port, self.share_weights);
         super::cloud::run_cloud_command(
             Some(self.golden),
             move |http, endpoint, golden_id| async move {
                 eprintln!("Forking {golden_id} -> {clone_name}...");
                 let resp = http
                     .post(format!("{}/v1/machines/{}/fork", endpoint, golden_id))
-                    .json(&serde_json::json!({ "name": clone_name, "ports": ports }))
+                    .json(&body)
                     .send()
                     .await?;
                 match resp.status().as_u16() {
@@ -291,157 +134,16 @@ impl ForkCmd {
     }
 }
 
-/// Remove a partially-created clone after a failure mid-fork.
-fn rollback(db: &SmolvmDb, clone: &str, clone_dir: &Path) {
-    let _ = db.remove_vm(clone);
-    let _ = std::fs::remove_dir_all(clone_dir);
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-/// Give the clone copy-on-write disks backed by the (frozen) golden's. Linux
-/// uses qcow2 overlays (O(metadata)); macOS clonefiles (APFS CoW). The
-/// `.formatted` marker is copied so the clone never reformats the inherited fs.
-fn clone_disks(gdir: &Path, clone_dir: &Path) -> anyhow::Result<()> {
-    use smolvm::data::disk::DiskFormat;
-    use smolvm::data::storage::{OVERLAY_DISK_FILENAME, STORAGE_DISK_FILENAME};
-
-    let disks: Vec<(&str, std::path::PathBuf, DiskFormat)> =
-        [STORAGE_DISK_FILENAME, OVERLAY_DISK_FILENAME]
-            .into_iter()
-            .map(|raw| {
-                let (src, fmt) = resolve_disk_image(gdir, raw);
-                (raw, src, fmt)
-            })
-            .filter(|(_, src, _)| src.exists())
-            .collect();
-
-    #[cfg(target_os = "linux")]
-    {
-        let mut specs = Vec::with_capacity(disks.len());
-        for (raw, src, fmt) in &disks {
-            let base = src
-                .canonicalize()
-                .map_err(|e| anyhow::anyhow!("clone disk {}: {e}", src.display()))?;
-            let overlay = clone_dir.join(Path::new(raw).with_extension("qcow2"));
-            specs.push((overlay, base, *fmt));
-        }
-        if std::env::var_os("SMOL_FORK_DEBUG").is_some() {
-            for (overlay, base, fmt) in &specs {
-                eprintln!(
-                    "[fork-dbg] overlay={} exists={} | base={} exists={} fmt={:?}",
-                    overlay.display(),
-                    overlay.exists(),
-                    base.display(),
-                    base.exists(),
-                    fmt
-                );
-            }
-            if let Ok(rd) = std::fs::read_dir(clone_dir) {
-                for e in rd.flatten() {
-                    eprintln!(
-                        "[fork-dbg] clone_dir has: {}",
-                        e.file_name().to_string_lossy()
-                    );
-                }
-            }
-        }
-        smolvm::agent::create_disk_overlays(&specs)
-            .map_err(|e| anyhow::anyhow!("create clone overlays: {e}"))?;
-        for (raw, _, _) in &disks {
-            let marker = Path::new(raw).with_extension("formatted");
-            let src_marker = gdir.join(&marker);
-            if src_marker.exists() {
-                let _ = std::fs::copy(&src_marker, clone_dir.join(&marker));
-            }
-        }
+    #[test]
+    fn cloud_fork_preserves_weight_sharing_and_ports() {
+        let body = cloud_fork_body("clone", &[PortMapping::new(49152, 9222)], true);
+        assert_eq!(body["name"], "clone");
+        assert_eq!(body["ports"][0]["hostPort"], 49152);
+        assert_eq!(body["ports"][0]["port"], 9222);
+        assert_eq!(body["shareWeights"], true);
     }
-    #[cfg(target_os = "macos")]
-    {
-        for (_, src, _) in &disks {
-            let dst = clone_dir.join(src.file_name().unwrap());
-            smolvm::disk_utils::clone_or_copy_file(src, &dst)
-                .map_err(|e| anyhow::anyhow!("clone disk {}: {e}", src.display()))?;
-            let src_marker = src.with_extension("formatted");
-            if src_marker.exists() {
-                let _ = std::fs::copy(&src_marker, dst.with_extension("formatted"));
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Best-effort identity rejuvenation: unique hostname, fresh machine-id, and a
-/// stir of the kernel RNG with host entropy so clones don't share streams.
-fn rejuvenate_clone(clone: &str, sock: &Path) {
-    let seed = host_random_hex(64);
-    // `clone` is validated (alphanumeric + dashes), so single-quoting is safe.
-    let script = format!(
-        "hostname '{c}' 2>/dev/null; printf '%s\\n' '{c}' > /etc/hostname 2>/dev/null; \
-         (cat /proc/sys/kernel/random/uuid 2>/dev/null | tr -d '-' > /etc/machine-id) 2>/dev/null; \
-         printf '%s' '{s}' > /dev/urandom 2>/dev/null; true",
-        c = clone,
-        s = seed,
-    );
-    let mut client = match AgentClient::connect_with_retry(sock) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("Warning: clone '{clone}' rejuvenation skipped (agent connect: {e})");
-            return;
-        }
-    };
-    match client.vm_exec(
-        vec!["/bin/sh".into(), "-c".into(), script],
-        vec![],
-        None,
-        Some(Duration::from_secs(10)),
-        None,
-    ) {
-        Ok((0, _, _)) => {}
-        Ok((code, _, stderr)) => eprintln!(
-            "Warning: clone '{clone}' rejuvenation exited {code}: {}",
-            String::from_utf8_lossy(&stderr).trim()
-        ),
-        Err(e) => eprintln!("Warning: clone '{clone}' rejuvenation failed: {e}"),
-    }
-}
-
-/// Allocate a free host TCP port by binding to :0 and reading it back.
-fn alloc_free_host_port() -> Option<u16> {
-    std::net::TcpListener::bind(("127.0.0.1", 0))
-        .ok()
-        .and_then(|l| l.local_addr().ok())
-        .map(|addr| addr.port())
-}
-
-/// `hex_len/2` random bytes from the host RNG, hex-encoded.
-fn host_random_hex(hex_len: usize) -> String {
-    let mut buf = vec![0u8; hex_len / 2];
-    if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
-        let _ = f.read_exact(&mut buf);
-    }
-    buf.iter().map(|b| format!("{b:02x}")).collect()
-}
-
-/// Send one line to a VM control socket and return its reply line.
-fn control_socket_cmd(sock: &Path, cmd: &str) -> anyhow::Result<String> {
-    let mut stream =
-        UdsStream::connect(sock).map_err(|e| anyhow::anyhow!("connect control socket: {e}"))?;
-    stream.set_read_timeout(Some(Duration::from_secs(60))).ok();
-    stream
-        .write_all(format!("{cmd}\n").as_bytes())
-        .map_err(|e| anyhow::anyhow!("write control socket: {e}"))?;
-    let mut reply = String::new();
-    let mut byte = [0u8; 1];
-    loop {
-        match stream.read(&mut byte) {
-            Ok(0) => break,
-            Ok(_) => {
-                if byte[0] == b'\n' {
-                    break;
-                }
-                reply.push(byte[0] as char);
-            }
-            Err(e) => return Err(anyhow::anyhow!("read control socket: {e}")),
-        }
-    }
-    Ok(reply)
 }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -8,6 +8,29 @@ use smolvm::data::storage::HostMount;
 use smolvm::smolfile::{self, Smolfile};
 use std::path::PathBuf;
 
+fn resolve_fork_config(
+    fork: smolvm::smolfile::ForkConfig,
+    cuda: bool,
+) -> anyhow::Result<(bool, Option<u32>, Option<u64>)> {
+    if fork.pool_size == Some(0) {
+        anyhow::bail!("Smolfile [fork] pool_size must be greater than zero");
+    }
+    if fork.cuda_vram_limit_mib == Some(0) {
+        anyhow::bail!("Smolfile [fork] cuda_vram_limit_mib must be greater than zero");
+    }
+    if fork.pool_size.is_some() && !cuda {
+        anyhow::bail!("Smolfile [fork] pool_size requires cuda = true or auto_graph = true");
+    }
+    if fork.cuda_vram_limit_mib.is_some() && fork.pool_size.is_none() {
+        anyhow::bail!("Smolfile [fork] cuda_vram_limit_mib requires pool_size");
+    }
+    Ok((
+        fork.enabled.unwrap_or(false) || fork.pool_size.is_some(),
+        fork.pool_size,
+        fork.cuda_vram_limit_mib,
+    ))
+}
+
 #[derive(Args, Debug)]
 pub struct UpCmd {
     /// Run in background
@@ -76,6 +99,10 @@ impl UpCmd {
         let net = sf.net.unwrap_or(false) || !ports.is_empty();
         let gpu = sf.gpu.unwrap_or(false);
         let gpu_vram_mib = sf.gpu_vram;
+        let auto_graph = sf.auto_graph.unwrap_or(false);
+        let cuda = sf.cuda.unwrap_or(false) || auto_graph;
+        let (forkable, cuda_fork_pool_size, cuda_vram_limit_mib) =
+            resolve_fork_config(sf.fork.unwrap_or_default(), cuda)?;
 
         // Resolve [network] section for egress policy
         let network_config = sf.network.unwrap_or_default();
@@ -111,7 +138,7 @@ impl UpCmd {
             gpu,
             gpu_vram_mib,
             rosetta: sf.rosetta.unwrap_or(false),
-            cuda: sf.cuda.unwrap_or(false),
+            cuda,
             dns: None,
         };
 
@@ -131,6 +158,9 @@ impl UpCmd {
         // Merge env: top-level + [dev]
         let mut all_env = sf.env.clone();
         all_env.extend(dev.env.clone());
+        if auto_graph {
+            smolvm::util::enable_cuda_auto_graph_env_specs(&mut all_env);
+        }
         let env = smolvm::util::parse_env_list(&all_env);
 
         // Workdir: [dev].workdir > top-level workdir
@@ -187,7 +217,10 @@ impl UpCmd {
             // all have record fields the engine's own Smolfile path wires — mirror
             // it here so `file up` honors them.
             record.rosetta = sf.rosetta;
-            record.cuda = sf.cuda.unwrap_or(false);
+            record.cuda = cuda;
+            record.forkable = forkable;
+            record.cuda_fork_pool_size = cuda_fork_pool_size;
+            record.cuda_vram_limit_mib = cuda_vram_limit_mib;
             record.docker_socket = sf.docker_socket.unwrap_or(false);
 
             // Wire [restart] policy into record.
@@ -240,7 +273,10 @@ impl UpCmd {
         let features = LaunchFeatures {
             ssh_agent_socket,
             dns_filter_hosts,
-            cuda: sf.cuda.unwrap_or(false),
+            cuda,
+            forkable,
+            cuda_fork_pool_size,
+            cuda_vram_limit_mib,
             expose_docker: sf.docker_socket.unwrap_or(false),
             ..Default::default()
         };
@@ -295,6 +331,22 @@ impl UpCmd {
             }
         }
 
+        // Image machines are services, not just image caches: launch the image
+        // workload before `file up` reports success so published ports become
+        // useful and a later fork inherits the live process.
+        if sf.image.is_some() {
+            let record = smolvm::db::SmolvmDb::open()?
+                .get_vm(&name)?
+                .ok_or_else(|| anyhow::anyhow!("machine record disappeared during start"))?;
+            let mut client = smolvm::AgentClient::connect_with_retry(manager.vsock_socket())?;
+            if let Err(error) =
+                smolvm::workload::launch_image_workload(&mut client, &name, &record, env.clone())
+            {
+                let _ = manager.stop();
+                return Err(error.into());
+            }
+        }
+
         // Update DB state. Mark init as completed so a later start doesn't re-run
         // it (init effects now persist in the overlay).
         let pid_start_time = pid.and_then(smolvm::process::process_start_time);
@@ -315,5 +367,36 @@ impl UpCmd {
 
         manager.detach();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pool_size_implies_forkable_launch() {
+        let fork = smolvm::smolfile::ForkConfig {
+            enabled: None,
+            pool_size: Some(8),
+            cuda_vram_limit_mib: Some(6144),
+        };
+        assert_eq!(
+            resolve_fork_config(fork, true).unwrap(),
+            (true, Some(8), Some(6144))
+        );
+    }
+
+    #[test]
+    fn cuda_pool_validation_matches_the_engine() {
+        let fork = smolvm::smolfile::ForkConfig {
+            enabled: None,
+            pool_size: Some(8),
+            cuda_vram_limit_mib: None,
+        };
+        assert!(resolve_fork_config(fork, false)
+            .unwrap_err()
+            .to_string()
+            .contains("requires cuda"));
     }
 }


### PR DESCRIPTION
Adds automatic image startup, stable readiness, remapped local endpoints, inherited overlay access, and shared fork handling for the CLI and SDKs after smol-machines/smolvm#917 lands.