### PR TITLE
Fix the arm64 Node addon release build against rustc's cortex-a53 erratum flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,17 @@ jobs:
           LIBKRUN_BUNDLE: ${{ matrix.engine_lib }}
           SMOLVM_LIB_DIR: ${{ matrix.engine_lib }}
         run: |
+          # aarch64-linux only: rustc emits `-Wl,--fix-cortex-a53-843419`, which
+          # zig 0.13's driver rejects and which breaks napi's `--zig` link. Shim
+          # `zig` ahead on PATH to strip that one flag, keeping napi's own zig
+          # handling (CC/target translation + the glibc-2.34 pin) intact.
+          if [ "$RUNNER_OS" = "Linux" ] && [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            export REAL_ZIG="$(command -v zig)"
+            mkdir -p "$RUNNER_TEMP/zigshim"
+            cp "$GITHUB_WORKSPACE/sdk/node/scripts/zig-nofix" "$RUNNER_TEMP/zigshim/zig"
+            chmod +x "$RUNNER_TEMP/zigshim/zig"
+            export PATH="$RUNNER_TEMP/zigshim:$PATH"
+          fi
           if [ "$RUNNER_OS" = "Linux" ]; then
             npm run build:native -- --target ${{ matrix.target }} --zig --zig-abi-suffix=2.34
           else

--- a/sdk/node/scripts/zig-nofix
+++ b/sdk/node/scripts/zig-nofix
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# `zig` shim for the aarch64-linux Node addon build.
+#
+# napi-rs's `--zig` sets up zig as the C compiler and linker (handling target
+# translation and the glibc-2.34 pin correctly). The only problem is that rustc
+# emits `-Wl,--fix-cortex-a53-843419` (a Cortex-A53 erratum workaround) which
+# zig 0.13's driver rejects with "unsupported linker arg", failing the link.
+#
+# This shim strips that one flag from every zig invocation and forwards to the
+# real zig (path in $REAL_ZIG), so napi's own zig handling keeps working. It is
+# placed ahead of the real zig on PATH only for the arm64-linux addon build.
+set -euo pipefail
+args=()
+for a in "$@"; do
+  [ "$a" = "-Wl,--fix-cortex-a53-843419" ] && continue
+  args+=("$a")
+done
+exec "${REAL_ZIG:?REAL_ZIG must point at the real zig}" "${args[@]}"


### PR DESCRIPTION
The aarch64-linux Node addon release build fails because rustc emits \`-Wl,--fix-cortex-a53-843419\` (a Cortex-A53 erratum workaround) which napi-rs's zig 0.13 linker driver rejects with "unsupported linker arg", so \`quote\`/\`proc-macro2\`/\`libc\` fail to link and both npm and PyPI publishes are gated off. This shims \`zig\` ahead on PATH for the arm64-linux build to strip that one flag, keeping napi's own zig handling (CC/target translation and the glibc-2.34 floor) intact. Verified by re-driving the SDK release build to green.