### PR TITLE
Return refreshed tokens to the caller so the first push after expiry succeeds

### DIFF
--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -223,16 +223,33 @@ enum ResolvedCredential {
     Basic { username: String, password: String },
 }
 
+/// A built `RegistryClient`, plus the settings as they exist after building it.
+///
+/// Resolving credentials can silently refresh an expired cloud session, which
+/// rewrites `config.toml`. That leaves the caller's own `SmolSettings` snapshot
+/// stale, so the refreshed copy is handed back here rather than only reaching
+/// disk. Anything that reads credentials afterwards — notably
+/// [`namespaced_repo`], whose `/v1/me` lookup authenticates with the stored
+/// identity token — must use these settings, not the pre-call snapshot.
+pub struct BuiltRegistryClient {
+    pub client: smolvm_registry::RegistryClient,
+    /// `Some` when a refresh replaced the stored tokens; `None` when the call
+    /// made no change and the caller's snapshot is still accurate.
+    pub refreshed_settings: Option<smolvm::SmolSettings>,
+}
+
 /// Build a `RegistryClient` from a registry hostname, applying auth and mirror config.
 ///
 /// Silently refreshes an expired identity token if a `refresh_token` is stored.
 /// On successful refresh the new tokens are persisted to `~/.config/smolvm/config.toml`
-/// so subsequent invocations don't need to re-authenticate.
+/// so subsequent invocations don't need to re-authenticate, **and** are returned
+/// in [`BuiltRegistryClient::refreshed_settings`] so this call cannot invalidate
+/// a snapshot the caller is still holding.
 pub fn build_registry_client(
     registry: &str,
     config: &smolvm::registry::RegistryConfig,
     cloud: &smolvm::settings::CloudSection,
-) -> anyhow::Result<smolvm_registry::RegistryClient> {
+) -> anyhow::Result<BuiltRegistryClient> {
     let effective_registry = config.get_mirror(registry).unwrap_or(registry);
 
     // Docker Hub: user-facing name is "docker.io" but the Distribution API
@@ -255,7 +272,8 @@ pub fn build_registry_client(
     // Credentials are stored by `smol auth login`. Identity tokens are refreshed
     // here if expired. Route based on credential type, not registry hostname,
     // so self-hosted registries using the identity_token path work correctly.
-    match resolve_token(registry, config, cloud)? {
+    let resolved = resolve_token(registry, config, cloud)?;
+    match resolved.credential {
         Some(ResolvedCredential::Identity(token)) => {
             client = client.with_identity_token(token);
         }
@@ -268,7 +286,26 @@ pub fn build_registry_client(
         None => {}
     }
 
-    Ok(client)
+    Ok(BuiltRegistryClient {
+        client,
+        refreshed_settings: resolved.refreshed_settings,
+    })
+}
+
+/// A resolved credential, plus any settings a silent refresh rewrote on the way.
+struct ResolvedToken {
+    credential: Option<ResolvedCredential>,
+    refreshed_settings: Option<smolvm::SmolSettings>,
+}
+
+impl ResolvedToken {
+    /// A resolution that touched no persistent state.
+    fn unchanged(credential: Option<ResolvedCredential>) -> Self {
+        ResolvedToken {
+            credential,
+            refreshed_settings: None,
+        }
+    }
 }
 
 /// Resolve credentials for `registry` from config, refreshing if expired.
@@ -276,11 +313,13 @@ pub fn build_registry_client(
 /// Returns `None` when no credentials are configured for the registry.
 /// Returns the stored credentials unchanged when they have no expiry set.
 /// Only `ResolvedCredential::Identity` is eligible for silent OAuth refresh.
+/// A refresh also yields the rewritten settings, so the caller can replace the
+/// snapshot this call just invalidated.
 fn resolve_token(
     registry: &str,
     config: &smolvm::registry::RegistryConfig,
     cloud: &smolvm::settings::CloudSection,
-) -> anyhow::Result<Option<ResolvedCredential>> {
+) -> anyhow::Result<ResolvedToken> {
     // The smolmachines registry's credential IS the cloud Auth0 session — the
     // registry token endpoint (`/v2/auth`) authenticates that same JWT. Read it
     // LIVE from `[cloud]` (single source of truth) instead of a separate copy in
@@ -289,35 +328,42 @@ fn resolve_token(
     // registries (docker.io, private, self-hosted) keep their own independent
     // per-registry credentials via the entry logic below.
     if registry == smolvm::registry::SMOLMACHINES_REGISTRY {
-        if let Some(cred) = resolve_smolmachines_cloud_token(cloud)? {
-            return Ok(Some(cred));
+        let resolved = resolve_smolmachines_cloud_token(cloud)?;
+        if resolved.credential.is_some() {
+            return Ok(resolved);
         }
         // No cloud session configured → fall through to any manual registry entry.
     }
 
     let entry = match config.registries.get(registry) {
         Some(e) => e,
-        None => return Ok(None),
+        None => return Ok(ResolvedToken::unchanged(None)),
     };
 
     // identity_token (e.g. Auth0 JWT) takes precedence.
     // Direct/Basic credentials are static — they don't expire via OAuth refresh.
     if let Some(identity_token) = &entry.identity_token {
-        return resolve_identity_token(registry, identity_token, entry);
+        return Ok(ResolvedToken::unchanged(resolve_identity_token(
+            registry,
+            identity_token,
+            entry,
+        )?));
     }
 
     if let Some(auth) = config.get_credentials(registry) {
         if auth.username == "token" {
-            return Ok(Some(ResolvedCredential::Direct(auth.password)));
+            return Ok(ResolvedToken::unchanged(Some(ResolvedCredential::Direct(
+                auth.password,
+            ))));
         } else {
-            return Ok(Some(ResolvedCredential::Basic {
+            return Ok(ResolvedToken::unchanged(Some(ResolvedCredential::Basic {
                 username: auth.username,
                 password: auth.password,
-            }));
+            })));
         }
     }
 
-    Ok(None)
+    Ok(ResolvedToken::unchanged(None))
 }
 
 /// Resolve the smolmachines registry credential from the `[cloud]` Auth0 session
@@ -329,16 +375,22 @@ fn resolve_token(
 /// ONLY when the cloud token is actually expired — the common warm path is a
 /// borrow + clone with no I/O, which also keeps the unit tests offline.
 ///
+/// The refreshed settings are returned rather than only written to disk: this
+/// function rewrites the very state its callers are holding, and a caller that
+/// keeps using its pre-call snapshot resolves the wrong tenant namespace.
+///
 /// [`apply_refreshed_smolmachines_tokens`]: super::auth::apply_refreshed_smolmachines_tokens
 fn resolve_smolmachines_cloud_token(
     cloud: &smolvm::settings::CloudSection,
-) -> anyhow::Result<Option<ResolvedCredential>> {
+) -> anyhow::Result<ResolvedToken> {
     let token = match &cloud.api_key {
         Some(t) => t.clone(),
-        None => return Ok(None),
+        None => return Ok(ResolvedToken::unchanged(None)),
     };
     if !cloud.is_token_expired() {
-        return Ok(Some(ResolvedCredential::Identity(token)));
+        return Ok(ResolvedToken::unchanged(Some(
+            ResolvedCredential::Identity(token),
+        )));
     }
 
     // Expired (or within the refresh buffer): silently refresh via the cloud
@@ -350,7 +402,9 @@ fn resolve_smolmachines_cloud_token(
             eprintln!(
                 "warning: cloud session is expired. Run `smol auth login` to re-authenticate."
             );
-            return Ok(Some(ResolvedCredential::Identity(token)));
+            return Ok(ResolvedToken::unchanged(Some(
+                ResolvedCredential::Identity(token),
+            )));
         }
     };
 
@@ -370,7 +424,10 @@ fn resolve_smolmachines_cloud_token(
     super::auth::apply_refreshed_smolmachines_tokens(&mut settings, &new_tokens);
     settings.save()?;
 
-    Ok(Some(ResolvedCredential::Identity(new_tokens.access_token)))
+    Ok(ResolvedToken {
+        credential: Some(ResolvedCredential::Identity(new_tokens.access_token)),
+        refreshed_settings: Some(settings),
+    })
 }
 
 /// Handle expiry check and silent refresh for identity tokens (Auth0 JWTs).
@@ -522,7 +579,8 @@ mod tests {
             &config,
             &smolvm::settings::CloudSection::default(),
         )
-        .unwrap();
+        .unwrap()
+        .client;
         assert_eq!(client.base_url(), "https://registry.smolmachines.com");
     }
 
@@ -534,7 +592,8 @@ mod tests {
             &config,
             &smolvm::settings::CloudSection::default(),
         )
-        .unwrap();
+        .unwrap()
+        .client;
         assert_eq!(client.base_url(), "http://localhost:5050");
     }
 
@@ -546,7 +605,8 @@ mod tests {
             &config,
             &smolvm::settings::CloudSection::default(),
         )
-        .unwrap();
+        .unwrap()
+        .client;
         assert_eq!(client.base_url(), "http://127.0.0.1:5000");
     }
 
@@ -568,7 +628,8 @@ mod tests {
             &config,
             &smolvm::settings::CloudSection::default(),
         )
-        .unwrap();
+        .unwrap()
+        .client;
         assert_eq!(client.base_url(), "https://mirror.example.com");
     }
 
@@ -590,7 +651,8 @@ mod tests {
             &config,
             &smolvm::settings::CloudSection::default(),
         )
-        .unwrap();
+        .unwrap()
+        .client;
         assert_eq!(
             client.identity_token(),
             Some("eyJ_self_hosted_jwt"),
@@ -615,7 +677,8 @@ mod tests {
             &config,
             &smolvm::settings::CloudSection::default(),
         )
-        .unwrap();
+        .unwrap()
+        .client;
         assert_eq!(client.identity_token(), None);
         assert_eq!(
             client.basic_credentials(),
@@ -641,7 +704,8 @@ mod tests {
             &config,
             &smolvm::settings::CloudSection::default(),
         )
-        .unwrap();
+        .unwrap()
+        .client;
         assert_eq!(client.identity_token(), None);
         assert_eq!(client.basic_credentials(), None);
     }
@@ -654,7 +718,8 @@ mod tests {
             &config,
             &smolvm::settings::CloudSection::default(),
         )
-        .unwrap();
+        .unwrap()
+        .client;
         assert_eq!(
             client.base_url(),
             "https://registry-1.docker.io",
@@ -700,6 +765,51 @@ mod tests {
             "registry.smolmachines.com",
             &config,
             &smolvm::settings::CloudSection::default(),
+        );
+    }
+
+    /// `refreshed_settings` means "this call rewrote your settings", so it must
+    /// stay `None` whenever nothing was persisted. A caller that sees `Some`
+    /// replaces its snapshot; one that sees `None` keeps using it, and a false
+    /// positive here would silently discard a caller's own edits.
+    ///
+    /// Both no-write paths are covered offline: a live session (no refresh
+    /// needed) and an expired session with no refresh token (cannot refresh).
+    /// The refresh path itself performs network I/O, so it is exercised by the
+    /// scripted repro in the PR rather than here.
+    #[test]
+    fn no_write_paths_report_settings_unchanged() {
+        let live = smolvm::settings::CloudSection {
+            api_key: Some("live_jwt".to_string()),
+            token_expires_at: Some(4000000000), // year 2096
+            ..Default::default()
+        };
+        let built = build_registry_client(
+            "registry.smolmachines.com",
+            &RegistryConfig::default(),
+            &live,
+        )
+        .unwrap();
+        assert!(
+            built.refreshed_settings.is_none(),
+            "a live session performs no refresh, so nothing was rewritten"
+        );
+
+        let expired_no_refresh = smolvm::settings::CloudSection {
+            api_key: Some("expired_jwt".to_string()),
+            token_expires_at: Some(1), // 1970 — expired
+            refresh_token: None,       // ...and no way to refresh
+            ..Default::default()
+        };
+        let built = build_registry_client(
+            "registry.smolmachines.com",
+            &RegistryConfig::default(),
+            &expired_no_refresh,
+        )
+        .unwrap();
+        assert!(
+            built.refreshed_settings.is_none(),
+            "an expired session with no refresh token cannot rewrite anything"
         );
     }
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -112,12 +112,18 @@ impl DeployCmd {
         let push_inputs = if self.file.is_some() {
             let parsed = smolvm::registry::Reference::parse(&reference)
                 .map_err(|e| anyhow::anyhow!("{}", e))?;
-            let settings = smolvm::SmolSettings::load()?;
-            let client = super::common::build_registry_client(
+            let mut settings = smolvm::SmolSettings::load()?;
+            let built = super::common::build_registry_client(
                 &parsed.registry,
                 &settings.machines,
                 &settings.cloud,
             )?;
+            // See push.rs: a silent refresh here invalidates the snapshot the
+            // namespace lookup below would otherwise read.
+            if let Some(refreshed) = built.refreshed_settings {
+                settings = refreshed;
+            }
+            let client = built.client;
             let repo = super::common::namespaced_repo(
                 &parsed.registry,
                 &parsed.repository(),

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -31,12 +31,18 @@ impl InspectCmd {
             super::common::require_ref(self.reference.as_deref(), self.ref_flag.as_deref())?;
         let parsed =
             smolvm::registry::Reference::parse(reference).map_err(|e| anyhow::anyhow!("{}", e))?;
-        let settings = smolvm::SmolSettings::load()?;
-        let client = super::common::build_registry_client(
+        let mut settings = smolvm::SmolSettings::load()?;
+        let built = super::common::build_registry_client(
             &parsed.registry,
             &settings.machines,
             &settings.cloud,
         )?;
+        // See push.rs: a silent refresh here invalidates the snapshot the
+        // namespace lookup below would otherwise read.
+        if let Some(refreshed) = built.refreshed_settings {
+            settings = refreshed;
+        }
+        let client = built.client;
 
         // Scope a bare repo under the caller's tenant on the smolmachines
         // registry, matching `pack push`/`pack pull` — otherwise a short ref

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -31,12 +31,18 @@ impl PullCmd {
             super::common::require_ref(self.reference.as_deref(), self.ref_flag.as_deref())?;
         let parsed =
             smolvm::registry::Reference::parse(reference).map_err(|e| anyhow::anyhow!("{}", e))?;
-        let settings = smolvm::SmolSettings::load()?;
-        let client = super::common::build_registry_client(
+        let mut settings = smolvm::SmolSettings::load()?;
+        let built = super::common::build_registry_client(
             &parsed.registry,
             &settings.machines,
             &settings.cloud,
         )?;
+        // See push.rs: a silent refresh here invalidates the snapshot the
+        // namespace lookup below would otherwise read.
+        if let Some(refreshed) = built.refreshed_settings {
+            settings = refreshed;
+        }
+        let client = built.client;
 
         // Scope a bare repo under the caller's tenant on the smolmachines
         // registry, matching `pack push` — otherwise a short ref pushed as

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -35,12 +35,19 @@ impl PushCmd {
             super::common::require_ref(self.reference.as_deref(), self.ref_flag.as_deref())?;
         let parsed =
             smolvm::registry::Reference::parse(reference).map_err(|e| anyhow::anyhow!("{}", e))?;
-        let settings = smolvm::SmolSettings::load()?;
-        let client = super::common::build_registry_client(
+        let mut settings = smolvm::SmolSettings::load()?;
+        let built = super::common::build_registry_client(
             &parsed.registry,
             &settings.machines,
             &settings.cloud,
         )?;
+        // Building the client may have refreshed an expired cloud session and
+        // rewritten config.toml; adopt that state before resolving the namespace
+        // below, which authenticates with the stored identity token.
+        if let Some(refreshed) = built.refreshed_settings {
+            settings = refreshed;
+        }
+        let client = built.client;
 
         // For the smolmachines registry, scope a bare repo under the caller's
         // tenant (`tenants/<tenant>/<name>`) — the registry token only grants the

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -132,7 +132,8 @@ impl CatalogArgs {
             .unwrap_or_else(|| SMOLMACHINES_REGISTRY.to_string());
         let settings = SmolSettings::load()?;
         let config = registry_config_for(&settings, &host);
-        let client = super::common::build_registry_client(&host, config, &settings.cloud)?;
+        // Only the credential matters here; no snapshot is read afterwards.
+        let client = super::common::build_registry_client(&host, config, &settings.cloud)?.client;
 
         let rt = tokio::runtime::Runtime::new()?;
         let repos = rt.block_on(client.list_repositories()).map_err(|e| {
@@ -177,8 +178,9 @@ impl TagsArgs {
             .map_err(|e| anyhow::anyhow!("{}", e))?;
         let settings = SmolSettings::load()?;
         let config = registry_config_for(&settings, &parsed.registry);
+        // Only the credential matters here; no snapshot is read afterwards.
         let client =
-            super::common::build_registry_client(&parsed.registry, config, &settings.cloud)?;
+            super::common::build_registry_client(&parsed.registry, config, &settings.cloud)?.client;
 
         let repo = parsed.repository();
         let rt = tokio::runtime::Runtime::new()?;


### PR DESCRIPTION
`smol pack push` fails once with a registry permission error and succeeds on an immediate retry, on the first invocation after the cloud session expires. Fixes #122, taking option 1 from that issue.

## What breaks

`resolve_smolmachines_cloud_token` takes an immutable `&CloudSection`, then internally does its own `load()` → mutate → `save()` and returns only the credential. The refreshed tokens reach **disk** and the **returned credential**, but not the settings the caller is still holding.

`push.rs` snapshots settings, builds the registry client, which refreshes, then calls `namespaced_repo` on that same snapshot. So the namespace lookup authenticates `/v1/me` with the **pre-refresh** token, gets a 401, and falls back to the JWT-claim namespace `google-oauth2-…`, which the registry token does not grant. The retry is a fresh process that reads the persisted token, so it works.

## The mechanism

`build_registry_client` now returns `BuiltRegistryClient { client, refreshed_settings }`, so a call that rewrites persistent state says so in its type instead of doing it behind the caller's back. The four callers that read settings afterwards, `push.rs`, `pull.rs`, `deploy.rs`, `inspect.rs`, adopt what came back before resolving the namespace. `registry.rs` (2 sites) never reads the snapshot afterwards and just takes `.client`.

## Repro

The issue was reasoned from source; this is the run. A mock Auth0 issuer + control plane + registry, driven through `OIDC_ISSUER` / `SMOL_CLOUD_API` / a registry `mirror`, with the stored session forced expired (`token_expires_at = 1000000000`) rather than waiting out a real one. `/v1/me` accepts **only** the refreshed token, and the registry token service grants only `tenants/<canonical>/*`.

**Before**. First run vs. an identical retry:

```
RUN 1  Refreshing expired cloud session...
       Pushing … to registry.smolmachines.com/tenants/google-oauth2-12345/myapp:v1
RUN 2  Pushing … to registry.smolmachines.com/tenants/canonical-tenant-id/myapp:v1

server: REFRESH  POST /oauth/token -> issued FRESH token
        CONTROL  GET /v1/me  bearer=STALE  -> 401 (namespace lookup FAILS)
        CONTROL  GET /v1/me  bearer=FRESH  -> 200 tenants/canonical-tenant-id
```

Same command, different target repo. Through `pack inspect`, which reaches the registry, that becomes a user-visible denial and a clean retry:

```
RUN 3  Error: registry returned 403: requested access to
       'tenants/google-oauth2-12345/myapp' is not granted
RUN 4  (authorized)

server: REGISTRY GET /v2/tenants/google-oauth2-12345/myapp/manifests/v1 -> 403 DENIED
        REGISTRY GET /v2/tenants/canonical-tenant-id/myapp/manifests/v1 -> 200
```

**After**, every `/v1/me` gets the refreshed bearer, no 401, no 403, and run 1 resolves the same namespace as the retry:

```
server: REFRESH  POST /oauth/token -> issued FRESH token
        CONTROL  GET /v1/me  bearer=FRESH  -> 200 tenants/canonical-tenant-id
        CONTROL  GET /v1/me  bearer=FRESH  -> 200 tenants/canonical-tenant-id
        REGISTRY GET /v2/tenants/canonical-tenant-id/myapp/manifests/v1 -> 200
```

Both runs still end on an error from the mock's fabricated artifact bytes (`pack format error`, `missing field 'image'`), identical in run 1 and the retry, i.e. after auth, and not a first-run/retry divergence.

## Alternatives considered

**Option 3** (thread the resolved credential into `namespaced_repo`) stops that one function consulting the snapshot but leaves the hidden write in place for the next consumer. **Option 2** (re-read settings after `build_registry_client`) needs the same reload pasted into four call sites and re-breaks the moment a fifth is added. Option 1 puts the change where the signature lies.

## Validation

`cargo test --workspace` 86 passed / 0 failed · `cargo clippy --all-targets -- -D warnings` 0 warnings · `cargo fmt --check` clean. Grepped from the full logs for `^error`, `panicked`, `failures:`. All zero, none read from a tail.

The added test locks the other half of the contract offline: `refreshed_settings` stays `None` on both no-write paths (live session; expired session with no refresh token), so a caller is never told to discard a snapshot that is still good. The refresh path itself does network I/O, so it is covered by the scripted repro above rather than a unit test.
