### PR TITLE
Accept S3 volumes on machine create, update, and Smolfile up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.8.2"
+version = "1.10.1"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.8.2"
+version = "1.10.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -2385,15 +2385,16 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.8.2"
+version = "1.10.1"
 dependencies = [
+ "getrandom 0.3.4",
  "libc",
  "libloading",
 ]
 
 [[package]]
 name = "smolvm-network"
-version = "1.8.2"
+version = "1.10.1"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2406,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.8.2"
+version = "1.10.1"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2425,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.8.2"
+version = "1.10.1"
 dependencies = [
  "base64",
  "serde",
@@ -2435,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.8.2"
+version = "1.10.1"
 dependencies = [
  "bytes",
  "dirs",

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -143,8 +143,12 @@ impl CreateCmd {
             .name
             .unwrap_or_else(smolvm::util::generate_machine_name);
 
+        // Remote volumes are mounted inside the guest by the agent, so peel
+        // them off before the host-directory parse, which would reject an
+        // `s3://` source as a missing directory.
+        let (host_volume_specs, remote_volumes) = smolvm::remote_volume::split_specs(&self.volume)?;
         let mounts: Vec<(String, String, bool)> =
-            smolvm::data::storage::HostMount::parse(&self.volume)?
+            smolvm::data::storage::HostMount::parse(&host_volume_specs)?
                 .into_iter()
                 .map(|m| m.to_storage_tuple())
                 .collect();
@@ -183,6 +187,9 @@ impl CreateCmd {
             record.dns_filter_hosts = Some(self.allow_host.clone());
         }
         record.image = self.image;
+        // The engine mounts these itself on every start, so persisting them is
+        // all that is needed for the volume to come back after a stop.
+        record.remote_volumes = remote_volumes;
         // CLI trailing args become the machine's workload (entrypoint cleared
         // so they win over the image default, matching the engine).
         if !self.command.is_empty() {
@@ -263,8 +270,12 @@ impl CreateCmd {
                 })?;
         }
 
+        // Remote volumes are mounted inside the guest by the agent, so peel
+        // them off before the host-directory parse, which would reject an
+        // `s3://` source as a missing directory.
+        let (host_volume_specs, remote_volumes) = smolvm::remote_volume::split_specs(&self.volume)?;
         let mounts: Vec<(String, String, bool)> =
-            smolvm::data::storage::HostMount::parse(&self.volume)?
+            smolvm::data::storage::HostMount::parse(&host_volume_specs)?
                 .into_iter()
                 .map(|m| m.to_storage_tuple())
                 .collect();
@@ -281,6 +292,7 @@ impl CreateCmd {
             self.net || manifest.network,
         );
         record.image = Some(manifest.image);
+        record.remote_volumes = remote_volumes;
         // CLI trailing args override the artifact's baked (entrypoint, cmd),
         // matching the engine's precedence.
         if self.command.is_empty() {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -80,7 +80,27 @@ impl RunCmd {
             );
         }
 
-        let mounts = HostMount::parse(&self.volume)?;
+        // Remote volumes are mounted inside the guest by the agent, so peel
+        // them off before the host-directory parse, which would reject an
+        // `s3://` source as a missing directory.
+        let (host_volume_specs, remote_volumes) = smolvm::remote_volume::split_specs(&self.volume)?;
+        // `run` is ephemeral and boots the default machine, so it has no
+        // persistent overlay — and the engine only mounts remote volumes into
+        // a container it establishes for one. Refuse rather than start with the
+        // volume silently missing, which would let a workload read an empty
+        // directory and produce wrong results.
+        if !remote_volumes.is_empty() {
+            anyhow::bail!(
+                "remote volumes are not supported by ephemeral `run` yet; \
+                 create a machine instead: smol create --image <IMAGE> --net -v {}",
+                self.volume
+                    .iter()
+                    .find(|v| v.starts_with("s3://"))
+                    .cloned()
+                    .unwrap_or_default()
+            );
+        }
+        let mounts = HostMount::parse(&host_volume_specs)?;
         // Virtiofs binding form the agent uses to bind each mount into the
         // container: (tag, guest_target, read_only). The tag is `smolvm{i}` and
         // must match the virtiofs device order libkrun exposes at VM start, i.e.

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -88,7 +88,11 @@ impl UpCmd {
             &sf.init
         };
 
-        let mounts = HostMount::parse(mounts_strs)?;
+        // Remote volumes are mounted inside the guest by the agent, so peel
+        // them off before the host-directory parse, which would reject an
+        // `s3://` source as a missing directory.
+        let (host_volume_specs, remote_volumes) = smolvm::remote_volume::split_specs(mounts_strs)?;
+        let mounts = HostMount::parse(&host_volume_specs)?;
         let ports: Vec<PortMapping> = port_strs
             .iter()
             .map(|s| PortMapping::parse(s).map_err(|e| anyhow::anyhow!("{}", e)))
@@ -205,6 +209,10 @@ impl UpCmd {
             record.overlay_gb = sf.overlay;
             record.ssh_agent = ssh_agent;
             record.dns_filter_hosts = dns_filter_hosts.clone();
+            // The engine mounts these itself on every start, so persisting them
+            // is all that is needed for the volume to come back after a stop.
+            record.remote_volumes = remote_volumes.clone();
+            record.validate_remote_volumes()?;
             // Persist the Smolfile's [secrets] so they are resolved and injected
             // into the machine's execs (matching the engine's Smolfile path).
             // Without this the declared secrets are parsed then silently dropped,
@@ -311,6 +319,10 @@ impl UpCmd {
                         .with_env(env.clone())
                         .with_workdir(workdir.clone())
                         .with_mounts(mount_bindings.clone())
+                        .with_s3_volumes(smolvm::remote_volume::to_s3_volumes(
+                            &remote_volumes,
+                            &env,
+                        ))
                         .with_persistent_overlay(Some(name.clone()));
                     client.run_non_interactive(config)?
                 } else {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -101,7 +101,12 @@ impl UpdateCmd {
             }
         }
 
-        let new_mounts = HostMount::parse(&self.volume)?;
+        // Remote volumes are mounted inside the guest by the agent, so peel
+        // them off before the host-directory parse, which would reject an
+        // `s3://` source as a missing directory.
+        let (host_volume_specs, new_remote_volumes) =
+            smolvm::remote_volume::split_specs(&self.volume)?;
+        let new_mounts = HostMount::parse(&host_volume_specs)?;
 
         // Reject duplicate host ports after the proposed changes.
         {
@@ -161,6 +166,21 @@ impl UpdateCmd {
                 });
                 if r.mounts.len() < before {
                     changes.push(format!("  removed volume: {rm}"));
+                }
+            }
+            for rv in &new_remote_volumes {
+                if !r
+                    .remote_volumes
+                    .iter()
+                    .any(|e| e.source == rv.source && e.target == rv.target)
+                {
+                    changes.push(format!(
+                        "  added remote volume: {}:{}{}",
+                        rv.source,
+                        rv.target,
+                        if rv.read_only { ":ro" } else { "" }
+                    ));
+                    r.remote_volumes.push(rv.clone());
                 }
             }
             for m in &new_mounts {


### PR DESCRIPTION
Peel s3:// sources off the host-directory parse and persist them on the machine record so the engine mounts them on every start.