### PR TITLE
Spread MachineSpec defaults in both SDK initializers so new engine fields stop breaking the build

### DIFF
--- a/sdk/node/src/machine.rs
+++ b/sdk/node/src/machine.rs
@@ -90,6 +90,7 @@ impl NapiMachine {
             image: config.image.clone(),
             persistent: config.persistent.unwrap_or(false),
             runtime_managed: false,
+            ..Default::default()
         };
 
         runtime()

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -375,6 +375,7 @@ impl Machine {
             image,
             persistent,
             runtime_managed: false,
+            ..Default::default()
         };
         runtime()
             .map_err(err)?


### PR DESCRIPTION
Engine 1.8.1 added `MachineSpec.labels` and both SDK crates construct the spec exhaustively, so the node addon fails to compile against the bundled engine (`missing field labels`) — caught by SDK CI only after the bump merged, because the local-microVM job is the only one that builds the addon against the engine; both initializers now end in `..Default::default()`, which fixes the build and keeps the next additive engine field from breaking them again.