### PR TITLE
Spread VmResources defaults in the node SDK initializer too

### DIFF
--- a/sdk/node/src/types.rs
+++ b/sdk/node/src/types.rs
@@ -195,15 +195,12 @@ impl VmResourcesConfig {
             cpus: self.cpus.unwrap_or(DEFAULT_MICROVM_CPU_COUNT),
             memory_mib: self.memory_mib.unwrap_or(DEFAULT_MICROVM_MEMORY_MIB),
             network: self.network.unwrap_or(false),
-            network_backend: None,
             storage_gib: self.storage_gib.map(|g| g as u64),
             overlay_gib: self.overlay_gib.map(|g| g as u64),
-            allowed_cidrs: None,
             gpu: self.gpu.unwrap_or(false),
             gpu_vram_mib: self.gpu_vram_mib,
             cuda: self.cuda.unwrap_or(false),
-            rosetta: false,
-            dns: None,
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
The node addon kept the last literal VmResources initializer in the repo, so new engine resource fields broke only the SDK release builds; it now spreads Default like the CLI initializers.