### PR TITLE
Add checkpoint and branch aliases for the fork primitive

### DIFF
--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -69,6 +69,10 @@ export class Machine {
     config: MachineConfig = {},
     conn: ConnectOptions = {},
   ): Promise<Machine> {
+    // `checkpoint: true` is the RL/agent-facing name for `forkable: true` — a
+    // machine you branch rollback-isolated clones from. Normalize it here so
+    // the rest of the stack only ever sees `forkable`.
+    if (config.checkpoint) config = { ...config, forkable: true };
     return new Machine(await makeTransport(config, conn));
   }
 
@@ -241,6 +245,16 @@ export class Machine {
     return new Machine(await this.transport.fork(name, ports));
   }
 
+  /** Branch a rollback-isolated clone from this checkpoint — the RL/agent name
+   *  for `fork()`. The branch inherits the checkpoint's warm RAM *and* disk via
+   *  copy-on-write, explores independently, and is discarded when done; the next
+   *  branch starts from the same checkpoint, so both memory and filesystem are
+   *  rolled back for free. Requires this machine to be a checkpoint
+   *  (`MachineConfig({ checkpoint: true })`). Alias of {@link fork}. */
+  branch(name: string, ports?: PortSpec[]): Promise<Machine> {
+    return this.fork(name, ports);
+  }
+
   /** Fork this forkable machine into MANY clones in one call — the RL fan-out
    *  primitive (GRPO group sampling / eval-task fan-out). Each clone is a live-RAM
    *  CoW fork off this golden, like `fork()`. On the cloud target the batch is
@@ -259,6 +273,19 @@ export class Machine {
   async forkBatch(opts: ForkBatchOptions): Promise<Machine[]> {
     const clones = await this.transport.forkBatch(opts);
     return clones.map((t) => new Machine(t));
+  }
+
+  /** Branch MANY rollback-isolated clones from this checkpoint in one call — the
+   *  RL/agent name for `forkBatch()` (tree-search fan-out / GRPO group sampling).
+   *  Each branch is a live-RAM + disk CoW clone of the checkpoint. Alias of
+   *  {@link forkBatch}.
+   *
+   *  ```ts
+   *  const ckpt = await Machine.create({ image, checkpoint: true });
+   *  const branches = await ckpt.branchBatch({ count: 32, namePrefix: "rollout" });
+   *  ``` */
+  branchBatch(opts: ForkBatchOptions): Promise<Machine[]> {
+    return this.forkBatch(opts);
   }
 
   /** Assign an RL episode: fork + provision a clone of this forkable golden under

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -125,6 +125,9 @@ export interface MachineConfig {
   /** Start as a live-RAM fork base (cloud) so the machine can be cloned with
    *  `Machine.fork`. The golden and its clones are pinned to one node. */
   forkable?: boolean;
+  /** RL/agent-facing alias for `forkable`: mark this machine as a checkpoint
+   *  you branch rollback-isolated clones from (`Machine.branch`). */
+  checkpoint?: boolean;
   /** Environment variables for the image workload launched at create. */
   env?: Record<string, string>;
   /** Working directory for the image workload, set at create. Overrides

--- a/sdk/python/python/smol/async_machine.py
+++ b/sdk/python/python/smol/async_machine.py
@@ -190,6 +190,13 @@ class AsyncMachine:
         clone = await asyncio.to_thread(self._m.fork, name, ports)
         return AsyncMachine(clone)
 
+    async def branch(
+        self, name: str, ports: Optional[list[PortSpec]] = None
+    ) -> "AsyncMachine":
+        """Branch a rollback-isolated clone from this checkpoint (RAM + disk CoW) —
+        the RL/agent name for :meth:`fork`. Alias of :meth:`fork`."""
+        return await self.fork(name, ports)
+
     async def fork_batch(
         self,
         count: Optional[int] = None,
@@ -209,6 +216,20 @@ class AsyncMachine:
             ports=ports,
         )
         return [AsyncMachine(c) for c in clones]
+
+    async def branch_batch(
+        self,
+        count: Optional[int] = None,
+        *,
+        names: Optional[list[str]] = None,
+        name_prefix: Optional[str] = None,
+        ports: Optional[list[PortSpec]] = None,
+    ) -> "list[AsyncMachine]":
+        """Branch MANY rollback-isolated clones from this checkpoint in one call —
+        the RL/agent name for :meth:`fork_batch`. Alias of :meth:`fork_batch`."""
+        return await self.fork_batch(
+            count, names=names, name_prefix=name_prefix, ports=ports
+        )
 
     async def assign(
         self,

--- a/sdk/python/python/smol/machine.py
+++ b/sdk/python/python/smol/machine.py
@@ -212,6 +212,16 @@ class Machine:
         """
         return Machine(self._t.fork(name, ports))
 
+    def branch(self, name: str, ports: Optional[list[PortSpec]] = None) -> "Machine":
+        """Branch a rollback-isolated clone from this checkpoint — the RL/agent
+        name for :meth:`fork`. The branch inherits the checkpoint's warm RAM *and*
+        disk via copy-on-write, explores independently, and is discarded when
+        done; the next branch starts from the same checkpoint, so both memory and
+        filesystem are rolled back for free. Requires this machine to be a
+        checkpoint (``MachineConfig(checkpoint=True)``). Alias of :meth:`fork`.
+        """
+        return self.fork(name, ports)
+
     def fork_batch(
         self,
         count: Optional[int] = None,
@@ -243,6 +253,23 @@ class Machine:
                 count, names=names, name_prefix=name_prefix, ports=ports
             )
         ]
+
+    def branch_batch(
+        self,
+        count: Optional[int] = None,
+        *,
+        names: Optional[list[str]] = None,
+        name_prefix: Optional[str] = None,
+        ports: Optional[list[PortSpec]] = None,
+    ) -> "list[Machine]":
+        """Branch MANY rollback-isolated clones from this checkpoint in one call —
+        the RL/agent name for :meth:`fork_batch` (tree-search fan-out / GRPO group
+        sampling). Each branch is a live-RAM + disk CoW clone of the checkpoint.
+        Alias of :meth:`fork_batch`.
+        """
+        return self.fork_batch(
+            count, names=names, name_prefix=name_prefix, ports=ports
+        )
 
     def assign(
         self,

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -99,11 +99,20 @@ class MachineConfig:
     forkable: bool = False
     """Start as a live-RAM fork base (cloud) so the machine can be cloned with
     :meth:`Machine.fork`. The golden and its clones are pinned to one node."""
+    checkpoint: bool = False
+    """RL/agent-facing alias for :attr:`forkable`: mark this machine as a
+    checkpoint you branch rollback-isolated clones from (:meth:`Machine.branch`)."""
     env: Optional[dict[str, str]] = None
     """Environment variables for the image workload launched at create."""
     workdir: Optional[str] = None
     """Working directory for the image workload, set at create. Overrides the
     image's own workdir."""
+
+    def __post_init__(self) -> None:
+        # `checkpoint=True` is the RL/agent name for `forkable=True`; fold it in
+        # so the rest of the stack only ever reads `forkable`.
+        if self.checkpoint:
+            self.forkable = True
 
 
 @dataclass


### PR DESCRIPTION
A forkable machine is a checkpoint you branch rollback-isolated clones from — each branch inherits the checkpoint's RAM and disk via copy-on-write and is discarded when done — so the SDKs now expose checkpoint (config alias for forkable) plus branch and branchBatch (aliases for fork and forkBatch) across the Node, Python, and async-Python surfaces, letting agent and RL code read as checkpoint-rollback rather than VM cloning.