### PR TITLE
Call the hosted service smol cloud in the README and CLI docs instead of its internal name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ directly in your **Node** or **Python** app.
 **The same code runs on your laptop and in the cloud.** One `Machine` API, two
 transports: `local` boots a microVM on the machine you are sitting at (bundled
 engine, no server, no account), `cloud` runs the identical calls on
-**smolfleet**. Develop and test against a real VM offline, then move the same
+**smol cloud**. Develop and test against a real VM offline, then move the same
 program to managed capacity by changing where it connects — not what it does:
 
 ```ts
 const spec = { image: 'alpine', network: true };
 
 const dev  = await Machine.create(spec);                       // local: this machine
-const prod = await Machine.create(spec, { target: 'cloud' });  // smolfleet
+const prod = await Machine.create(spec, { target: 'cloud' });  // smol cloud
 ```
 
 Create, exec, files, state, stop, delete — and branching — behave the same on
@@ -34,7 +34,7 @@ up front on cloud rather than silently dropped.)
 ```
 ┌──────────────┐     ┌──────────────────────────── one Machine API ┐
 │   smol CLI   │     │  LocalTransport  ──▶ embedded smolvm microVM  │
-│  (Rust)      │     │  CloudTransport  ──▶ smolfleet /v1 (REST)     │
+│  (Rust)      │     │  CloudTransport  ──▶ smol cloud /v1 (REST)    │
 └──────────────┘     └──────────────────────────────────────────────┘
 ```
 
@@ -99,7 +99,7 @@ const fleet = await source.branchBatch({ count: 8, namePrefix: 'run' });
 
 Branches are the unit of work for agents and CI: a fresh, VM-isolated machine
 per task without paying boot + setup each time. They work on both transports —
-locally against the machine in front of you, and on smolfleet, where a batch is
+locally against the machine in front of you, and on smol cloud, where a batch is
 atomic (all N branches or none). A branch is always node-local: it lives on the
 same host as its parent, because it shares that parent's memory pages.
 
@@ -119,7 +119,7 @@ try {
   await m.delete();
 }
 
-// Cloud: same API, just point at smolfleet.
+// Cloud: same API, just point at smol cloud.
 const c = await Machine.create(
   { image: 'alpine:3.20' },
   { target: 'cloud' }, // uses SMOL_CLOUD_TOKEN
@@ -163,7 +163,7 @@ smol machine exec --name mybox -- apk add curl
 smol machine ls                                    # lists local + cloud
 smol machine rm mybox
 
-# cloud (smolfleet)
+# smol cloud
 smol auth login
 smol cloud deploy --image alpine:3.20
 smol machine ls --cloud

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,7 @@
 # smol CLI reference
 
 `smol` manages microVM sandboxes locally (in-process, via the bundled smolvm
-engine) and on the **smolfleet** cloud. Run `smol <command> --help` for the
+engine) and on **smol cloud**. Run `smol <command> --help` for the
 exact flags of any command — this page is the map.
 
 Global behavior:
@@ -12,10 +12,10 @@ Global behavior:
 - Commands are grouped under nouns: `smol machine …` (a machine's whole
   lifecycle), `smol file …` (Smolfile), `smol pack …` (artifacts),
   `smol registry …` (registries), `smol auth …` (login), `smol cloud …`
-  (smolfleet), and `smol rollout …` (fused policy generation). `smol run`
+  (hosted machines), and `smol rollout …` (fused policy generation). `smol run`
   (ephemeral one-shot) stays top-level.
 - **Local or cloud is resolved automatically.** `smol machine …` commands find a
-  machine wherever it lives — local engine or smolfleet — so `smol machine ls`
+  machine wherever it lives — local engine or smol cloud — so `smol machine ls`
   shows both. Force one side with `--local` / `--cloud`, or with a `local/<name>`
   / `cloud/<name>` prefix (a `mach-…` id is always cloud).
 
@@ -87,9 +87,9 @@ pass `--api-url` when it listens elsewhere.
 
 | Command | Description |
 |---------|-------------|
-| `smol auth login` / `smol auth logout` | Authenticate to the registry and cloud (OAuth device flow) — one token covers both the artifact registry and the smolfleet API. |
+| `smol auth login` / `smol auth logout` | Authenticate to the registry and cloud (OAuth device flow) — one token covers both the artifact registry and the smol cloud API. |
 
-## Cloud (smolfleet) — `smol cloud …`
+## smol cloud — `smol cloud …`
 
 Cloud machines are also reachable through `smol machine …` with `--cloud` (or a
 `cloud/<name>` prefix); this group holds the cloud-only operations.


### PR DESCRIPTION
The README and CLI reference named the hosted service smolfleet, the internal name for the control plane, which means nothing to a reader arriving at the project. Call it smol cloud in both, keeping the architecture diagram's alignment intact.