### PR TITLE
Add staged mount support to CLI and SDKs

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -121,6 +121,7 @@ jobs:
           bun test/bun-package-e2e.ts
           bun test/fork-service-e2e.ts
           bun test/checkpoint-branch-e2e.ts
+          bun test/staged-mount-e2e.ts
 
   python-check:
     name: Python · unit + cloud-mock

--- a/sdk/node/binding.d.ts
+++ b/sdk/node/binding.d.ts
@@ -43,6 +43,8 @@ export interface HostMountConfig {
   target: string
   /** Mount as read-only (default: false — writable, matching the CLI). */
   readOnly?: boolean
+  /** Use a guest-local working copy and synchronize changes in batches. */
+  staged?: boolean
 }
 /** A port mapping from host to guest. */
 export interface PortMappingConfig {
@@ -214,6 +216,8 @@ export declare class NapiMachine {
   readFile(path: string): Promise<Buffer>
   /** Execute a command and return streaming stdout/stderr/exit events. */
   execStreaming(command: Array<string>, options?: ExecOptions | undefined | null): Promise<Array<ExecStreamEvent>>
+  /** Copy guest-local staged mounts back to their host sources. */
+  sync(): Promise<void>
   /** Stop the machine VM gracefully. */
   stop(): Promise<void>
   /** Stop the machine and clean up all storage (disks, config). */

--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -240,6 +240,11 @@ export class Machine {
     return this.transport.listImages();
   }
 
+  /** Copy guest-local staged mounts back to their host directories without stopping. */
+  sync(): Promise<void> {
+    return this.transport.sync();
+  }
+
   /** Stop the machine. */
   stop(): Promise<void> {
     return this.transport.stop();

--- a/sdk/node/native.ts
+++ b/sdk/node/native.ts
@@ -23,6 +23,7 @@ export interface NativeHostMount {
   source: string;
   target: string;
   readOnly?: boolean | undefined;
+  staged?: boolean | undefined;
 }
 
 export interface NativePortMapping {
@@ -123,6 +124,7 @@ export interface NapiMachine {
   ): Promise<void>;
   readFile(path: string): Promise<Buffer>;
   execStream(command: string[], options?: NativeExecOptions): NativeExecStream;
+  sync(): Promise<void>;
   stop(): Promise<void>;
   delete(): Promise<void>;
 }

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -50,6 +50,7 @@
     "build": "npm run build:native && npm run build:ts && npm run bundle:native",
     "bundle:native": "cp binding.js binding.d.ts *.node dist/ 2>/dev/null || true",
     "test:e2e": "napi build --platform --js binding.js --dts binding.d.ts && tsx test/e2e.ts",
+    "test:staged": "tsx test/staged-mount-e2e.ts",
     "gen:openapi": "bash scripts/gen-openapi.sh",
     "test:cloud": "tsx test/cloud-mock.ts",
     "test:unit": "tsx test/unit.ts"

--- a/sdk/node/src/machine.rs
+++ b/sdk/node/src/machine.rs
@@ -67,6 +67,11 @@ impl NapiMachine {
         let remote_volumes: Vec<_> = remote_specs
             .into_iter()
             .map(|m| {
+                if m.staged.unwrap_or(false) {
+                    return Err(smolvm::Error::invalid_mount_path(
+                        "staged mode is only supported for local host directories",
+                    ));
+                }
                 smolvm::remote_volume::from_parts(
                     &m.source,
                     &m.target,
@@ -457,6 +462,17 @@ impl NapiMachine {
         .into_napi()?;
 
         Ok(events.into_iter().map(ExecStreamEvent::from).collect())
+    }
+
+    /// Copy guest-local staged mounts back to their host sources.
+    #[napi]
+    pub async fn sync(&self) -> napi::Result<()> {
+        let runtime = runtime().into_napi()?;
+        let name = self.name.clone();
+        tokio::task::spawn_blocking(move || runtime.sync_machine(&name))
+            .await
+            .map_err(join_error)?
+            .into_napi()
     }
 
     /// Stop the machine VM gracefully.

--- a/sdk/node/src/types.rs
+++ b/sdk/node/src/types.rs
@@ -60,6 +60,8 @@ pub struct HostMountConfig {
     pub target: String,
     /// Mount as read-only (default: false — writable, matching the CLI).
     pub read_only: Option<bool>,
+    /// Use a guest-local working copy and synchronize changes in batches.
+    pub staged: Option<bool>,
 }
 
 /// A port mapping from host to guest.
@@ -193,7 +195,16 @@ impl TryFrom<&HostMountConfig> for HostMount {
         // Default writable, matching the engine's own `HostMount::parse`
         // (host:guest[:ro|:rw] defaults to writable) and the `smol -v` CLI. A
         // read-only mount is opt-in via read_only: true.
-        HostMount::new(&m.source, &m.target, m.read_only.unwrap_or(false))
+        let read_only = m.read_only.unwrap_or(false);
+        let staged = m.staged.unwrap_or(false);
+        if read_only && staged {
+            return Err(smolvm::Error::invalid_mount_path(
+                "a staged mount is writable and cannot also be read-only",
+            ));
+        }
+        let mut mount = HostMount::new(&m.source, &m.target, read_only)?;
+        mount.staged = staged;
+        Ok(mount)
     }
 }
 

--- a/sdk/node/test/cloud-mock.ts
+++ b/sdk/node/test/cloud-mock.ts
@@ -473,6 +473,14 @@ async function main(): Promise<void> {
   }
   check("cloud create rejects host mounts as NotSupported", mountsGated);
 
+  let syncGated = false;
+  try {
+    await m.sync();
+  } catch (e) {
+    syncGated = e instanceof NotSupportedError;
+  }
+  check("cloud sync is gated as NotSupported", syncGated);
+
   // Published ports ARE a cloud feature: create sends only the guest port; the
   // control plane allocates the node host port. (Contrast: host mounts above.)
   await Machine.create(

--- a/sdk/node/test/staged-mount-e2e.ts
+++ b/sdk/node/test/staged-mount-e2e.ts
@@ -1,0 +1,41 @@
+/** Local staged-mount E2E: explicit sync and graceful-stop sync. */
+
+import assert from "node:assert";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Machine } from "../index";
+
+async function main(): Promise<void> {
+  const host = mkdtempSync(join(tmpdir(), "smol-staged-node-"));
+  const name = `staged-node-${process.pid}-${Date.now()}`;
+  writeFileSync(join(host, "state.txt"), "initial\n");
+  const machine = await Machine.create({
+    name,
+    image: "alpine:3.20",
+    persistent: true,
+    mounts: [{ source: host, target: "/work", staged: true }],
+    resources: { cpus: 1, memoryMb: 512, network: true },
+  });
+  try {
+    (await machine.exec(["sh", "-c", "echo explicit > /work/state.txt"]))
+      .assertSuccess();
+    assert.strictEqual(readFileSync(join(host, "state.txt"), "utf8"), "initial\n");
+    await machine.sync();
+    assert.strictEqual(readFileSync(join(host, "state.txt"), "utf8"), "explicit\n");
+
+    (await machine.exec(["sh", "-c", "echo stopped > /work/state.txt"]))
+      .assertSuccess();
+    await machine.stop();
+    assert.strictEqual(readFileSync(join(host, "state.txt"), "utf8"), "stopped\n");
+    console.log("staged mount explicit sync + graceful stop: PASS");
+  } finally {
+    await machine.delete();
+    rmSync(host, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/sdk/node/test/unit.ts
+++ b/sdk/node/test/unit.ts
@@ -112,6 +112,14 @@ check('forwards image workload env and workdir to the local engine', () => {
   assert.deepStrictEqual(cfg.env, [{ key: 'SESSION', value: 'golden' }]);
   assert.strictEqual(cfg.workdir, '/workspace');
 });
+check('forwards staged mount mode to the local engine', () => {
+  const cfg = toNativeConfig('m', {
+    mounts: [{ source: '/host/work', target: '/work', staged: true }],
+  });
+  assert.deepStrictEqual(cfg.mounts, [
+    { source: '/host/work', target: '/work', readOnly: undefined, staged: true },
+  ]);
+});
 
 check('rollout adapter digest matches the engine contract', () => {
   const dir = mkdtempSync(join(tmpdir(), 'smol-rollout-unit-'));

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -107,6 +107,7 @@ export interface Transport {
   pullImage(image: string): Promise<ImageInfo>;
   listImages(): Promise<ImageInfo[]>;
   readonly machineId: string;
+  sync(): Promise<void>;
   stop(): Promise<void>;
   start(): Promise<void>;
   delete(): Promise<void>;
@@ -258,6 +259,7 @@ export function toNativeConfig(
       // lowercase `readonly` for backwards compatibility. Undefined → engine
       // default (writable).
       readOnly: m.readOnly ?? m.readonly,
+      staged: m.staged,
     })),
     ports: config.ports?.map((p) => ({ host: p.host, guest: p.guest })),
     resources:
@@ -462,6 +464,14 @@ class LocalTransport implements Transport {
   async listImages(): Promise<ImageInfo[]> {
     try {
       return await this.inner.listImages();
+    } catch (e) {
+      throw wrapNativeError(e);
+    }
+  }
+
+  async sync(): Promise<void> {
+    try {
+      await this.inner.sync();
     } catch (e) {
       throw wrapNativeError(e);
     }
@@ -1082,6 +1092,12 @@ class CloudTransport implements Transport {
   async listImages(): Promise<ImageInfo[]> {
     throw new NotSupportedError(
       "listImages is not available on the cloud target.",
+    );
+  }
+
+  async sync(): Promise<void> {
+    throw new NotSupportedError(
+      "sync() is local-only because cloud machines cannot carry host-directory mounts.",
     );
   }
 

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -52,6 +52,11 @@ export interface MountSpec {
   readOnly?: boolean;
   /** @deprecated Use `readOnly`. Kept for backwards compatibility. */
   readonly?: boolean;
+  /**
+   * Run from a guest-local working copy and copy changes back on `sync()`,
+   * graceful stop, or delete. Local only; cannot be combined with `readOnly`.
+   */
+  staged?: boolean;
 }
 
 /** Host→guest port mapping. */

--- a/sdk/python/python/smol/async_machine.py
+++ b/sdk/python/python/smol/async_machine.py
@@ -197,6 +197,10 @@ class AsyncMachine:
         """List cached OCI images. (local)"""
         return await asyncio.to_thread(self._m.list_images)
 
+    async def sync(self) -> None:
+        """Copy guest-local staged mounts back to their host directories without stopping."""
+        await asyncio.to_thread(self._m.sync)
+
     async def stop(self) -> None:
         """Stop the machine."""
         await asyncio.to_thread(self._m.stop)

--- a/sdk/python/python/smol/machine.py
+++ b/sdk/python/python/smol/machine.py
@@ -215,6 +215,10 @@ class Machine:
         """List cached OCI images. (local)"""
         return self._t.list_images()
 
+    def sync(self) -> None:
+        """Copy guest-local staged mounts back to their host directories without stopping."""
+        self._t.sync()
+
     def stop(self) -> None:
         """Stop the machine."""
         self._t.stop()

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -117,6 +117,7 @@ class Transport(Protocol):
     def pull_image(self, image: str) -> ImageInfo: ...
     def list_images(self) -> list[ImageInfo]: ...
     def stop(self) -> None: ...
+    def sync(self) -> None: ...
     def start(self) -> None: ...
     def delete(self) -> None: ...
     def delete_with_usage(self) -> MachineUsageReport: ...
@@ -217,7 +218,12 @@ def _native_config(name: str, config: MachineConfig) -> dict:
         cfg["workdir"] = config.workdir
     if config.mounts:
         cfg["mounts"] = [
-            {"source": m.source, "target": m.target, "read_only": m.effective_read_only}
+            {
+                "source": m.source,
+                "target": m.target,
+                "read_only": m.effective_read_only,
+                "staged": m.staged,
+            }
             for m in config.mounts
         ]
     if config.ports:
@@ -437,6 +443,12 @@ class LocalTransport:
     def list_images(self) -> list[ImageInfo]:
         try:
             return [_image_info(i) for i in self._inner.list_images()]
+        except Exception as e:  # noqa: BLE001
+            raise wrap_native_error(e) from e
+
+    def sync(self) -> None:
+        try:
+            self._inner.sync()
         except Exception as e:  # noqa: BLE001
             raise wrap_native_error(e) from e
 
@@ -820,6 +832,11 @@ class CloudTransport:
 
     def list_images(self) -> list[ImageInfo]:
         raise NotSupportedError("list_images is not available on the cloud target.")
+
+    def sync(self) -> None:
+        raise NotSupportedError(
+            "sync() is local-only because cloud machines cannot carry host-directory mounts."
+        )
 
     def stop(self) -> None:
         _cloud_fetch(self._base, self._key, "POST", f"/v1/machines/{self._id}/stop")

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -64,6 +64,9 @@ class MountSpec:
     """Mount read-only. Default: False (writable), matching the ``smol -v`` CLI."""
     readonly: Optional[bool] = None
     """Deprecated alias for :attr:`read_only`; kept for backwards compatibility."""
+    staged: bool = False
+    """Use a guest-local working copy and copy changes back on :meth:`Machine.sync`,
+    graceful stop, or delete. Local only; incompatible with read-only mode."""
 
     @property
     def effective_read_only(self) -> bool:

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -324,7 +324,7 @@ impl Machine {
                 }
             }
         }
-        // Map the Python `mounts` list (dicts of {source, target, read_only})
+        // Map the Python `mounts` list (dicts of {source, target, read_only, staged})
         // → engine `HostMount` (mirrors smol-node's `HostMount::try_from`).
         // `HostMount::new` validates the paths, so config errors surface here.
         let mut mounts: Vec<smolvm::agent::HostMount> = Vec::new();
@@ -350,20 +350,34 @@ impl Machine {
                         Some(v) if !v.is_none() => v.extract()?,
                         _ => true,
                     };
+                    let staged: bool = match d.get_item("staged")? {
+                        Some(v) if !v.is_none() => v.extract()?,
+                        _ => false,
+                    };
+                    if read_only && staged {
+                        return Err(PyRuntimeError::new_err(
+                            "[MOUNT_ERROR] a staged mount is writable and cannot also be read-only",
+                        ));
+                    }
                     // An `s3://` source is mounted inside the guest by the
                     // agent, not bind-mounted from the host, so it must not go
                     // through the host-directory validation below — which would
                     // reject it as a missing directory.
                     if smolvm::remote_volume::is_remote_source(&source) {
+                        if staged {
+                            return Err(PyRuntimeError::new_err(
+                                "[MOUNT_ERROR] staged mode is only supported for local host directories",
+                            ));
+                        }
                         remote_volumes.push(
                             smolvm::remote_volume::from_parts(&source, &target, read_only)
                                 .map_err(err)?,
                         );
                     } else {
-                        mounts.push(
-                            smolvm::agent::HostMount::new(&source, &target, read_only)
-                                .map_err(err)?,
-                        );
+                        let mut mount = smolvm::agent::HostMount::new(&source, &target, read_only)
+                            .map_err(err)?;
+                        mount.staged = staged;
+                        mounts.push(mount);
                     }
                 }
             }
@@ -513,6 +527,13 @@ impl Machine {
             source_pause_ms: result.source_pause.as_secs_f64() * 1000.0,
             elapsed_ms: result.elapsed.as_secs_f64() * 1000.0,
         })
+    }
+
+    /// Copy guest-local staged mounts back to their host sources.
+    fn sync(&self, py: Python<'_>) -> PyResult<()> {
+        let runtime = runtime().map_err(err)?;
+        py.allow_threads(|| runtime.sync_machine(&self.name))
+            .map_err(err)
     }
 
     /// Fork this running, forkable machine into a new clone via copy-on-write

--- a/sdk/python/tests/test_cloud_mock.py
+++ b/sdk/python/tests/test_cloud_mock.py
@@ -509,6 +509,12 @@ def main() -> int:
         except NotSupportedError:
             check("cloud create rejects host mounts", True)
 
+        try:
+            m.sync()
+            check("cloud sync is gated as NotSupported", False, "did not raise")
+        except NotSupportedError:
+            check("cloud sync is gated as NotSupported", True)
+
         # Published ports ARE a cloud feature: create sends only the guest port;
         # the control plane allocates the node host port. (Contrast: mounts above.)
         Machine.create(

--- a/sdk/python/tests/test_mounts_e2e.py
+++ b/sdk/python/tests/test_mounts_e2e.py
@@ -6,6 +6,7 @@ becomes visible inside the guest, and a read-only mount rejects writes.
 Needs the native build + boot env (SMOLVM_BOOT_BINARY, SMOLVM_LIB_DIR).
 """
 
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -61,6 +62,31 @@ def main() -> int:
               Path(host_dir2, "out.txt").exists()
               and Path(host_dir2, "out.txt").read_text().strip() == "FROM_GUEST",
               "guest write not visible on host")
+
+    # Staged mode deliberately hides guest writes until explicit sync, then
+    # synchronizes the final state again during graceful stop.
+    host_dir3 = tempfile.mkdtemp(prefix="smolmount-staged-")
+    Path(host_dir3, "state.txt").write_text("initial\n")
+    m = Machine.create(
+        MachineConfig(
+            name=f"staged-python-{os.getpid()}",
+            persistent=True,
+            mounts=[MountSpec(source=host_dir3, target="/mnt/staged", staged=True)],
+            resources=ResourceSpec(cpus=1, memory_mb=512),
+        )
+    )
+    try:
+        first = m.exec(["sh", "-c", "echo explicit > /mnt/staged/state.txt"])
+        check("staged_write_succeeds", first.exit_code == 0, first.stderr)
+        check("staged_write_isolated", Path(host_dir3, "state.txt").read_text() == "initial\n")
+        m.sync()
+        check("staged_explicit_sync", Path(host_dir3, "state.txt").read_text() == "explicit\n")
+        second = m.exec(["sh", "-c", "echo stopped > /mnt/staged/state.txt"])
+        check("staged_second_write", second.exit_code == 0, second.stderr)
+        m.stop()
+        check("staged_stop_sync", Path(host_dir3, "state.txt").read_text() == "stopped\n")
+    finally:
+        m.delete()
 
     print(f"\n{passed} passed, {failed} failed")
     print("RESULT=PASS" if failed == 0 else "RESULT=FAIL")

--- a/sdk/python/tests/test_unit.py
+++ b/sdk/python/tests/test_unit.py
@@ -22,6 +22,7 @@ from smol.types import (  # noqa: E402
     ConnectOptions,
     ExecResult,
     MachineConfig,
+    MountSpec,
     ResourceSpec,
 )
 
@@ -238,6 +239,20 @@ def test_native_config_forwards_image_workload_env_and_workdir():
     assert native["command"] == ["python", "-m", "service"]
     assert native["env"] == {"SESSION": "golden"}
     assert native["workdir"] == "/workspace"
+
+
+def test_native_config_forwards_staged_mount_mode():
+    cfg = MachineConfig(
+        mounts=[MountSpec(source="/host/work", target="/work", staged=True)]
+    )
+    assert _native_config("m", cfg)["mounts"] == [
+        {
+            "source": "/host/work",
+            "target": "/work",
+            "read_only": False,
+            "staged": True,
+        }
+    ]
 
 
 def test_rollout_adapter_digest_matches_engine_contract():

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -53,8 +53,8 @@ pub struct CreateCmd {
     #[arg(trailing_var_arg = true, value_name = "COMMAND")]
     pub command: Vec<String>,
 
-    /// Mount host directory (HOST:GUEST[:ro])
-    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
+    /// Mount a host directory. `:staged` uses a guest-local working copy until sync or stop.
+    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro|rw|staged]")]
     pub volume: Vec<String>,
 
     /// Expose port (HOST:GUEST)
@@ -147,11 +147,9 @@ impl CreateCmd {
         // them off before the host-directory parse, which would reject an
         // `s3://` source as a missing directory.
         let (host_volume_specs, remote_volumes) = smolvm::remote_volume::split_specs(&self.volume)?;
-        let mounts: Vec<(String, String, bool)> =
-            smolvm::data::storage::HostMount::parse(&host_volume_specs)?
-                .into_iter()
-                .map(|m| m.to_storage_tuple())
-                .collect();
+        let parsed_mounts = smolvm::data::storage::HostMount::parse(&host_volume_specs)?;
+        let (mounts, staged_mounts) =
+            smolvm::data::storage::HostMount::split_storage_tuples(&parsed_mounts);
 
         let ports = smolvm::data::network::PortMapping::to_tuples(&self.port);
 
@@ -180,6 +178,7 @@ impl CreateCmd {
 
         let mut record =
             smolvm::config::VmRecord::new(name.clone(), self.cpus, self.mem, mounts, ports, net);
+        record.staged_mounts = staged_mounts;
         if !allow_cidrs.is_empty() {
             record.allowed_cidrs = Some(allow_cidrs);
         }
@@ -274,11 +273,9 @@ impl CreateCmd {
         // them off before the host-directory parse, which would reject an
         // `s3://` source as a missing directory.
         let (host_volume_specs, remote_volumes) = smolvm::remote_volume::split_specs(&self.volume)?;
-        let mounts: Vec<(String, String, bool)> =
-            smolvm::data::storage::HostMount::parse(&host_volume_specs)?
-                .into_iter()
-                .map(|m| m.to_storage_tuple())
-                .collect();
+        let parsed_mounts = smolvm::data::storage::HostMount::parse(&host_volume_specs)?;
+        let (mounts, staged_mounts) =
+            smolvm::data::storage::HostMount::split_storage_tuples(&parsed_mounts);
         let ports = smolvm::data::network::PortMapping::to_tuples(&self.port);
         let mut env = smolvm::util::parse_env_list(&manifest.env);
         env.extend(smolvm::util::parse_env_list(&self.env));
@@ -291,6 +288,7 @@ impl CreateCmd {
             ports,
             self.net || manifest.network,
         );
+        record.staged_mounts = staged_mounts;
         record.image = Some(manifest.image);
         record.remote_volumes = remote_volumes;
         // CLI trailing args override the artifact's baked (entrypoint, cmd),

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -168,7 +168,7 @@ impl ExecCmd {
                     .enumerate()
                     .map(|(i, m)| {
                         (
-                            smolvm::data::storage::HostMount::mount_tag(i),
+                            m.runtime_mount_tag(i),
                             m.target.to_string_lossy().into_owned(),
                             m.read_only,
                         )

--- a/src/commands/machine.rs
+++ b/src/commands/machine.rs
@@ -65,6 +65,9 @@ pub enum MachineSubcommand {
     /// Copy files between host and machine
     Cp(crate::commands::cp::CpCmd),
 
+    /// Synchronize guest-local staged mounts back to their host directories
+    Sync(crate::commands::sync::SyncCmd),
+
     /// Branch a running, branchable machine into an independent child (CoW RAM + disks)
     #[command(name = "branch", visible_alias = "fork")]
     Branch(crate::commands::fork::ForkCmd),
@@ -125,6 +128,7 @@ impl MachineCmd {
             .run(),
             MachineSubcommand::Logs(cmd) => cmd.run(),
             MachineSubcommand::Cp(cmd) => cmd.run(),
+            MachineSubcommand::Sync(cmd) => cmd.run(),
             MachineSubcommand::Branch(cmd) => cmd.run(),
             MachineSubcommand::BranchBatch(cmd) => cmd.run(),
             MachineSubcommand::Checkpoint(cmd) => cmd.run(),
@@ -205,5 +209,14 @@ mod tests {
             assert_eq!(batch.golden, "source");
             assert_eq!(batch.count, Some(2));
         }
+    }
+
+    #[test]
+    fn sync_is_available_on_the_machine_surface() {
+        let parsed = TestCli::parse_from(["smol", "sync", "--name", "workspace"]);
+        let MachineSubcommand::Sync(sync) = parsed.command else {
+            panic!("expected sync command");
+        };
+        assert_eq!(sync.name.as_deref(), Some("workspace"));
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -39,5 +39,6 @@ pub mod scale;
 pub mod start;
 pub mod status;
 pub mod stop;
+pub mod sync;
 pub mod up;
 pub mod update;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -32,8 +32,8 @@ pub struct RunCmd {
     #[arg(short = 'w', long, value_name = "DIR")]
     pub workdir: Option<String>,
 
-    /// Mount host directory (HOST:GUEST[:ro])
-    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
+    /// Mount a host directory. `:staged` uses a guest-local working copy and syncs on exit.
+    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro|rw|staged]")]
     pub volume: Vec<String>,
 
     /// Expose port (HOST:GUEST)
@@ -112,7 +112,7 @@ impl RunCmd {
             .enumerate()
             .map(|(i, m)| {
                 (
-                    HostMount::mount_tag(i),
+                    m.runtime_mount_tag(i),
                     m.target.to_string_lossy().into_owned(),
                     m.read_only,
                 )
@@ -260,6 +260,14 @@ impl RunCmd {
             }
         };
 
+        if mounts.iter().any(|mount| mount.staged) {
+            if let Err(error) = smolvm::staged_mount::sync_mounts(&mounts, &mut client) {
+                manager.detach();
+                return Err(anyhow::anyhow!(
+                    "sync staged mounts: {error}; the ephemeral machine was left running so its guest-local data remains recoverable"
+                ));
+            }
+        }
         manager.kill();
         std::process::exit(exit_code);
     }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -53,6 +53,7 @@ impl StatusCmd {
                 "memory_mib": record.as_ref().map(|r| r.mem),
                 "image": record.as_ref().and_then(|r| r.image.clone()),
                 "network": record.as_ref().map(|r| r.network),
+                "mounts": record.as_ref().map(|r| r.mounts.len() + r.staged_mounts.len()),
             });
             println!("{}", serde_json::to_string_pretty(&obj)?);
         } else if is_running {
@@ -68,8 +69,8 @@ impl StatusCmd {
                 if r.network {
                     println!("  Network: enabled");
                 }
-                if !r.mounts.is_empty() {
-                    println!("  Mounts: {}", r.mounts.len());
+                if !r.mounts.is_empty() || !r.staged_mounts.is_empty() {
+                    println!("  Mounts: {}", r.mounts.len() + r.staged_mounts.len());
                 }
                 if !r.ports.is_empty() {
                     println!("  Ports: {}", r.ports.len());

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -44,7 +44,16 @@ impl StopCmd {
                 }
 
                 println!("Stopping machine '{}'...", name);
+                let _source_lock = smolvm::agent::fork::lock_fork_source(&name)?;
                 let manager = AgentManager::for_vm(&name)?;
+                // Explicit stop still works after detach; this only prevents a
+                // failed sync from stopping the machine through Drop.
+                manager.detach();
+                if !record.staged_mounts.is_empty() {
+                    let mut client =
+                        smolvm::agent::AgentClient::connect_with_retry(manager.vsock_socket())?;
+                    smolvm::staged_mount::sync_staged_mounts(&record, &mut client)?;
+                }
                 manager.stop()?;
 
                 config.update_vm(&name, |r| {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,0 +1,53 @@
+//! smol machine sync — copy staged mount contents back to the host.
+
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct SyncCmd {
+    /// Machine to synchronize (default: "default")
+    #[arg(short = 'n', long, value_name = "NAME")]
+    pub name: Option<String>,
+
+    /// Force a local machine. Staged host mounts are local-only.
+    #[arg(long)]
+    pub local: bool,
+
+    /// Reject explicitly: cloud machines cannot carry host-directory mounts.
+    #[arg(long, conflicts_with = "local")]
+    pub cloud: bool,
+}
+
+impl SyncCmd {
+    pub fn run(self) -> anyhow::Result<()> {
+        use super::resolve::{self, Location, Target};
+
+        let target = Target::from_flags(self.local, self.cloud)?;
+        let (location, name) = resolve::route(self.name.as_deref(), target)?;
+        if location == Location::Cloud {
+            anyhow::bail!("staged mounts are local-only; cloud machines have no host directories to synchronize");
+        }
+
+        let db = smolvm::db::SmolvmDb::open()?;
+        let record = db
+            .get_vm(&name)?
+            .ok_or_else(|| smolvm::Error::vm_not_found(&name))?;
+        if record.staged_mounts.is_empty() {
+            println!("Machine '{name}' has no staged mounts");
+            return Ok(());
+        }
+
+        let _source_lock = smolvm::agent::fork::lock_fork_source(&name)?;
+        let manager = smolvm::agent::AgentManager::for_vm(&name)?;
+        if manager.try_connect_existing().is_none() {
+            anyhow::bail!(
+                "machine '{name}' is not running; start it before synchronizing staged mounts"
+            );
+        }
+        let mut client = smolvm::agent::AgentClient::connect_with_retry(manager.vsock_socket())?;
+        // A failed sync must leave the persistent machine available for retry.
+        manager.detach();
+        smolvm::staged_mount::sync_staged_mounts(&record, &mut client)?;
+        println!("Synchronized staged mounts for '{name}'");
+        Ok(())
+    }
+}

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -171,16 +171,7 @@ impl UpCmd {
 
         // Create or update record
         let ports_tuples = PortMapping::to_tuples(&ports);
-        let mounts_tuples: Vec<(String, String, bool)> = mounts
-            .iter()
-            .map(|m| {
-                (
-                    m.source.to_string_lossy().to_string(),
-                    m.target.to_string_lossy().to_string(),
-                    m.read_only,
-                )
-            })
-            .collect();
+        let (mounts_tuples, staged_mounts) = HostMount::split_storage_tuples(&mounts);
         // Virtiofs binding form (tag, guest_target, read_only) for running init
         // inside the image container — computed before `mounts` is consumed by
         // `ensure_running_with_full_config` below.
@@ -189,7 +180,7 @@ impl UpCmd {
             .enumerate()
             .map(|(i, m)| {
                 (
-                    HostMount::mount_tag(i),
+                    m.runtime_mount_tag(i),
                     m.target.to_string_lossy().into_owned(),
                     m.read_only,
                 )
@@ -199,6 +190,7 @@ impl UpCmd {
         if config.get_vm(&name).is_none() {
             let mut record =
                 VmRecord::new(name.clone(), cpus, mem, mounts_tuples, ports_tuples, net);
+            record.staged_mounts = staged_mounts;
             record.image = sf.image.clone();
             record.env = env.clone();
             record.workdir = workdir.clone();

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -17,8 +17,8 @@ pub struct UpdateCmd {
     #[arg(short = 'n', long, value_name = "NAME")]
     pub name: String,
 
-    /// Add volume mount (HOST:GUEST[:ro])
-    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
+    /// Add a host mount. `:staged` uses a guest-local working copy until sync or stop.
+    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro|rw|staged]")]
     pub volume: Vec<String>,
     /// Remove volume mount (HOST:GUEST)
     #[arg(long = "remove-volume", value_name = "HOST:GUEST")]
@@ -108,6 +108,39 @@ impl UpdateCmd {
             smolvm::remote_volume::split_specs(&self.volume)?;
         let new_mounts = HostMount::parse(&host_volume_specs)?;
 
+        // Preserve mount modes and ordering while applying additions/removals.
+        let mut final_mounts = record.host_mounts();
+        for rm in &self.remove_volume {
+            let rm_without_mode = rm
+                .strip_suffix(":ro")
+                .or_else(|| rm.strip_suffix(":rw"))
+                .or_else(|| rm.strip_suffix(":staged"))
+                .unwrap_or(rm);
+            let canonical_rm = if let Some((rm_src, rm_tgt)) = rm_without_mode.rsplit_once(':') {
+                let resolved = std::fs::canonicalize(rm_src)
+                    .unwrap_or_else(|_| std::path::PathBuf::from(rm_src));
+                Some((resolved, std::path::PathBuf::from(rm_tgt)))
+            } else {
+                None
+            };
+            final_mounts.retain(|mount| {
+                canonical_rm.as_ref().is_none_or(|(source, target)| {
+                    mount.source != *source || mount.target != *target
+                })
+            });
+        }
+        for mount in &new_mounts {
+            if !final_mounts
+                .iter()
+                .any(|current| current.source == mount.source && current.target == mount.target)
+            {
+                final_mounts.push(mount.clone());
+            }
+        }
+        HostMount::ensure_unique_targets(&final_mounts)?;
+        let (final_live_mounts, final_staged_mounts) =
+            HostMount::split_storage_tuples(&final_mounts);
+
         // Reject duplicate host ports after the proposed changes.
         {
             let mut final_ports: Vec<PortMapping> = record
@@ -151,22 +184,27 @@ impl UpdateCmd {
             if let Some(o) = self.overlay {
                 r.overlay_gb = Some(o);
             }
-            for rm in &self.remove_volume {
-                let canonical_rm = if let Some((rm_src, rm_tgt)) = rm.split_once(':') {
-                    let resolved = std::fs::canonicalize(rm_src)
-                        .unwrap_or_else(|_| std::path::PathBuf::from(rm_src));
-                    format!("{}:{}", resolved.display(), rm_tgt)
-                } else {
-                    rm.clone()
-                };
-                let before = r.mounts.len();
-                r.mounts.retain(|(src, tgt, _)| {
-                    let spec = format!("{src}:{tgt}");
-                    spec != canonical_rm && spec != *rm
-                });
-                if r.mounts.len() < before {
+            if !self.remove_volume.is_empty() || !new_mounts.is_empty() {
+                for rm in &self.remove_volume {
                     changes.push(format!("  removed volume: {rm}"));
                 }
+                for mount in &new_mounts {
+                    let mode = if mount.staged {
+                        ":staged"
+                    } else if mount.read_only {
+                        ":ro"
+                    } else {
+                        ""
+                    };
+                    changes.push(format!(
+                        "  added volume: {}:{}{}",
+                        mount.source.display(),
+                        mount.target.display(),
+                        mode
+                    ));
+                }
+                r.mounts = final_live_mounts.clone();
+                r.staged_mounts = final_staged_mounts.clone();
             }
             for rv in &new_remote_volumes {
                 if !r
@@ -181,22 +219,6 @@ impl UpdateCmd {
                         if rv.read_only { ":ro" } else { "" }
                     ));
                     r.remote_volumes.push(rv.clone());
-                }
-            }
-            for m in &new_mounts {
-                let tuple = m.to_storage_tuple();
-                if !r
-                    .mounts
-                    .iter()
-                    .any(|(s, t, _)| *s == tuple.0 && *t == tuple.1)
-                {
-                    changes.push(format!(
-                        "  added volume: {}:{}{}",
-                        tuple.0,
-                        tuple.1,
-                        if tuple.2 { ":ro" } else { "" }
-                    ));
-                    r.mounts.push(tuple);
                 }
             }
             for rm in &self.remove_port {


### PR DESCRIPTION
Adds staged mount creation and synchronization across Smolfile, the CLI, and the Node/Bun and Python SDKs, and depends on smol-machines/smolvm#1126.