### PR TITLE
Keep Harbor transfers off the event loop

### DIFF
--- a/sdk/python/python/smol/harbor.py
+++ b/sdk/python/python/smol/harbor.py
@@ -53,6 +53,33 @@ _SHELL_USER_EXEC = (
 _TRANSFER_DIR = PurePosixPath("/tmp")
 
 
+def _read_local_file(source: Path) -> tuple[bytes, int]:
+    return source.read_bytes(), source.stat().st_mode & 0o777
+
+
+def _write_local_file(target: Path, payload: bytes) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(payload)
+
+
+def _archive_directory(source: Path) -> bytes:
+    with tempfile.TemporaryDirectory() as tmp:
+        archive = Path(tmp) / "upload.tar.gz"
+        with tarfile.open(archive, "w:gz") as bundle:
+            for child in source.iterdir():
+                bundle.add(child, arcname=child.name, recursive=True)
+        return archive.read_bytes()
+
+
+def _extract_directory(payload: bytes, target: Path) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        archive = Path(tmp) / "download.tar.gz"
+        archive.write_bytes(payload)
+        with tarfile.open(archive, "r:gz") as bundle:
+            bundle.extractall(target, filter="data")
+
+
 def _machine_name(value: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9-]+", "-", value).strip("-").lower()
     return (normalized or "harbor")[:128].rstrip("-")
@@ -627,11 +654,8 @@ class SmolEnvironment(BaseEnvironment):
                 raise RuntimeError(
                     f"failed to create upload directory {parent!r}: {result.stderr}"
                 )
-        await machine.write_file(
-            target_path,
-            source.read_bytes(),
-            mode=source.stat().st_mode & 0o777,
-        )
+        payload, mode = await asyncio.to_thread(_read_local_file, source)
+        await machine.write_file(target_path, payload, mode=mode)
 
     @override
     async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
@@ -639,14 +663,8 @@ class SmolEnvironment(BaseEnvironment):
         if not source.is_dir():
             raise NotADirectoryError(source)
         transfer = _TRANSFER_DIR / f"smol-harbor-{uuid.uuid4().hex}.tar.gz"
-        with tempfile.TemporaryDirectory() as tmp:
-            archive = Path(tmp) / "upload.tar.gz"
-            with tarfile.open(archive, "w:gz") as bundle:
-                for child in source.iterdir():
-                    bundle.add(child, arcname=child.name, recursive=True)
-            await self._require_machine().write_file(
-                str(transfer), archive.read_bytes()
-            )
+        payload = await asyncio.to_thread(_archive_directory, source)
+        await self._require_machine().write_file(str(transfer), payload)
         command = (
             f"mkdir -p {shlex.quote(target_dir)} && "
             f"tar xzf {shlex.quote(str(transfer))} -C {shlex.quote(target_dir)}; "
@@ -661,8 +679,8 @@ class SmolEnvironment(BaseEnvironment):
     @override
     async def download_file(self, source_path: str, target_path: Path | str) -> None:
         target = Path(target_path)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(await self._require_machine().read_file(source_path))
+        payload = await self._require_machine().read_file(source_path)
+        await asyncio.to_thread(_write_local_file, target, payload)
 
     @override
     async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
@@ -678,13 +696,7 @@ class SmolEnvironment(BaseEnvironment):
         finally:
             with contextlib.suppress(Exception):
                 await self.exec(f"rm -f {shlex.quote(str(transfer))}", user="root")
-        target = Path(target_dir)
-        target.mkdir(parents=True, exist_ok=True)
-        with tempfile.TemporaryDirectory() as tmp:
-            archive = Path(tmp) / "download.tar.gz"
-            archive.write_bytes(payload)
-            with tarfile.open(archive, "r:gz") as bundle:
-                bundle.extractall(target, filter="data")
+        await asyncio.to_thread(_extract_directory, payload, Path(target_dir))
 
 
 __all__ = ["SmolEnvironment", "close_harbor_goldens"]

--- a/sdk/python/tests/test_harbor_adapter.py
+++ b/sdk/python/tests/test_harbor_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from pathlib import Path
 from typing import ClassVar
 
@@ -155,6 +156,71 @@ async def test_cold_environment_maps_resources_exec_and_files(tmp_path: Path) ->
     machine = env._machine
     await env.stop(delete=True)
     assert machine.deleted is True
+
+
+@pytest.mark.asyncio
+async def test_local_transfer_work_runs_off_the_event_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env = _environment(tmp_path, auto_checkpoint=False)
+    await env.start(force_build=False)
+
+    source_file = tmp_path / "source.txt"
+    source_file.write_text("file payload")
+    source_dir = tmp_path / "source-dir"
+    (source_dir / "nested").mkdir(parents=True)
+    (source_dir / "nested" / "payload.txt").write_text("directory payload")
+    directory_payload = adapter._archive_directory(source_dir)
+
+    event_loop_thread = threading.get_ident()
+    worker_threads: dict[str, int] = {}
+
+    def record_thread(name, function):
+        def wrapper(*args):
+            worker_threads[name] = threading.get_ident()
+            return function(*args)
+
+        return wrapper
+
+    for name in (
+        "_read_local_file",
+        "_write_local_file",
+        "_archive_directory",
+        "_extract_directory",
+    ):
+        monkeypatch.setattr(
+            adapter,
+            name,
+            record_thread(name, getattr(adapter, name)),
+        )
+
+    await env.upload_file(source_file, "/workspace/source.txt")
+    await env.upload_dir(source_dir, "/workspace/source-dir")
+
+    env._machine.files["/workspace/result.txt"] = b"downloaded file"
+
+    async def read_file(path: str) -> bytes:
+        if path.startswith("/tmp/smol-harbor-"):
+            return directory_payload
+        return env._machine.files[path]
+
+    monkeypatch.setattr(env._machine, "read_file", read_file)
+    downloaded_file = tmp_path / "downloaded" / "result.txt"
+    downloaded_dir = tmp_path / "downloaded-dir"
+    await env.download_file("/workspace/result.txt", downloaded_file)
+    await env.download_dir("/workspace/source-dir", downloaded_dir)
+
+    assert downloaded_file.read_bytes() == b"downloaded file"
+    assert (downloaded_dir / "nested" / "payload.txt").read_text() == (
+        "directory payload"
+    )
+    assert set(worker_threads) == {
+        "_read_local_file",
+        "_write_local_file",
+        "_archive_directory",
+        "_extract_directory",
+    }
+    assert all(thread != event_loop_thread for thread in worker_threads.values())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Moves Harbor archive, extraction, and local file I/O onto bounded worker threads so concurrent trials remain responsive.