### PR TITLE
Fix Python SDK concurrency

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -47,6 +47,9 @@ harbor = ["harbor>=0.22,<0.23"]
 [project.entry-points."nemo_gym.sandbox_providers"]
 smol = "smol.nemo_gym:SmolProvider"
 
+[project.entry-points."harbor.environments"]
+smol = "smol.harbor:SmolEnvironment"
+
 [tool.maturin]
 # Mixed Rust/Python layout: pure-Python package lives in python/smol, the native
 # extension compiles to smol._native.

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -235,7 +235,7 @@ struct Machine {
 impl Machine {
     /// Create (and register) a machine. Does not boot until `start()`.
     #[new]
-    fn new(config: &Bound<'_, PyDict>) -> PyResult<Self> {
+    fn new(py: Python<'_>, config: &Bound<'_, PyDict>) -> PyResult<Self> {
         let name: String = config
             .get_item("name")?
             .ok_or_else(|| PyRuntimeError::new_err("[INVALID_CONFIG] config['name'] is required"))?
@@ -416,9 +416,8 @@ impl Machine {
             remote_volumes,
             ..Default::default()
         };
-        runtime()
-            .map_err(err)?
-            .create_machine_with_workload(spec, env, workdir)
+        let runtime = runtime().map_err(err)?;
+        py.allow_threads(|| runtime.create_machine_with_workload(spec, env, workdir))
             .map_err(err)?;
         Ok(Self { name })
     }
@@ -427,10 +426,9 @@ impl Machine {
     /// (start-or-reconnect). Re-opens a persisted machine in a new process —
     /// backs the SDK's local `Machine.connect()`.
     #[staticmethod]
-    fn connect(name: String) -> PyResult<Self> {
-        runtime()
-            .map_err(err)?
-            .connect_or_start_machine(&name)
+    fn connect(py: Python<'_>, name: String) -> PyResult<Self> {
+        let runtime = runtime().map_err(err)?;
+        py.allow_threads(|| runtime.connect_or_start_machine(&name))
             .map_err(err)?;
         Ok(Self { name })
     }
@@ -440,31 +438,34 @@ impl Machine {
         self.name.clone()
     }
 
-    fn state(&self) -> PyResult<String> {
-        Ok(runtime().map_err(err)?.state(&self.name))
+    fn state(&self, py: Python<'_>) -> PyResult<String> {
+        let runtime = runtime().map_err(err)?;
+        Ok(py.allow_threads(|| runtime.state(&self.name)))
     }
 
-    fn host_port(&self, guest_port: u16) -> PyResult<Option<u16>> {
-        runtime()
-            .map_err(err)?
-            .host_port(&self.name, guest_port)
+    fn host_port(&self, py: Python<'_>, guest_port: u16) -> PyResult<Option<u16>> {
+        let runtime = runtime().map_err(err)?;
+        py.allow_threads(|| runtime.host_port(&self.name, guest_port))
             .map_err(err)
     }
 
-    fn guest_ports(&self) -> PyResult<Vec<u16>> {
-        runtime().map_err(err)?.guest_ports(&self.name).map_err(err)
+    fn guest_ports(&self, py: Python<'_>) -> PyResult<Vec<u16>> {
+        let runtime = runtime().map_err(err)?;
+        py.allow_threads(|| runtime.guest_ports(&self.name))
+            .map_err(err)
     }
 
-    fn start(&self) -> PyResult<()> {
-        runtime().map_err(err)?.start_machine(&self.name).map_err(err)
+    fn start(&self, py: Python<'_>) -> PyResult<()> {
+        let runtime = runtime().map_err(err)?;
+        py.allow_threads(|| runtime.start_machine(&self.name))
+            .map_err(err)
     }
 
     /// Start this machine as a forkable fork base (memfd-backed guest RAM +
     /// control socket) so it can later be `fork()`-ed.
-    fn start_forkable(&self) -> PyResult<()> {
-        runtime()
-            .map_err(err)?
-            .start_forkable_machine(&self.name)
+    fn start_forkable(&self, py: Python<'_>) -> PyResult<()> {
+        let runtime = runtime().map_err(err)?;
+        py.allow_threads(|| runtime.start_forkable_machine(&self.name))
             .map_err(err)
     }
 
@@ -472,12 +473,7 @@ impl Machine {
     /// live RAM + disks (same host). `ports` are `(host, guest)` inbound forwards
     /// for the clone. Returns a handle to the running clone.
     #[pyo3(signature = (name, ports=None))]
-    fn fork(
-        &self,
-        py: Python<'_>,
-        name: String,
-        ports: Option<Vec<(u16, u16)>>,
-    ) -> PyResult<Self> {
+    fn fork(&self, py: Python<'_>, name: String, ports: Option<Vec<(u16, u16)>>) -> PyResult<Self> {
         let pinned = ports.unwrap_or_default();
         let runtime = runtime().map_err(err)?;
         py.allow_threads(|| runtime.fork_machine(&self.name, &name, &pinned))
@@ -503,28 +499,59 @@ impl Machine {
     }
 
     #[pyo3(signature = (command, options=None))]
-    fn exec(&self, command: Vec<String>, options: Option<&Bound<'_, PyDict>>) -> PyResult<ExecResult> {
+    fn exec(
+        &self,
+        py: Python<'_>,
+        command: Vec<String>,
+        options: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<ExecResult> {
         let (env, workdir, timeout) = parse_exec_opts(options)?;
-        let (code, out, errb) = runtime()
-            .map_err(err)?
-            .exec(&self.name, command, env, workdir, timeout.map(std::time::Duration::from_secs))
+        let runtime = runtime().map_err(err)?;
+        let (code, out, errb) = py
+            .allow_threads(|| {
+                runtime.exec(
+                    &self.name,
+                    command,
+                    env,
+                    workdir,
+                    timeout.map(std::time::Duration::from_secs),
+                )
+            })
             .map_err(err)?;
-        Ok(ExecResult { exit_code: code, stdout: lossy(out), stderr: lossy(errb) })
+        Ok(ExecResult {
+            exit_code: code,
+            stdout: lossy(out),
+            stderr: lossy(errb),
+        })
     }
 
     #[pyo3(signature = (image, command, options=None))]
     fn run(
         &self,
+        py: Python<'_>,
         image: String,
         command: Vec<String>,
         options: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<ExecResult> {
         let (env, workdir, timeout) = parse_exec_opts(options)?;
-        let (code, out, errb) = runtime()
-            .map_err(err)?
-            .run(&self.name, &image, command, env, workdir, timeout.map(std::time::Duration::from_secs))
+        let runtime = runtime().map_err(err)?;
+        let (code, out, errb) = py
+            .allow_threads(|| {
+                runtime.run(
+                    &self.name,
+                    &image,
+                    command,
+                    env,
+                    workdir,
+                    timeout.map(std::time::Duration::from_secs),
+                )
+            })
             .map_err(err)?;
-        Ok(ExecResult { exit_code: code, stdout: lossy(out), stderr: lossy(errb) })
+        Ok(ExecResult {
+            exit_code: code,
+            stdout: lossy(out),
+            stderr: lossy(errb),
+        })
     }
 
     /// Execute a command and stream its output LIVE. Returns an `ExecStream`
@@ -565,31 +592,52 @@ impl Machine {
     }
 
     fn read_file<'py>(&self, py: Python<'py>, path: String) -> PyResult<Bound<'py, PyBytes>> {
-        let data = runtime().map_err(err)?.read_file(&self.name, &path).map_err(err)?;
+        let runtime = runtime().map_err(err)?;
+        let data = py
+            .allow_threads(|| runtime.read_file(&self.name, &path))
+            .map_err(err)?;
         Ok(PyBytes::new_bound(py, &data))
     }
 
     #[pyo3(signature = (path, data, mode=None))]
-    fn write_file(&self, path: String, data: Vec<u8>, mode: Option<u32>) -> PyResult<()> {
-        runtime().map_err(err)?.write_file(&self.name, &path, data, mode).map_err(err)
+    fn write_file(
+        &self,
+        py: Python<'_>,
+        path: String,
+        data: Vec<u8>,
+        mode: Option<u32>,
+    ) -> PyResult<()> {
+        let runtime = runtime().map_err(err)?;
+        py.allow_threads(|| runtime.write_file(&self.name, &path, data, mode))
+            .map_err(err)
     }
 
-    fn pull_image(&self, image: String) -> PyResult<ImageInfo> {
-        let i = runtime().map_err(err)?.pull_image(&self.name, &image).map_err(err)?;
+    fn pull_image(&self, py: Python<'_>, image: String) -> PyResult<ImageInfo> {
+        let runtime = runtime().map_err(err)?;
+        let i = py
+            .allow_threads(|| runtime.pull_image(&self.name, &image))
+            .map_err(err)?;
         Ok(to_image_info(i))
     }
 
-    fn list_images(&self) -> PyResult<Vec<ImageInfo>> {
-        let imgs = runtime().map_err(err)?.list_images(&self.name).map_err(err)?;
+    fn list_images(&self, py: Python<'_>) -> PyResult<Vec<ImageInfo>> {
+        let runtime = runtime().map_err(err)?;
+        let imgs = py
+            .allow_threads(|| runtime.list_images(&self.name))
+            .map_err(err)?;
         Ok(imgs.into_iter().map(to_image_info).collect())
     }
 
-    fn stop(&self) -> PyResult<()> {
-        runtime().map_err(err)?.stop_machine(&self.name).map_err(err)
+    fn stop(&self, py: Python<'_>) -> PyResult<()> {
+        let runtime = runtime().map_err(err)?;
+        py.allow_threads(|| runtime.stop_machine(&self.name))
+            .map_err(err)
     }
 
-    fn delete(&self) -> PyResult<()> {
-        runtime().map_err(err)?.delete_machine(&self.name).map_err(err)
+    fn delete(&self, py: Python<'_>) -> PyResult<()> {
+        let runtime = runtime().map_err(err)?;
+        py.allow_threads(|| runtime.delete_machine(&self.name))
+            .map_err(err)
     }
 }
 

--- a/sdk/python/tests/test_local_e2e.py
+++ b/sdk/python/tests/test_local_e2e.py
@@ -6,12 +6,45 @@ signed smol/smolvm helper, ``SMOLVM_LIB_DIR`` at the libkrun dir). Skips cleanly
 if the native ext isn't available.
 """
 
+import asyncio
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
 
-from smol import ExecutionError, Machine, MachineConfig, ResourceSpec  # noqa: E402
+from smol import (  # noqa: E402
+    AsyncMachine,
+    ExecutionError,
+    Machine,
+    MachineConfig,
+    ResourceSpec,
+)
+
+
+async def concurrent_exec_probe():
+    golden = await AsyncMachine.create(
+        MachineConfig(
+            checkpoint=True,
+            resources=ResourceSpec(cpus=2, memory_mb=1024),
+        )
+    )
+    clones = []
+    try:
+        clones = await golden.fork_batch(
+            names=[f"{golden.name}-concurrency-a", f"{golden.name}-concurrency-b"]
+        )
+        started = time.perf_counter()
+        results = await asyncio.gather(
+            *(clone.exec(["sleep", "2"]) for clone in clones)
+        )
+        return time.perf_counter() - started, results
+    finally:
+        if clones:
+            await asyncio.gather(
+                *(clone.delete() for clone in clones), return_exceptions=True
+            )
+        await golden.delete()
 
 
 def main() -> int:
@@ -27,7 +60,9 @@ def main() -> int:
             print(f"  FAIL {name} {detail}")
 
     print("smol Python SDK local e2e\n")
-    m = Machine.create(MachineConfig(resources=ResourceSpec(cpus=2, memory_mb=1024, network=True)))
+    m = Machine.create(
+        MachineConfig(resources=ResourceSpec(cpus=2, memory_mb=1024, network=True))
+    )
     try:
         check("machine has a name", bool(m.name), m.name)
 
@@ -56,6 +91,14 @@ def main() -> int:
         check("list_images includes python", any("python" in i.reference for i in imgs))
     finally:
         m.delete()
+
+    elapsed, results = asyncio.run(concurrent_exec_probe())
+    check("concurrent execs exit 0", all(result.exit_code == 0 for result in results))
+    check(
+        "concurrent execs overlap off-GIL",
+        elapsed < 3.5,
+        f"two sleep-2 execs took {elapsed:.3f}s",
+    )
 
     print(f"\n{passed} passed, {failed} failed")
     return 1 if failed else 0


### PR DESCRIPTION
Releases the Python GIL around blocking engine calls so concurrent SmolVM operations overlap correctly and registers the Harbor environment alias.