### PR TITLE
Spread VmResources defaults in every initializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.7.5"
+version = "1.8.2"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.7.5"
+version = "1.8.2"
 dependencies = [
  "async-stream",
  "axum",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.7.5"
+version = "1.8.2"
 dependencies = [
  "libc",
  "libloading",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.7.5"
+version = "1.8.2"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.7.5"
+version = "1.8.2"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.7.5"
+version = "1.8.2"
 dependencies = [
  "base64",
  "serde",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.7.5"
+version = "1.8.2"
 dependencies = [
  "bytes",
  "dirs",

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -154,6 +154,7 @@ impl PackCreateCmd {
                 rosetta: false,
                 cuda: false,
                 dns: None,
+                ..Default::default()
             },
         )?;
 

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -145,15 +145,6 @@ impl PackCreateCmd {
                 cpus: 2,
                 memory_mib: 512,
                 network: true,
-                storage_gib: None,
-                overlay_gib: None,
-                allowed_cidrs: None,
-                network_backend: None,
-                gpu: false,
-                gpu_vram_mib: None,
-                rosetta: false,
-                cuda: false,
-                dns: None,
                 ..Default::default()
             },
         )?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -113,6 +113,7 @@ impl RunCmd {
             rosetta: false,
             cuda: self.cuda,
             dns: None,
+            ..Default::default()
         };
 
         // Resolve the image: a registry reference is pulled in-guest, while a

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -104,15 +104,9 @@ impl RunCmd {
             cpus: self.cpus.unwrap_or(4),
             memory_mib: self.mem.unwrap_or(8192),
             network: self.net || !self.port.is_empty(),
-            storage_gib: None,
-            overlay_gib: None,
-            allowed_cidrs: None,
-            network_backend: None,
             gpu: self.gpu,
             gpu_vram_mib: self.gpu_vram,
-            rosetta: false,
             cuda: self.cuda,
-            dns: None,
             ..Default::default()
         };
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -140,6 +140,7 @@ impl UpCmd {
             rosetta: sf.rosetta.unwrap_or(false),
             cuda,
             dns: None,
+            ..Default::default()
         };
 
         // Resolve [auth] for SSH agent

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -134,12 +134,10 @@ impl UpCmd {
             } else {
                 Some(allowed_cidrs)
             },
-            network_backend: None,
             gpu,
             gpu_vram_mib,
             rosetta: sf.rosetta.unwrap_or(false),
             cuda,
-            dns: None,
             ..Default::default()
         };
 


### PR DESCRIPTION
New engine resource fields no longer break the build: the remaining literal VmResources initializers now spread Default like the MachineSpec ones already do.