### PR TITLE
Confine the spawned VMM by default on Linux (seccomp + Landlock enforce)

### DIFF
--- a/sdk/node/assets.ts
+++ b/sdk/node/assets.ts
@@ -62,7 +62,27 @@ export function wireBundledAssets(): RuntimeAssets {
     }
     break;
   }
+  wireDefaultHardening();
   return assets;
+}
+
+/** Confine the spawned VMM by default on Linux.
+ *
+ *  `smol-vmm _boot-vm` reads SMOLVM_SECCOMP / SMOLVM_LANDLOCK and treats unset
+ *  as OFF, which `smolvm serve` compensates for by defaulting both to
+ *  "enforce". An embedding app got neither, so the SDK — whose whole purpose is
+ *  running untrusted code — was the least confined way to boot a VM. Default
+ *  them on here so `npm i smolmachines` is hardened out of the box; an
+ *  explicitly-set value always wins, so `SMOLVM_SECCOMP=off` remains the escape
+ *  hatch for a workload the allowlist does not cover.
+ *
+ *  Linux only: seccomp filtering is x86_64-Linux and Landlock is Linux; on
+ *  macOS the helper ignores both, so setting them would only be misleading.
+ */
+export function wireDefaultHardening(): void {
+  if (process.platform !== 'linux') return;
+  process.env.SMOLVM_SECCOMP ??= 'enforce';
+  process.env.SMOLVM_LANDLOCK ??= 'enforce';
 }
 
 wireBundledAssets();

--- a/sdk/node/test/unit.ts
+++ b/sdk/node/test/unit.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { wrapNativeError, SmolError } from '../errors';
 import { adapterSha256, RolloutClient } from '../rollout';
 import { cliConfigApiKey, encodePath, resolveNetwork, selectsCloud, toNativeConfig } from '../transport';
+import { wireDefaultHardening } from '../assets';
 
 let passed = 0;
 let failed = 0;
@@ -221,6 +222,44 @@ check('selectsCloud: an explicit local target beats every credential', () => {
 });
 check('selectsCloud: an explicit cloud target needs no credential to select', () => {
   withCloudToken(undefined, () => assert.strictEqual(selectsCloud({ target: 'cloud' }), true));
+});
+
+// --- wireDefaultHardening: confine the spawned VMM unless told otherwise ---
+const withHardeningEnv = (
+  seccomp: string | undefined,
+  landlock: string | undefined,
+  fn: () => void,
+) => {
+  const prev = [process.env.SMOLVM_SECCOMP, process.env.SMOLVM_LANDLOCK];
+  const set = (k: string, v: string | undefined) => {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  };
+  set('SMOLVM_SECCOMP', seccomp);
+  set('SMOLVM_LANDLOCK', landlock);
+  try {
+    fn();
+  } finally {
+    set('SMOLVM_SECCOMP', prev[0]);
+    set('SMOLVM_LANDLOCK', prev[1]);
+  }
+};
+check('wireDefaultHardening: an explicit value always wins', () => {
+  withHardeningEnv('off', 'off', () => {
+    wireDefaultHardening();
+    assert.strictEqual(process.env.SMOLVM_SECCOMP, 'off');
+    assert.strictEqual(process.env.SMOLVM_LANDLOCK, 'off');
+  });
+});
+check('wireDefaultHardening: enforces by default on Linux, no-ops elsewhere', () => {
+  withHardeningEnv(undefined, undefined, () => {
+    wireDefaultHardening();
+    // Both knobs are Linux-only in the engine; setting them on macOS/Windows
+    // would imply a confinement the helper does not apply.
+    const expected = process.platform === 'linux' ? 'enforce' : undefined;
+    assert.strictEqual(process.env.SMOLVM_SECCOMP, expected);
+    assert.strictEqual(process.env.SMOLVM_LANDLOCK, expected);
+  });
 });
 
 async function checkAsync(name: string, fn: () => Promise<void>) {

--- a/sdk/python/python/smol/__init__.py
+++ b/sdk/python/python/smol/__init__.py
@@ -11,6 +11,7 @@ is chosen via :class:`ConnectOptions` / ``SMOL_CLOUD_TOKEN``. Mirrors the Node S
 from __future__ import annotations
 
 import os as _os
+import sys as _sys
 from pathlib import Path as _Path
 
 
@@ -36,7 +37,26 @@ def _wire_bundled_native() -> None:
         _os.environ.setdefault("SMOLVM_AGENT_ROOTFS_TAR", str(rootfs_tar))
 
 
+def _wire_default_hardening() -> None:
+    """Confine the spawned VMM by default on Linux.
+
+    ``smol-vmm _boot-vm`` reads SMOLVM_SECCOMP / SMOLVM_LANDLOCK and treats
+    unset as OFF, which ``smolvm serve`` compensates for by defaulting both to
+    "enforce". An embedding app got neither, so the SDK — whose whole purpose is
+    running untrusted code — was the least confined way to boot a VM. Default
+    them on here; an explicitly-set value always wins, so ``SMOLVM_SECCOMP=off``
+    remains the escape hatch for a workload the allowlist does not cover. Linux
+    only: seccomp filtering is x86_64-Linux and Landlock is Linux, so setting
+    them elsewhere would only mislead.
+    """
+    if not _sys.platform.startswith("linux"):
+        return
+    _os.environ.setdefault("SMOLVM_SECCOMP", "enforce")
+    _os.environ.setdefault("SMOLVM_LANDLOCK", "enforce")
+
+
 _wire_bundled_native()
+_wire_default_hardening()
 
 from .errors import (
     ExecutionError,


### PR DESCRIPTION
`smol-vmm _boot-vm` treats an unset SMOLVM_SECCOMP/SMOLVM_LANDLOCK as off and only `smolvm serve` defaulted them to enforce, leaving the SDK — whose whole purpose is running untrusted code — as the least confined way to boot a VM, so both are now defaulted on at the existing asset-wiring point (Linux only, since the filters are Linux-only, and an explicit value still wins so `SMOLVM_SECCOMP=off` remains the escape hatch), at no measured cost: interleaved A/B on x86_64 Linux/KVM over 10 iterations per arm shows create+ready mean 2880ms under both settings and a branch delta well inside the noise, with fork clones keeping the filter and inheriting parent state throughout.