### PR TITLE
Accept a top-level network on Python's MachineConfig, matching the Node SDK

### DIFF
--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -201,28 +201,33 @@ def _native_config(name: str, config: MachineConfig) -> dict:
     if config.ports:
         cfg["ports"] = [{"host": p.host, "guest": p.guest} for p in config.ports]
     r = config.resources
-    if r is not None:
+    network = resolve_network(config)
+    # A top-level `network` alone must still produce a resources block, so the
+    # assignment below is keyed on the RESOLVED value rather than on `resources`
+    # being present.
+    if r is not None or network is not None:
         res: dict[str, Any] = {}
-        if r.cpus is not None:
-            res["cpus"] = r.cpus
-        if r.memory_mb is not None:
-            res["memory_mib"] = r.memory_mb
-        if r.network is not None:
-            res["network"] = r.network
-        if r.allow_cidrs is not None:
-            res["allowed_cidrs"] = list(r.allow_cidrs)
-        if r.allow_hosts is not None:
-            res["allowed_hosts"] = list(r.allow_hosts)
-        if r.storage_gb is not None:
-            res["storage_gib"] = r.storage_gb
-        if r.overlay_gb is not None:
-            res["overlay_gib"] = r.overlay_gb
-        if r.gpu is not None:
-            res["gpu"] = r.gpu
-        if r.gpu_vram_mib is not None:
-            res["gpu_vram_mib"] = r.gpu_vram_mib
-        if r.cuda is not None:
-            res["cuda"] = r.cuda
+        if network is not None:
+            res["network"] = network
+        if r is not None:
+            if r.cpus is not None:
+                res["cpus"] = r.cpus
+            if r.memory_mb is not None:
+                res["memory_mib"] = r.memory_mb
+            if r.allow_cidrs is not None:
+                res["allowed_cidrs"] = list(r.allow_cidrs)
+            if r.allow_hosts is not None:
+                res["allowed_hosts"] = list(r.allow_hosts)
+            if r.storage_gb is not None:
+                res["storage_gib"] = r.storage_gb
+            if r.overlay_gb is not None:
+                res["overlay_gib"] = r.overlay_gb
+            if r.gpu is not None:
+                res["gpu"] = r.gpu
+            if r.gpu_vram_mib is not None:
+                res["gpu_vram_mib"] = r.gpu_vram_mib
+            if r.cuda is not None:
+                res["cuda"] = r.cuda
         cfg["resources"] = res
     return cfg
 
@@ -1182,6 +1187,19 @@ def _token_is_expired(expires_at: Any) -> bool:
         return False
 
 
+def resolve_network(config: MachineConfig) -> Optional[bool]:
+    """The effective network setting for a config.
+
+    `resources.network` is canonical; a top-level `network` is the shape callers
+    reach for first. Reading only the canonical one dropped the other in
+    silence. `resources.network` still wins when both are present, so no
+    existing config changes meaning. Mirrors `resolveNetwork` in the Node SDK.
+    """
+    r = config.resources
+    canonical = r.network if r is not None else None
+    return canonical if canonical is not None else config.network
+
+
 def _cli_session() -> tuple[Optional[str], Optional[str]]:
     """`(api_key, endpoint)` from the CLI's login session, or `(None, None)`.
     An expired access token is treated as absent so the caller surfaces an
@@ -1263,7 +1281,7 @@ def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None)
                 "cidrs": r.allow_cidrs or [],
                 "hosts": r.allow_hosts or [],
             }
-        elif r and r.network:
+        elif resolve_network(config):
             body["network"] = {"mode": "open"}
         # Publish ports: supply only the guest port; the control plane allocates
         # the node host port (read the allocated hostPort back from the machine

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -93,6 +93,14 @@ class MachineConfig:
     mounts: Optional[list[MountSpec]] = None
     ports: Optional[list[PortSpec]] = None
     resources: Optional[ResourceSpec] = None
+    network: Optional[bool] = None
+    """Give the guest network access. :attr:`ResourceSpec.network` is canonical;
+    this is the shape callers reach for first (and the one the Node SDK already
+    accepts). Reading only the canonical one meant this was dropped in silence,
+    so a config that plainly asked for network produced a machine without it —
+    and an image pull then failed with an unreachable-network error that reads
+    like a broken VM. ``resources.network`` still wins when both are given, so
+    no existing config changes meaning."""
     persistent: bool = False
     """Keep the machine record after the process exits (local)."""
     auto_stop_seconds: Optional[int] = None

--- a/sdk/python/tests/test_unit.py
+++ b/sdk/python/tests/test_unit.py
@@ -12,7 +12,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
 from smol.errors import ExecutionError, SmolError, wrap_native_error  # noqa: E402
 from smol.rollout import RolloutClient, RolloutError, adapter_sha256  # noqa: E402
 from smol import transport as transport_module  # noqa: E402
-from smol.transport import _cli_config_api_key, _encode_path, _native_config  # noqa: E402
+from smol.transport import (  # noqa: E402
+    _cli_config_api_key,
+    _encode_path,
+    _native_config,
+    resolve_network,
+)
 from smol.types import (  # noqa: E402
     ConnectOptions,
     ExecResult,
@@ -523,3 +528,36 @@ if __name__ == "__main__":
             traceback.print_exc()
     print(f"\n{passed} passed, {failed} failed")
     sys.exit(1 if failed else 0)
+
+
+# --- resolve_network: a top-level `network` must not be dropped (Node parity) ---
+def test_toplevel_network_is_honoured_instead_of_dropped():
+    cfg = MachineConfig(image="alpine", network=True)
+    assert resolve_network(cfg) is True
+    assert _native_config("m", cfg)["resources"]["network"] is True
+
+
+def test_resources_network_still_wins_when_both_are_given():
+    cfg = MachineConfig(image="alpine", network=True, resources=ResourceSpec(network=False))
+    assert resolve_network(cfg) is False
+    assert _native_config("m", cfg)["resources"]["network"] is False
+
+
+def test_canonical_resources_network_is_unchanged():
+    cfg = MachineConfig(image="alpine", resources=ResourceSpec(network=True))
+    assert resolve_network(cfg) is True
+    assert _native_config("m", cfg)["resources"]["network"] is True
+
+
+def test_asking_for_neither_leaves_network_unset():
+    cfg = MachineConfig(image="alpine")
+    assert resolve_network(cfg) is None
+    assert "resources" not in _native_config("m", cfg)
+
+
+def test_toplevel_network_alone_still_emits_a_resources_block():
+    # The whole point of the fix: no ResourceSpec at all, network asked for at
+    # the top level, and the native config must still carry it.
+    cfg = MachineConfig(image="alpine", network=True)
+    native = _native_config("m", cfg)
+    assert native["resources"] == {"network": True}


### PR DESCRIPTION
Python only accepted the canonical `resources.network`, so `MachineConfig(network=True)` — the shape callers reach for first and the one the Node SDK already takes — raised `TypeError`, while omitting network made image pulls fail with an unreachable-network error that reads like a broken VM; this adds the field plus a `resolve_network()` mirroring Node's `resolveNetwork` (canonical still wins, and the resources block is now keyed on the resolved value so a top-level `network` alone is no longer built and dropped), verified by the previously-raising call booting and branching in 106ms.