### PR TITLE
Add --stream to cloud exec so a hosted command writes output as it is produced

### DIFF
--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -655,6 +655,14 @@ pub struct CloudExecArgs {
     #[arg(long, value_name = "SECONDS")]
     pub timeout: Option<u64>,
 
+    /// Write output as it is produced instead of buffering until the command
+    /// exits. Without this a command that prints over ten minutes returns
+    /// nothing for ten minutes, which reads as a hang to whoever is watching
+    /// and hides progress from an agent deciding what to do next. Streaming
+    /// also lifts the buffered path's cap on captured output.
+    #[arg(long, conflicts_with = "detach")]
+    pub stream: bool,
+
     /// Start the command and return immediately, leaving it running in the
     /// machine. Its output is appended to a log under /workspace, which
     /// survives stop/start; read it back with `smol cloud logs`.
@@ -826,7 +834,7 @@ impl CloudCmd {
                     command,
                     interactive: false,
                     tty: false,
-                    stream: false,
+                    stream: a.stream,
                     env,
                     workdir: a.workdir,
                     user: a.user,


### PR DESCRIPTION
The streaming exec path already existed and was reachable as `smol machine exec --cloud --stream`, but `smol cloud exec` hardcoded it off and exposed no flag, so every hosted exec buffered until the command exited. A command that prints over ten minutes returned nothing for ten minutes.

The flag conflicts with `--detach`, which returns immediately and has no output to stream. Verified against a hosted machine: output arrives a second apart as produced, exit codes propagate, stdout and stderr stay separate, and the default stays buffered.