### PR TITLE
Let the Node and Python SDKs run a machine's workload as a chosen user

### DIFF
--- a/sdk/node/src/machine.rs
+++ b/sdk/node/src/machine.rs
@@ -104,6 +104,7 @@ impl NapiMachine {
             .map(|item| (item.key, item.value))
             .collect();
         let workdir = config.workdir;
+        let user = config.user;
         let spec = MachineSpec {
             name: config.name.clone(),
             mounts,
@@ -119,7 +120,7 @@ impl NapiMachine {
 
         runtime()
             .into_napi()?
-            .create_machine_with_workload(spec, env, workdir)
+            .create_machine_with_workload(spec, env, workdir, user)
             .into_napi()?;
 
         Ok(Self { name: config.name })

--- a/sdk/node/src/types.rs
+++ b/sdk/node/src/types.rs
@@ -38,6 +38,8 @@ pub struct MachineConfig {
     pub env: Option<Vec<EnvVar>>,
     /// Working directory for the image workload.
     pub workdir: Option<String>,
+    /// Run the workload as this user (image user name or `uid[:gid]`).
+    pub user: Option<String>,
     /// Host directories to mount into the VM.
     pub mounts: Option<Vec<HostMountConfig>>,
     /// Port mappings from host to guest.

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -156,6 +156,10 @@ export interface MachineConfig {
   /** Working directory for the image workload, set at create. Overrides
    *  the image's own workdir. */
   workdir?: string;
+  /** Run the workload as this user: a name from the image or a numeric
+   *  `uid[:gid]`. Overrides the image's USER, so a workload can match the
+   *  owner of a mounted host directory. */
+  user?: string;
 }
 
 /** Per-call execution options. */

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -216,6 +216,8 @@ def _native_config(name: str, config: MachineConfig) -> dict:
         cfg["env"] = dict(config.env)
     if config.workdir is not None:
         cfg["workdir"] = config.workdir
+    if config.user is not None:
+        cfg["user"] = config.user
     if config.mounts:
         cfg["mounts"] = [
             {

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -127,6 +127,10 @@ class MachineConfig:
     workdir: Optional[str] = None
     """Working directory for the image workload, set at create. Overrides the
     image's own workdir."""
+    user: Optional[str] = None
+    """Run the workload as this user: a name from the image or a numeric
+    ``uid[:gid]``. Overrides the image's USER, so a workload can match the owner
+    of a mounted host directory."""
 
     def __post_init__(self) -> None:
         # Native/cloud transports retain the compatibility `forkable` field.

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -421,6 +421,11 @@ impl Machine {
             .filter(|value| !value.is_none())
             .map(|value| value.extract())
             .transpose()?;
+        let user = config
+            .get_item("user")?
+            .filter(|value| !value.is_none())
+            .map(|value| value.extract())
+            .transpose()?;
         let command = config
             .get_item("command")?
             .filter(|value| !value.is_none())
@@ -443,7 +448,7 @@ impl Machine {
             ..Default::default()
         };
         let runtime = runtime().map_err(err)?;
-        py.allow_threads(|| runtime.create_machine_with_workload(spec, env, workdir))
+        py.allow_threads(|| runtime.create_machine_with_workload(spec, env, workdir, user))
             .map_err(err)?;
         Ok(Self { name })
     }


### PR DESCRIPTION
A create can now name the account the workload runs as, matching the engine's user directive and the argument its embedded runtime now takes.