### PR TITLE
Expose the workload user across the CLI

### DIFF
--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -647,6 +647,10 @@ pub struct CloudExecArgs {
     #[arg(short = 'w', long, value_name = "DIR")]
     pub workdir: Option<String>,
 
+    /// Run as this user (name or `uid[:gid]`), overriding the image's USER.
+    #[arg(short = 'u', long, value_name = "USER")]
+    pub user: Option<String>,
+
     /// Command timeout in seconds (default 600)
     #[arg(long, value_name = "SECONDS")]
     pub timeout: Option<u64>,
@@ -747,6 +751,7 @@ impl CloudCmd {
                 stream: false,
                 env: vec![],
                 workdir: None,
+                user: None,
                 secret_env: vec![],
                 secret_file: vec![],
                 timeout: None,
@@ -776,6 +781,7 @@ impl CloudCmd {
                     stream: a.follow,
                     env: vec![],
                     workdir: None,
+                    user: None,
                     secret_env: vec![],
                     secret_file: vec![],
                     timeout: None,
@@ -823,6 +829,7 @@ impl CloudCmd {
                     stream: false,
                     env,
                     workdir: a.workdir,
+                    user: a.user,
                     secret_env: a.secret_env,
                     secret_file: a.secret_file,
                     timeout: a.timeout,

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -107,6 +107,12 @@ pub struct CreateCmd {
     #[arg(short = 'w', long, value_name = "DIR")]
     pub workdir: Option<String>,
 
+    /// Run the workload as this user, like `docker run --user`: a name from the
+    /// image or a numeric `uid[:gid]`. Overrides the image's USER, so a workload
+    /// can match the owner of a mounted host directory.
+    #[arg(short = 'u', long, value_name = "USER")]
+    pub user: Option<String>,
+
     /// Inject a secret from a host env var (GUEST_VAR=HOST_VAR), resolved at
     /// each start/exec; only the reference is stored, never the plaintext
     #[arg(long = "secret-env", value_name = "GUEST_VAR=HOST_VAR")]
@@ -196,6 +202,7 @@ impl CreateCmd {
         }
         record.env = env;
         record.workdir = self.workdir;
+        record.user = self.user;
         record.init = self.init;
         record.ssh_agent = self.ssh_agent;
         // Store secret references (not plaintext); resolved at each start/exec.
@@ -302,6 +309,7 @@ impl CreateCmd {
         }
         record.env = env;
         record.workdir = manifest.workdir;
+        record.user = self.user.or(manifest.user);
         record.init = self.init;
         record.ssh_agent = self.ssh_agent;
         record.network_backend = self.net_backend;

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -63,6 +63,11 @@ pub struct ExecCmd {
     #[arg(short = 'w', long, value_name = "DIR")]
     pub workdir: Option<String>,
 
+    /// Run as this user (a name from the image or a numeric `uid[:gid]`),
+    /// overriding the image's USER.
+    #[arg(short = 'u', long, value_name = "USER")]
+    pub user: Option<String>,
+
     /// Inject a secret from a host env var (GUEST_VAR=HOST_VAR), resolved on the
     /// host for this exec; never persisted
     #[arg(long = "secret-env", value_name = "GUEST_VAR=HOST_VAR")]
@@ -205,6 +210,7 @@ impl ExecCmd {
                 let config = RunConfig::new(image, command.clone())
                     .with_env(env)
                     .with_workdir(self.workdir.clone())
+                    .with_user(self.user.clone())
                     .with_timeout(timeout)
                     .with_mounts(mount_bindings.clone())
                     .with_persistent_overlay(Some(overlay_owner.clone()));
@@ -226,6 +232,7 @@ impl ExecCmd {
                 let config = RunConfig::new(image, command.clone())
                     .with_env(env)
                     .with_workdir(self.workdir.clone())
+                    .with_user(self.user.clone())
                     .with_timeout(timeout)
                     .with_tty(self.tty)
                     .with_mounts(mount_bindings.clone())
@@ -238,6 +245,7 @@ impl ExecCmd {
             let config = RunConfig::new(image, command.clone())
                 .with_env(env)
                 .with_workdir(self.workdir.clone())
+                .with_user(self.user.clone())
                 .with_timeout(timeout)
                 .with_mounts(mount_bindings)
                 .with_persistent_overlay(Some(overlay_owner));

--- a/src/commands/machine.rs
+++ b/src/commands/machine.rs
@@ -119,6 +119,7 @@ impl MachineCmd {
                 stream: false,
                 env: vec![],
                 workdir: None,
+                user: None,
                 secret_env: vec![],
                 secret_file: vec![],
                 timeout: None,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -32,6 +32,11 @@ pub struct RunCmd {
     #[arg(short = 'w', long, value_name = "DIR")]
     pub workdir: Option<String>,
 
+    /// Run as this user (a name from the image or a numeric `uid[:gid]`),
+    /// overriding the image's USER.
+    #[arg(short = 'u', long, value_name = "USER")]
+    pub user: Option<String>,
+
     /// Mount a host directory. `:staged` uses a guest-local working copy and syncs on exit.
     #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro|rw|staged]")]
     pub volume: Vec<String>,
@@ -226,6 +231,7 @@ impl RunCmd {
                 let config = RunConfig::new(img, command)
                     .with_env(env)
                     .with_workdir(self.workdir)
+                    .with_user(self.user.clone())
                     .with_mounts(mount_bindings.clone())
                     .with_tty(self.tty);
                 client.run_interactive(config)?
@@ -233,6 +239,7 @@ impl RunCmd {
                 let config = RunConfig::new(img, command)
                     .with_env(env)
                     .with_workdir(self.workdir)
+                    .with_user(self.user.clone())
                     .with_mounts(mount_bindings.clone());
                 let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
                 if !stdout.is_empty() {

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -168,6 +168,9 @@ impl UpCmd {
 
         // Workdir: [dev].workdir > top-level workdir
         let workdir = dev.workdir.or(sf.workdir);
+        // User: same precedence, so a checked-in Smolfile can run the workload
+        // as the account that owns a mounted host directory.
+        let user = dev.user.or(sf.user);
 
         // Create or update record
         let ports_tuples = PortMapping::to_tuples(&ports);
@@ -194,6 +197,7 @@ impl UpCmd {
             record.image = sf.image.clone();
             record.env = env.clone();
             record.workdir = workdir.clone();
+            record.user = user.clone();
             record.init = init_cmds.clone();
             record.entrypoint = sf.entrypoint.clone();
             record.cmd = sf.cmd.clone();
@@ -310,6 +314,7 @@ impl UpCmd {
                     let config = RunConfig::new(image, argv)
                         .with_env(env.clone())
                         .with_workdir(workdir.clone())
+                        .with_user(user.clone())
                         .with_mounts(mount_bindings.clone())
                         .with_s3_volumes(smolvm::remote_volume::to_s3_volumes(
                             &remote_volumes,


### PR DESCRIPTION
A machine can now run its workload as a chosen account, matching the engine's user directive.