### PR TITLE
Add machine labels to create and surface them in ls --json

### DIFF
--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -61,6 +61,15 @@ pub struct CreateCmd {
     #[arg(short = 'p', long = "port", value_parser = PortMapping::parse, value_name = "HOST:GUEST")]
     pub port: Vec<PortMapping>,
 
+    /// Attach metadata to the machine (repeatable), e.g.
+    /// `--label owner=ci --label sandbox=agent-7`.
+    ///
+    /// Never interpreted: labels exist so a process managing many machines can
+    /// recognise its own later, instead of encoding that into the name. Read
+    /// them back with `smol machine ls --json`.
+    #[arg(long = "label", value_name = "KEY=VALUE")]
+    pub label: Vec<String>,
+
     /// Enable outbound network access
     #[arg(long)]
     pub net: bool,
@@ -194,6 +203,7 @@ impl CreateCmd {
         record.gpu = if self.gpu { Some(true) } else { None };
         record.gpu_vram_mib = smolvm::data::resources::validate_gpu_vram_mib(self.gpu_vram)
             .map_err(|e| anyhow::anyhow!("--gpu-vram: {}", e))?;
+        record.labels = smolvm::util::parse_labels(&self.label)?;
         record.cuda = self.cuda;
 
         let mut config = SmolvmConfig::load()?;

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -40,6 +40,9 @@ impl LsCmd {
                         "cpus": m.cpus,
                         "memory_mib": m.memory_mib,
                         "source": m.source,
+                        // Without this labels are write-only: a caller could set
+                        // them and never read them back.
+                        "labels": m.labels,
                     })
                 })
                 .collect();

--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -74,6 +74,9 @@ pub struct MachineRef {
     pub source: Option<String>,
     pub cpus: Option<u32>,
     pub memory_mib: Option<u32>,
+    /// Caller metadata set with `--label`. Empty for cloud machines, which have
+    /// no equivalent yet.
+    pub labels: std::collections::BTreeMap<String, String>,
 }
 
 impl MachineRef {
@@ -136,6 +139,7 @@ fn list_local() -> Result<Vec<MachineRef>> {
             source: record.image.clone(),
             cpus: Some(record.cpus as u32),
             memory_mib: Some(record.mem),
+            labels: record.labels.clone(),
         })
         .collect())
 }
@@ -178,6 +182,9 @@ fn list_cloud() -> Result<Option<Vec<MachineRef>>> {
                 source: m.source.and_then(|s| s.reference),
                 cpus: m.resources.as_ref().and_then(|r| r.cpus),
                 memory_mib: m.resources.and_then(|r| r.memory_mb),
+                // The cloud API carries no labels yet; empty rather than absent
+                // so the JSON shape is identical for both locations.
+                labels: Default::default(),
             })
             .collect(),
     ))
@@ -434,6 +441,7 @@ mod tests {
             source: None,
             cpus: None,
             memory_mib: None,
+            labels: Default::default(),
         }
     }
 
@@ -549,6 +557,7 @@ mod tests {
             source: None,
             cpus: None,
             memory_mib: None,
+            labels: Default::default(),
         };
         assert_eq!(unnamed.display_name(), "mach-5bb1");
     }


### PR DESCRIPTION
Brings smol to parity with the smolvm CLI on labels: `machine create --label k=v` (repeatable) attaches metadata that smol never interprets, and `machine ls --json` reports it, so a process managing many machines can recognise its own later instead of encoding that into the name; depends on smol-machines/smolvm#930 for the shared parser.