### PR TITLE
Call the hosted service smol cloud in the SDK READMEs instead of its internal name

### DIFF
--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -10,7 +10,7 @@ guest escape lands there and not in your application.
 > Linux 2023). The **cloud** transport works anywhere the package installs.
 > Not yet prebuilt: macOS Intel, and Linux with glibc < 2.34.
 
-Run the **same code** against the local embedded engine or the smolfleet **cloud** —
+Run the **same code** against the local embedded engine or **smol cloud** —
 the backend is chosen by `ConnectOptions`:
 
 ```ts
@@ -23,7 +23,7 @@ const local = await Machine.create({ resources: { cpus: 2, memoryMb: 1024 } });
 const source = await Machine.create({ image: 'alpine', network: true, branchable: true });
 const branch = await source.branch('b1');
 
-// Cloud (smolfleet) — pass an API key, or set SMOL_CLOUD_TOKEN.
+// smol cloud — pass an API key, or set SMOL_CLOUD_TOKEN.
 const cloud = await Machine.create(
   { image: 'python:3.12' },
   { target: 'cloud' }, // uses SMOL_CLOUD_TOKEN

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,7 +1,7 @@
 # smol — Python SDK
 
 Embed isolated **microVM sandboxes** directly in your Python code. Same API
-locally (embedded engine, no server) or against the **smolfleet cloud** — the
+locally (embedded engine, no server) or against **smol cloud** — the
 backend is chosen via `ConnectOptions` / `SMOL_CLOUD_TOKEN`. Mirrors the
 [Node SDK](../node).
 
@@ -28,7 +28,7 @@ with Machine.create(MachineConfig(resources=ResourceSpec(cpus=2, memory_mb=1024,
 source = Machine.create(MachineConfig(image="alpine", network=True, branchable=True))
 branch = source.branch("b1")
 
-# Cloud (smolfleet) — create() waits until it is ready for work.
+# smol cloud — create() waits until it is ready for work.
 from smol import ConnectOptions
 m = Machine.create(
     MachineConfig(image="alpine:3.20"),
@@ -244,8 +244,8 @@ Dockerfile-only tasks fail clearly instead of silently changing semantics.
   `smol-node` NAPI crate. The local API is **synchronous** (the engine blocks).
   The extension is in your process; the VMM is not — it runs as a separate
   `smol-vmm` helper, seccomp- and Landlock-confined on Linux.
-- **Cloud transport**: a REST client to smolfleet `/v1` whose request/response
-  shapes match smolfleet's OpenAPI contract (Bearer `smk_…`).
+- **Cloud transport**: a REST client to smol cloud `/v1` whose request/response
+  shapes match smol cloud's OpenAPI contract (Bearer `smk_…`).
 
 ### Disposable workers: wait for `ready`, then connect (cloud)
 


### PR DESCRIPTION
The published Node and Python SDK READMEs named the hosted service smolfleet, which is the internal name for the control plane and means nothing to a reader installing the package. Call it smol cloud in both READMEs.