### PR TITLE
Put branching in the quickstarts and stop underselling the isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ engine, no server, no account), `cloud` runs the identical calls on
 program to managed capacity by changing where it connects — not what it does:
 
 ```ts
-const dev  = await Machine.create({ image: 'alpine', network: true });                    // local
-const prod = await Machine.create({ image: 'alpine' }, { target: 'cloud' });               // smolfleet
+const spec = { image: 'alpine', network: true };
+
+const dev  = await Machine.create(spec);                       // local: this machine
+const prod = await Machine.create(spec, { target: 'cloud' });  // smolfleet
 ```
 
 Create, exec, files, state, stop, delete — and branching — behave the same on

--- a/README.md
+++ b/README.md
@@ -12,9 +12,22 @@
 # smol
 
 Run code in isolated **microVM sandboxes** — from the command line, or embedded
-directly in your **Node** or **Python** app. The same `Machine` API works
-locally (an in-process microVM via the bundled smolvm engine — no server) or
-against the **smolfleet** cloud, selected at connect time.
+directly in your **Node** or **Python** app.
+
+**The same code runs on your laptop and in the cloud.** One `Machine` API, two
+transports: `local` boots a microVM on the machine you are sitting at (bundled
+engine, no server, no account), `cloud` runs the identical calls on
+**smolfleet**. Develop and test against a real VM offline, then move the same
+program to managed capacity by changing where it connects — not what it does:
+
+```ts
+const dev  = await Machine.create({ image: 'alpine', network: true });                    // local
+const prod = await Machine.create({ image: 'alpine' }, { target: 'cloud' });               // smolfleet
+```
+
+Create, exec, files, state, stop, delete — and branching — behave the same on
+both. (A handful of local-only concepts, such as host bind mounts, are rejected
+up front on cloud rather than silently dropped.)
 
 ```
 ┌──────────────┐     ┌──────────────────────────── one Machine API ┐
@@ -83,8 +96,10 @@ const fleet = await golden.branchBatch({ count: 8, namePrefix: 'run' });
 ```
 
 Branches are the unit of work for agents and CI: a fresh, VM-isolated machine
-per task without paying boot + setup each time. They are node-local — a branch
-lives on the same host as its parent.
+per task without paying boot + setup each time. They work on both transports —
+locally against the machine in front of you, and on smolfleet, where a batch is
+atomic (all N branches or none). A branch is always node-local: it lives on the
+same host as its parent, because it shares that parent's memory pages.
 
 ## Quickstart — Node
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ pip install smolmachines      # Python
 
 Prebuilt packages bundle everything the **local** transport needs — the
 `libkrun` libraries, a code-signed boot helper, and the guest rootfs — so
-`Machine.create()` boots an in-process microVM with no separate install (macOS
-Apple Silicon and Linux x86_64/arm64, glibc ≥ 2.34). The **cloud** transport is
+`Machine.create()` boots a microVM with no separate install (macOS Apple
+Silicon and Linux x86_64/arm64, glibc ≥ 2.34). The SDK is in your process; the
+VMM is not — the engine runs as a separate `smol-vmm` helper, confined by
+seccomp and Landlock on Linux, so a guest escape lands there rather than in
+your application. The **cloud** transport is
 pure-language and runs anywhere. Booting a local microVM needs hardware
 virtualization (macOS Hypervisor.framework or Linux `/dev/kvm`).
 
@@ -64,12 +67,31 @@ Pin a release with `SMOL_VERSION=v1.3.7`; override locations with `PREFIX` /
 | `src/` | The `smol` CLI (Rust): create / run / exec / files / logs, plus cloud deploy + a container registry. |
 | `docs/cli.md` | CLI command reference. |
 
+## Branching
+
+Set a machine up once — toolchain, repo, dependencies, warm caches — then fork
+it copy-on-write. A branch inherits the parent's RAM *and* disks, so nothing
+re-installs: `node_modules` is there, caches are warm, a process mid-request
+keeps running.
+
+```ts
+const golden = await Machine.create({ image: 'alpine', network: true, forkable: true });
+// ... install deps and warm the caches, once ...
+const b = await golden.branch('b1');          // typically under 200ms
+await b.exec(['npm', 'test']);                // full speed, isolated
+const fleet = await golden.branchBatch({ count: 8, namePrefix: 'run' });
+```
+
+Branches are the unit of work for agents and CI: a fresh, VM-isolated machine
+per task without paying boot + setup each time. They are node-local — a branch
+lives on the same host as its parent.
+
 ## Quickstart — Node
 
 ```ts
 import { Machine } from 'smolmachines';
 
-// Local: boots an in-process microVM, no server.
+// Local: no server, no config.
 const m = await Machine.create({ resources: { cpus: 2, memoryMb: 1024, network: true } });
 try {
   const r = await m.run('python:3.12', ['python', '-c', 'print(2 ** 10)']);

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -1,7 +1,9 @@
 # smol (Node SDK)
 
 Embed isolated **microVM sandboxes** directly in your Node.js code — no server to
-run. The smolvm engine is linked in-process via a native addon.
+run. The SDK is linked into your process via a native addon; the VMM itself is
+a separate `smol-vmm` helper (seccomp- and Landlock-confined on Linux), so a
+guest escape lands there and not in your application.
 
 > **Supported platforms** (native *local* transport): macOS **Apple Silicon**, and
 > **Linux x64/arm64 with glibc ≥ 2.34** (RHEL 9, Ubuntu 22.04+, Debian 12, Amazon
@@ -14,6 +16,12 @@ the backend is chosen by `ConnectOptions`:
 ```ts
 // Local (embedded, default) — no server, no config:
 const local = await Machine.create({ resources: { cpus: 2, memoryMb: 1024 } });
+
+// Branch a prepared machine: a CoW clone of its RAM and disks, typically
+// under 200ms, so a warm environment is reused instead of rebuilt. Pass
+// `network: true` whenever an image has to be pulled.
+const golden = await Machine.create({ image: 'alpine', network: true, forkable: true });
+const branch = await golden.branch('b1');
 
 // Cloud (smolfleet) — pass an API key, or set SMOL_CLOUD_TOKEN.
 const cloud = await Machine.create(

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -196,9 +196,11 @@ supports nested fork generations.
 ## Architecture
 - **Pure-Python layer** (`python/smol`): `Machine`, transports, types, errors —
   zero third-party deps (the cloud transport uses only `urllib`).
-- **Native core** (`src/lib.rs`, crate `smol-py`): a `pyo3` extension that links
-  the `smolvm` engine in-process for the local path — the Python analogue of the
+- **Native core** (`src/lib.rs`, crate `smol-py`): a `pyo3` extension that drives
+  the `smolvm` engine for the local path — the Python analogue of the
   `smol-node` NAPI crate. The local API is **synchronous** (the engine blocks).
+  The extension is in your process; the VMM is not — it runs as a separate
+  `smol-vmm` helper, seccomp- and Landlock-confined on Linux.
 - **Cloud transport**: a REST client to smolfleet `/v1` whose request/response
   shapes match smolfleet's OpenAPI contract (Bearer `smk_…`).
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -13,13 +13,20 @@ backend is chosen via `ConnectOptions` / `SMOL_CLOUD_TOKEN`. Mirrors the
 ```python
 from smol import Machine, MachineConfig, ResourceSpec
 
-# Local (embedded microVM) — boots in-process, no server.
+# Local — no server. The SDK is in your process; the VMM is a separate,
+# seccomp/Landlock-confined helper.
 with Machine.create(MachineConfig(resources=ResourceSpec(cpus=2, memory_mb=1024, network=True))) as m:
     res = m.run("python:3.12", ["python", "-c", "print(2 ** 10)"])
     res.assert_success()
     print(res.stdout)            # 1024
     m.write_file("/tmp/in.txt", "hi")
     print(m.read_file("/tmp/in.txt").decode())
+
+# Branch a prepared machine: a CoW clone of its RAM and disks, typically under
+# 200ms, so a warm environment is reused instead of rebuilt. Pass network=True
+# whenever an image has to be pulled.
+golden = Machine.create(MachineConfig(image="alpine", network=True, forkable=True))
+branch = golden.branch("b1")
 
 # Cloud (smolfleet) — create() waits until it is ready for work.
 from smol import ConnectOptions


### PR DESCRIPTION
No README showed branching and three places claimed the engine runs "in-process" when only the SDK does (the VMM is a separate, now seccomp/Landlock-confined `smol-vmm` helper — the stronger security story), while the opening buried the fact that the same program runs locally and on smolfleet with only its connect target changing; this leads with that local/cloud parity, adds branch/branchBatch to the root and both SDK quickstarts with the node-local reason and the `network: true` requirement for image pulls stated up front, and every snippet was run as written with a deliberately conservative "typically under 200ms" against measured 105ms (Python) and 116ms (Node).