### PR TITLE
Let a cloud deploy create a branchable machine so it can be forked, and move the pinned engine to 1.14.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.13.1"
+version = "1.14.5"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.13.1"
+version = "1.14.5"
 dependencies = [
  "async-stream",
  "axum",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.13.1"
+version = "1.14.5"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.13.1"
+version = "1.14.5"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.13.1"
+version = "1.14.5"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.13.1"
+version = "1.14.5"
 dependencies = [
  "base64",
  "serde",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.13.1"
+version = "1.14.5"
 dependencies = [
  "bytes",
  "dirs",

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -43,6 +43,12 @@ pub struct DeployCmd {
     #[arg(long)]
     pub network: bool,
 
+    /// Make the machine branchable (copy-on-write memory and disks) so
+    /// `smol machine branch --cloud` can fork it. Branchability is decided
+    /// when the machine is created and cannot be turned on later.
+    #[arg(long = "branchable", visible_alias = "forkable")]
+    pub branchable: bool,
+
     /// Scope egress to these CIDR ranges (repeatable). Implies `--network`;
     /// the machine can reach only the listed CIDRs (plus any `--allow-host`).
     #[arg(long = "allow-cidr", value_name = "CIDR")]
@@ -247,6 +253,12 @@ impl DeployCmd {
             "ports": [{ "port": self.port }],
             "public": self.public,
         });
+        // Only sent when asked: a branchable machine backs its guest RAM with a
+        // memfd and keeps a control socket, which an ordinary deploy does not
+        // need. Same field name the fork request uses.
+        if self.branchable {
+            body["branchable"] = serde_json::json!(true);
+        }
         // Optional command override, shell-split into argv. Omitted when unset so
         // the machine runs the source image's/artifact's own entrypoint (default).
         if let Some(cmd) = &self.command {


### PR DESCRIPTION
A cloud machine can only be branched if it was created branchable, but the deploy command had no way to ask for that, so `smol machine branch --cloud` was unreachable from the CLI and refused every deployed machine with "recreate it with branchable: true"; the pinned engine also moves from 1.13.1 to 1.14.5 to match main. Verified end to end against the live API: a branchable deploy branches in 0.996s, the child inherits the source's filesystem state, and a write in the child does not appear in the source.