### PR TITLE
Stop a stored CLI login from silently sending local SDK work to the cloud

### DIFF
--- a/sdk/node/test/unit.ts
+++ b/sdk/node/test/unit.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { wrapNativeError, SmolError } from '../errors';
 import { adapterSha256, RolloutClient } from '../rollout';
-import { cliConfigApiKey, encodePath, resolveNetwork, toNativeConfig } from '../transport';
+import { cliConfigApiKey, encodePath, resolveNetwork, selectsCloud, toNativeConfig } from '../transport';
 
 let passed = 0;
 let failed = 0;
@@ -177,6 +177,50 @@ check('cliConfigApiKey: empty api_key counts as absent', () => {
     writeFileSync(join(dir, 'smolvm', 'config.toml'), '[cloud]\napi_key = ""\n');
     assert.strictEqual(cliConfigApiKey(), undefined);
   });
+});
+
+// --- selectsCloud: a stored CLI login must not flip the default off local ---
+const withCloudToken = (value: string | undefined, fn: () => void) => {
+  const prev = process.env.SMOL_CLOUD_TOKEN;
+  if (value === undefined) delete process.env.SMOL_CLOUD_TOKEN;
+  else process.env.SMOL_CLOUD_TOKEN = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.SMOL_CLOUD_TOKEN;
+    else process.env.SMOL_CLOUD_TOKEN = prev;
+  }
+};
+check('selectsCloud: defaults to local with no explicit credential', () => {
+  withCloudToken(undefined, () => assert.strictEqual(selectsCloud({}), false));
+});
+check('selectsCloud: a CLI login on disk does NOT select cloud', () => {
+  // The regression: `smol auth login` writes config.toml, and reading it here
+  // used to send every default create to the cloud.
+  withXdg((dir) => {
+    mkdirSync(join(dir, 'smolvm'));
+    writeFileSync(join(dir, 'smolvm', 'config.toml'), '[cloud]\napi_key = "smk_from_cli"\n');
+    withCloudToken(undefined, () => {
+      assert.strictEqual(cliConfigApiKey(), 'smk_from_cli'); // the key IS on disk
+      assert.strictEqual(selectsCloud({}), false); // and is still not a target vote
+    });
+  });
+});
+check('selectsCloud: an explicit apiKey selects cloud', () => {
+  withCloudToken(undefined, () =>
+    assert.strictEqual(selectsCloud({ apiKey: 'smk_explicit' }), true),
+  );
+});
+check('selectsCloud: SMOL_CLOUD_TOKEN selects cloud', () => {
+  withCloudToken('smk_env', () => assert.strictEqual(selectsCloud({}), true));
+});
+check('selectsCloud: an explicit local target beats every credential', () => {
+  withCloudToken('smk_env', () =>
+    assert.strictEqual(selectsCloud({ target: 'local', apiKey: 'smk_explicit' }), false),
+  );
+});
+check('selectsCloud: an explicit cloud target needs no credential to select', () => {
+  withCloudToken(undefined, () => assert.strictEqual(selectsCloud({ target: 'cloud' }), true));
 });
 
 async function checkAsync(name: string, fn: () => Promise<void>) {

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -1242,6 +1242,21 @@ function cliSession(target: string | undefined): CliSession {
   return session;
 }
 
+/** Does this request target the cloud?
+ *
+ * Only an EXPLICIT credential may select cloud: `conn.apiKey` and
+ * SMOL_CLOUD_TOKEN are deliberate acts by the caller, whereas a CLI session on
+ * disk is a side effect of `smol auth login` and must never flip the default
+ * away from local. Letting the stored session decide sent every default
+ * `Machine.create()` on a machine that had ever logged in to the cloud — and
+ * failed outright once that key expired.
+ */
+export function selectsCloud(conn: ConnectOptions): boolean {
+  if (conn.target === "cloud") return true;
+  if (conn.target === "local") return false;
+  return Boolean(conn.apiKey ?? process.env.SMOL_CLOUD_TOKEN);
+}
+
 // Accurate guidance for the missing-credential errors. The old text said "run
 // 'smol login'" — a command that doesn't exist (it's `smol auth login`) and
 // that writes to config.toml, which the SDK now reads. Point at the real path.
@@ -1252,16 +1267,20 @@ export async function makeTransport(
   config: MachineConfig,
   conn: ConnectOptions,
 ): Promise<Transport> {
-  const { apiKey: cliKey, endpoint: cliUrl } = cliSession(conn.target);
-  const apiKey = conn.apiKey ?? process.env.SMOL_CLOUD_TOKEN ?? cliKey;
-  const useCloud =
-    conn.target === "cloud" || (conn.target !== "local" && Boolean(apiKey));
+  // Only an EXPLICIT credential may select the cloud target. `conn.apiKey` and
+  // SMOL_CLOUD_TOKEN are deliberate acts by the caller; a CLI session on disk is
+  // a side effect of `smol auth login` and must not flip the default away from
+  // local. Reading it here is what made every default `Machine.create()` on a
+  // machine that had ever logged in go to the cloud — and fail outright once
+  // that stored key expired.
+  const explicitKey = conn.apiKey ?? process.env.SMOL_CLOUD_TOKEN;
+  const useCloud = selectsCloud(conn);
 
   if (useCloud) {
-    // Fall back to the CLI's stored login only AFTER the cloud target is
-    // selected, so a `smol login` on the machine never silently flips the
-    // SDK's default target away from local.
-    const key = apiKey ?? cliConfigApiKey();
+    // Cloud is settled: NOW the CLI's stored login may supply the credential
+    // and endpoint, which is the reuse `smol auth login` promises.
+    const { apiKey: cliKey, endpoint: cliUrl } = cliSession(conn.target);
+    const key = explicitKey ?? cliKey ?? cliConfigApiKey();
     if (!key) {
       throw new InvalidConfigError(
         `cloud target requires an API key — ${NO_KEY_HINT}.`,
@@ -1418,10 +1437,14 @@ export async function connectTransport(
   id: string,
   conn: ConnectOptions,
 ): Promise<Transport> {
-  const { apiKey: cliKey, endpoint: cliUrl } = cliSession(conn.target);
-  const apiKey = conn.apiKey ?? process.env.SMOL_CLOUD_TOKEN ?? cliKey;
-  const useCloud =
-    conn.target === "cloud" || (conn.target !== "local" && !!apiKey);
+  // Only an EXPLICIT credential may select the cloud target. `conn.apiKey` and
+  // SMOL_CLOUD_TOKEN are deliberate acts by the caller; a CLI session on disk is
+  // a side effect of `smol auth login` and must not flip the default away from
+  // local. Reading it here is what made every default `Machine.create()` on a
+  // machine that had ever logged in go to the cloud — and fail outright once
+  // that stored key expired.
+  const explicitKey = conn.apiKey ?? process.env.SMOL_CLOUD_TOKEN;
+  const useCloud = selectsCloud(conn);
   if (!useCloud) {
     // Local: start-or-reconnect to the named machine via the native engine.
     try {
@@ -1443,7 +1466,8 @@ export async function connectTransport(
   }
   // As in makeTransport: the CLI-login fallback applies only once the cloud
   // target is already selected.
-  const key = apiKey ?? cliConfigApiKey();
+  const { apiKey: cliKey, endpoint: cliUrl } = cliSession(conn.target);
+  const key = explicitKey ?? cliKey ?? cliConfigApiKey();
   if (!key) {
     throw new InvalidConfigError(
       `connect requires an API key — ${NO_KEY_HINT}.`,

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -1205,15 +1205,21 @@ _NO_KEY_HINT = (
 
 def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None) -> Transport:
     conn = conn or ConnectOptions()
-    cli_key, cli_url = _cli_session() if conn.target != "local" else (None, None)
-    api_key = conn.api_key or os.environ.get("SMOL_CLOUD_TOKEN") or cli_key
-    use_cloud = conn.target == "cloud" or (conn.target != "local" and bool(api_key))
+    # Only an EXPLICIT credential may select the cloud target. `conn.api_key`
+    # and SMOL_CLOUD_TOKEN are deliberate acts by the caller; a CLI session on
+    # disk is a side effect of `smol auth login` and must not flip the default
+    # away from local. Reading it here is what made every default create on a
+    # machine that had ever logged in go to the cloud — and fail outright once
+    # that stored key expired.
+    explicit_key = conn.api_key or os.environ.get("SMOL_CLOUD_TOKEN")
+    use_cloud = conn.target == "cloud" or (conn.target != "local" and bool(explicit_key))
 
     if use_cloud:
-        # Fall back to the CLI's stored login only AFTER the cloud target is
-        # selected, so a `smol login` on the machine never silently flips the
-        # SDK's default target away from local.
-        api_key = api_key or _cli_config_api_key()
+        # Cloud is settled: NOW the CLI's stored login may supply the
+        # credential and endpoint, which is the reuse `smol auth login`
+        # promises.
+        cli_key, cli_url = _cli_session()
+        api_key = explicit_key or cli_key or _cli_config_api_key()
         if not api_key:
             raise InvalidConfigError(f"cloud target requires an api_key — {_NO_KEY_HINT}.")
         if not config.image:
@@ -1347,9 +1353,14 @@ def connect_transport(machine_id: str, conn: Optional[ConnectOptions] = None) ->
     * cloud: looks up the machine by id (raises NOT_FOUND otherwise).
     """
     conn = conn or ConnectOptions()
-    cli_key, cli_url = _cli_session() if conn.target != "local" else (None, None)
-    api_key = conn.api_key or os.environ.get("SMOL_CLOUD_TOKEN") or cli_key
-    use_cloud = conn.target == "cloud" or (conn.target != "local" and bool(api_key))
+    # Only an EXPLICIT credential may select the cloud target. `conn.api_key`
+    # and SMOL_CLOUD_TOKEN are deliberate acts by the caller; a CLI session on
+    # disk is a side effect of `smol auth login` and must not flip the default
+    # away from local. Reading it here is what made every default create on a
+    # machine that had ever logged in go to the cloud — and fail outright once
+    # that stored key expired.
+    explicit_key = conn.api_key or os.environ.get("SMOL_CLOUD_TOKEN")
+    use_cloud = conn.target == "cloud" or (conn.target != "local" and bool(explicit_key))
     if not use_cloud:
         # Local: start-or-reconnect to the named machine via the native engine.
         native = _load_native()
@@ -1369,7 +1380,8 @@ def connect_transport(machine_id: str, conn: Optional[ConnectOptions] = None) ->
             raise wrap_native_error(e) from e
     # As in make_transport: the CLI-login fallback applies only once the cloud
     # target is already selected.
-    api_key = api_key or _cli_config_api_key()
+    cli_key, cli_url = _cli_session()
+    api_key = explicit_key or cli_key or _cli_config_api_key()
     if not api_key:
         raise InvalidConfigError(f"connect requires an api_key — {_NO_KEY_HINT}.")
     base_url = (conn.base_url or os.environ.get("SMOL_CLOUD_URL") or cli_url or DEFAULT_CLOUD_URL).rstrip("/")


### PR DESCRIPTION
Target selection now comes from explicit credentials only (`conn.apiKey`/`SMOL_CLOUD_TOKEN`) instead of a stored `smol auth login` session, so a default `Machine.create()` runs on the local embedded engine as documented rather than silently going to the cloud and failing with `401 expired_key` — fixed in all four call sites across the Node and Python SDKs, with six new unit tests pinning the rule.