### PR TITLE
Expose incremental checkpoints in the CLI and SDKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "base64",
  "serde",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.14.5"
+version = "1.14.6"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.14.5"
+version = "1.14.6"
 dependencies = [
  "async-stream",
  "axum",
@@ -2492,11 +2492,12 @@ dependencies = [
  "utoipa-swagger-ui",
  "windows-sys 0.60.2",
  "zeroize",
+ "zstd",
 ]
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.14.5"
+version = "1.14.6"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
@@ -2505,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.14.5"
+version = "1.14.6"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2518,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.14.5"
+version = "1.14.6"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2537,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.14.5"
+version = "1.14.6"
 dependencies = [
  "base64",
  "serde",
@@ -2547,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.14.5"
+version = "1.14.6"
 dependencies = [
  "bytes",
  "dirs",

--- a/build.rs
+++ b/build.rs
@@ -63,13 +63,10 @@ fn is_lfs_pointer(path: &Path) -> bool {
     false
 }
 
-/// Link libkrun — weak on macOS so the binary can start without it
-/// (packed binary mode uses dlopen instead of link-time symbols).
+/// Linux loads libkrun through the engine; macOS retains weak linking.
 fn link_krun() {
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-arg=-Wl,-weak-lkrun");
-    #[cfg(not(target_os = "macos"))]
-    println!("cargo:rustc-link-lib=krun");
 }
 
 fn main() {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,6 +39,10 @@ Global behavior:
 | `smol machine cp <src> <dst>` | Copy files host↔guest (`name:/path` denotes a guest path). |
 | `smol machine logs <name>` | Fetch machine logs (`--tail N`). |
 | `smol machine branch --from <source> --name <child>` | Create an independent child from a running branchable machine (copy-on-write RAM + disks). Use `--branchable` on the child to branch again. `fork`, `--golden`, and `--forkable` remain compatibility aliases. |
+| `smol machine checkpoint --name <source> --store <store> --output <point.smolcheckpoint>` | Capture a periodic local rollback point as a self-contained directory while reusing unchanged RAM and disk chunks from the store. Omit `--store` to write one portable file. |
+| `smol machine checkpoint --export-from <point> --output <file.smolcheckpoint>` | Export a stored checkpoint directory as one portable file. |
+| `smol machine checkpoint-prune --store <store>` | Reclaim objects that no retained checkpoint in the store references. |
+| `smol machine restore --checkpoint <point-or-file> --name <machine>` | Restore a stored directory or portable checkpoint as a running branch source. |
 | `smol machine images --name <name>` | List a machine's cached images and storage usage (`--json`). |
 | `smol machine prune --name <name>` | Reclaim a machine's disk: free unreferenced layers, or `--all` to purge the cache (`--dry-run` to preview; `--all` requires the machine stopped). |
 | `smol machine update --name <name> …` | Modify a **stopped** machine: add/remove volumes/ports/env, set `--cpus`/`--mem`/`--workdir`, toggle `--net`/`--gpu`, expand `--storage`/`--overlay` (expand-only). |

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "async-stream",
  "axum",
@@ -2432,11 +2432,12 @@ dependencies = [
  "utoipa-swagger-ui",
  "windows-sys 0.60.2",
  "zeroize",
+ "zstd",
 ]
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
@@ -2445,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2458,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2477,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "base64",
  "serde",
@@ -2487,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "bytes",
  "dirs",

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "base64",
  "serde",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "bytes",
  "dirs",

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -23,6 +23,13 @@ const local = await Machine.create({ resources: { cpus: 2, memoryMb: 1024 } });
 const source = await Machine.create({ image: 'alpine', network: true, branchable: true });
 const branch = await source.branch('b1');
 
+// Periodic local rollback points reuse unchanged RAM and disk chunks.
+const first = await source.checkpoint('./points/1.smolcheckpoint', { store: './points/store' });
+const second = await source.checkpoint('./points/2.smolcheckpoint', { store: './points/store' });
+await Machine.restoreCheckpoint('./points/2.smolcheckpoint', 'restored');
+Machine.exportCheckpoint('./points/2.smolcheckpoint', './point-2.smolcheckpoint');
+Machine.pruneCheckpointStore('./points/store');
+
 // smol cloud — pass an API key, or set SMOL_CLOUD_TOKEN.
 const cloud = await Machine.create(
   { image: 'python:3.12' },
@@ -161,6 +168,8 @@ try {
 - `machine.readFile(path)` / `machine.writeFile(path, data, mode?)`.
 - `machine.pullImage(image)` / `machine.listImages()`.
 - `machine.branch(name, options?)` / `machine.branchBatch(options)`.
+- `machine.checkpoint(output, { store? })`, `Machine.restoreCheckpoint(...)`,
+  `Machine.exportCheckpoint(...)`, and `Machine.pruneCheckpointStore(...)`.
 - `machine.stop()` / `machine.delete()` / `await machine.state()`. Cloud
   `"started"` means VM launched, not ready for work.
 

--- a/sdk/node/binding.d.ts
+++ b/sdk/node/binding.d.ts
@@ -24,6 +24,8 @@ export interface MachineConfig {
   env?: Array<EnvVar>
   /** Working directory for the image workload. */
   workdir?: string
+  /** Run the workload as this user (image user name or `uid[:gid]`). */
+  user?: string
   /** Host directories to mount into the VM. */
   mounts?: Array<HostMountConfig>
   /** Port mappings from host to guest. */
@@ -119,8 +121,10 @@ export interface ImageInfo {
 }
 /** Result of writing a portable live checkpoint to local disk. */
 export interface LocalCheckpointResult {
-  /** Compressed artifact size in bytes. */
+  /** Compressed artifact bytes written by this capture. */
   sizeBytes: number
+  /** Logical bytes reused from earlier checkpoints in the store. */
+  reusedBytes: number
   /** Source pause at the RAM/disk consistency boundary, in milliseconds. */
   sourcePauseMs: number
   /** Complete capture and compression time, in milliseconds. */
@@ -156,6 +160,10 @@ export declare class NapiMachine {
   static connect(name: string): NapiMachine
   /** Create a stopped machine from a portable live checkpoint on disk. */
   static restoreCheckpoint(name: string, artifact: string): NapiMachine
+  /** Export a stored checkpoint directory as one portable checkpoint file. */
+  static exportCheckpoint(source: string, output: string): number
+  /** Remove objects that no retained checkpoint in a local store references. */
+  static pruneCheckpointStore(store: string): number
   /** Get the machine name. */
   get name(): string
   /**
@@ -185,7 +193,7 @@ export declare class NapiMachine {
    */
   startForkable(): Promise<void>
   /** Capture this running checkpointable machine to local disk. */
-  checkpoint(output: string): Promise<LocalCheckpointResult>
+  checkpoint(output: string, store?: string | undefined | null): Promise<LocalCheckpointResult>
   /**
    * Fork this running, forkable machine into a new clone via copy-on-write
    * live RAM + disks (same host). `ports` are `{ host, guest }` inbound

--- a/sdk/node/build.rs
+++ b/sdk/node/build.rs
@@ -25,8 +25,6 @@ fn is_lfs_pointer(path: &Path) -> bool {
 fn link_krun() {
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-arg=-Wl,-weak-lkrun");
-    #[cfg(not(target_os = "macos"))]
-    println!("cargo:rustc-link-lib=krun");
 }
 
 fn main() {

--- a/sdk/node/index.ts
+++ b/sdk/node/index.ts
@@ -41,6 +41,7 @@ export type {
   PortSpec,
   BranchOptions,
   BranchBatchOptions,
+  CheckpointOptions,
   ForkOptions,
   ForkBatchOptions,
   AssignOptions,

--- a/sdk/node/machine.ts
+++ b/sdk/node/machine.ts
@@ -9,7 +9,9 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { ExecutionError } from "./errors";
+import { resolve as resolvePath } from "node:path";
+import { ExecutionError, wrapNativeError } from "./errors";
+import { getNapiMachine } from "./native";
 import {
   makeTransport,
   connectTransport,
@@ -21,6 +23,7 @@ import type {
   AssignOptions,
   BranchBatchOptions,
   BranchOptions,
+  CheckpointOptions,
   ConnectOptions,
   ExecEvent,
   ExecOptions,
@@ -110,6 +113,24 @@ export class Machine {
     conn?: ConnectOptions,
   ): Promise<Machine> {
     return new Machine(await restoreCheckpointTransport(checkpointId, name, conn));
+  }
+
+  /** Export a local stored checkpoint directory as one portable file. */
+  static exportCheckpoint(source: string, output: string): number {
+    try {
+      return getNapiMachine().exportCheckpoint(resolvePath(source), resolvePath(output));
+    } catch (error) {
+      throw wrapNativeError(error);
+    }
+  }
+
+  /** Remove objects that no retained checkpoint in a local store references. */
+  static pruneCheckpointStore(store: string): number {
+    try {
+      return getNapiMachine().pruneCheckpointStore(resolvePath(store));
+    } catch (error) {
+      throw wrapNativeError(error);
+    }
   }
 
   /** Restore a local `.smolcheckpoint` path or durable cloud checkpoint id.
@@ -294,9 +315,13 @@ export class Machine {
   }
 
   /** Capture this running checkpointable machine. Local capture requires an
-   * output `.smolcheckpoint` path; cloud capture stores the artifact durably. */
-  checkpoint(output?: string): Promise<PortableCheckpointInfo> {
-    return this.transport.checkpoint(output);
+   * output path; with `store`, it is a self-contained directory, otherwise a
+   * `.smolcheckpoint` file. Cloud capture stores the artifact durably. */
+  checkpoint(
+    output?: string,
+    options?: CheckpointOptions,
+  ): Promise<PortableCheckpointInfo> {
+    return this.transport.checkpoint(output, options);
   }
 
   /** List durable portable checkpoints captured from this machine. */

--- a/sdk/node/native.ts
+++ b/sdk/node/native.ts
@@ -70,6 +70,7 @@ export interface NativeImageInfo {
 
 export interface NativeCheckpointResult {
   sizeBytes: number;
+  reusedBytes: number;
   sourcePauseMs: number;
   elapsedMs: number;
 }
@@ -95,7 +96,7 @@ export interface NapiMachine {
   guestPorts(): number[];
   start(): Promise<void>;
   startForkable(): Promise<void>;
-  checkpoint(output: string): Promise<NativeCheckpointResult>;
+  checkpoint(output: string, store?: string): Promise<NativeCheckpointResult>;
   fork(
     name: string,
     ports?: NativePortMapping[],
@@ -133,6 +134,8 @@ export interface NapiMachineCtor {
   new (config: NativeMachineConfig): NapiMachine;
   connect(name: string): NapiMachine;
   restoreCheckpoint(name: string, artifact: string): NapiMachine;
+  exportCheckpoint(source: string, output: string): number;
+  pruneCheckpointStore(store: string): number;
 }
 
 import { wireBundledAssets, type RuntimeAssets } from "./assets";

--- a/sdk/node/src/machine.rs
+++ b/sdk/node/src/machine.rs
@@ -148,6 +148,25 @@ impl NapiMachine {
         Ok(Self { name })
     }
 
+    /// Export a stored checkpoint directory as one portable checkpoint file.
+    #[napi]
+    pub fn export_checkpoint(source: String, output: String) -> napi::Result<f64> {
+        smolvm::checkpoint_store::export(
+            std::path::Path::new(&source),
+            std::path::Path::new(&output),
+        )
+        .map(|bytes| bytes as f64)
+        .map_err(|error| napi::Error::from_reason(format!("export checkpoint: {error}")))
+    }
+
+    /// Remove objects that no retained checkpoint in a local store references.
+    #[napi]
+    pub fn prune_checkpoint_store(store: String) -> napi::Result<f64> {
+        smolvm::checkpoint_store::prune(std::path::Path::new(&store))
+            .map(|bytes| bytes as f64)
+            .map_err(|error| napi::Error::from_reason(format!("prune checkpoint store: {error}")))
+    }
+
     /// Get the machine name.
     #[napi(getter)]
     pub fn name(&self) -> String {
@@ -248,24 +267,26 @@ impl NapiMachine {
 
     /// Capture this running checkpointable machine to local disk.
     #[napi]
-    pub async fn checkpoint(&self, output: String) -> napi::Result<LocalCheckpointResult> {
+    pub async fn checkpoint(
+        &self,
+        output: String,
+        store: Option<String>,
+    ) -> napi::Result<LocalCheckpointResult> {
         let name = self.name.clone();
         let result = tokio::task::spawn_blocking(move || {
             let options = smolvm::portable_checkpoint::CaptureOptions {
+                store_dir: store.map(std::path::PathBuf::from),
                 rootfs_dir: Some(smolvm::agent::AgentManager::default_rootfs_path()?),
                 ..Default::default()
             };
-            runtime()?.checkpoint_machine(
-                &name,
-                std::path::Path::new(&output),
-                &options,
-            )
+            runtime()?.checkpoint_machine(&name, std::path::Path::new(&output), &options)
         })
         .await
         .map_err(join_error)?
         .into_napi()?;
         Ok(LocalCheckpointResult {
             size_bytes: result.size_bytes as f64,
+            reused_bytes: result.reused_bytes as f64,
             source_pause_ms: result.source_pause.as_secs_f64() * 1000.0,
             elapsed_ms: result.elapsed.as_secs_f64() * 1000.0,
         })

--- a/sdk/node/src/types.rs
+++ b/sdk/node/src/types.rs
@@ -164,8 +164,10 @@ pub struct ImageInfo {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct LocalCheckpointResult {
-    /// Compressed artifact size in bytes.
+    /// Compressed artifact bytes written by this capture.
     pub size_bytes: f64,
+    /// Logical bytes reused from earlier checkpoints in the store.
+    pub reused_bytes: f64,
     /// Source pause at the RAM/disk consistency boundary, in milliseconds.
     pub source_pause_ms: f64,
     /// Complete capture and compression time, in milliseconds.

--- a/sdk/node/test/checkpoint-branch-e2e.ts
+++ b/sdk/node/test/checkpoint-branch-e2e.ts
@@ -25,14 +25,14 @@ async function main(): Promise<void> {
       branchable: true,
     });
     await source.writeFile("/dev/shm/ram-marker", "RAM-STATE");
-    await source.writeFile("/tmp/disk-marker", "DISK-STATE");
+    await source.writeFile("/root/disk-marker", "DISK-STATE");
 
     const first = await source.checkpoint(firstArtifact, { store });
     if (first.path !== firstArtifact || first.sizeBytes <= 0) {
       throw new Error("local checkpoint metadata was incomplete");
     }
     await source.writeFile("/dev/shm/ram-marker", "RAM-STATE-2");
-    await source.writeFile("/tmp/disk-marker", "DISK-STATE-2");
+    await source.writeFile("/root/disk-marker", "DISK-STATE-2");
     const second = await source.checkpoint(secondArtifact, { store });
     if (!second.reusedBytes || second.reusedBytes <= 0) {
       throw new Error("periodic checkpoint did not reuse existing objects");
@@ -55,7 +55,7 @@ async function main(): Promise<void> {
 
     restored = await Machine.restoreCheckpoint(secondArtifact, `sdk-restored-${suffix}`);
     const ram = (await restored.readFile("/dev/shm/ram-marker")).toString();
-    const disk = (await restored.readFile("/tmp/disk-marker")).toString();
+    const disk = (await restored.readFile("/root/disk-marker")).toString();
     if (ram !== "RAM-STATE-2" || disk !== "DISK-STATE-2") {
       throw new Error(`restored state mismatch: ram=${ram} disk=${disk}`);
     }

--- a/sdk/node/test/checkpoint-branch-e2e.ts
+++ b/sdk/node/test/checkpoint-branch-e2e.ts
@@ -1,13 +1,17 @@
 /** Real local portable-checkpoint and native batch-branch smoke test. */
 
-import { rmSync } from "node:fs";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Machine } from "../index";
 
 async function main(): Promise<void> {
   const suffix = `${process.pid}-${Date.now()}`;
-  const artifact = join(tmpdir(), `smol-sdk-${suffix}.smolcheckpoint`);
+  const root = mkdtempSync(join(tmpdir(), `smol-sdk-${suffix}-`));
+  const store = join(root, "store");
+  const firstArtifact = join(root, "checkpoint-1.smolcheckpoint");
+  const secondArtifact = join(root, "checkpoint-2.smolcheckpoint");
+  const portableArtifact = join(root, "checkpoint-2-portable.smolcheckpoint");
   let source: Machine | undefined;
   let restored: Machine | undefined;
   const children: Machine[] = [];
@@ -23,23 +27,36 @@ async function main(): Promise<void> {
     await source.writeFile("/dev/shm/ram-marker", "RAM-STATE");
     await source.writeFile("/tmp/disk-marker", "DISK-STATE");
 
-    const checkpoint = await source.checkpoint(artifact);
-    if (checkpoint.path !== artifact || checkpoint.sizeBytes <= 0) {
+    const first = await source.checkpoint(firstArtifact, { store });
+    if (first.path !== firstArtifact || first.sizeBytes <= 0) {
       throw new Error("local checkpoint metadata was incomplete");
+    }
+    await source.writeFile("/dev/shm/ram-marker", "RAM-STATE-2");
+    await source.writeFile("/tmp/disk-marker", "DISK-STATE-2");
+    const second = await source.checkpoint(secondArtifact, { store });
+    if (!second.reusedBytes || second.reusedBytes <= 0) {
+      throw new Error("periodic checkpoint did not reuse existing objects");
+    }
+    rmSync(firstArtifact, { recursive: true });
+    const reclaimed = Machine.pruneCheckpointStore(store);
+    if (reclaimed <= 0) throw new Error("checkpoint prune reclaimed no objects");
+    const exportedBytes = Machine.exportCheckpoint(secondArtifact, portableArtifact);
+    if (exportedBytes <= 0 || statSync(portableArtifact).size <= 0) {
+      throw new Error("stored checkpoint export was empty");
     }
     const sourceAlive = await source.exec([
       "sh",
       "-c",
-      'test "$(cat /dev/shm/ram-marker)" = RAM-STATE && echo SOURCE-ALIVE',
+      'test "$(cat /dev/shm/ram-marker)" = RAM-STATE-2 && echo SOURCE-ALIVE',
     ]);
     if (sourceAlive.stdout.trim() !== "SOURCE-ALIVE") {
       throw new Error("source did not continue after checkpoint capture");
     }
 
-    restored = await Machine.restoreCheckpoint(artifact, `sdk-restored-${suffix}`);
+    restored = await Machine.restoreCheckpoint(secondArtifact, `sdk-restored-${suffix}`);
     const ram = (await restored.readFile("/dev/shm/ram-marker")).toString();
     const disk = (await restored.readFile("/tmp/disk-marker")).toString();
-    if (ram !== "RAM-STATE" || disk !== "DISK-STATE") {
+    if (ram !== "RAM-STATE-2" || disk !== "DISK-STATE-2") {
       throw new Error(`restored state mismatch: ram=${ram} disk=${disk}`);
     }
 
@@ -64,7 +81,7 @@ async function main(): Promise<void> {
     await Promise.allSettled(children.map((machine) => machine.delete()));
     if (restored) await restored.delete().catch(() => {});
     if (source) await source.delete().catch(() => {});
-    rmSync(artifact, { force: true });
+    rmSync(root, { recursive: true, force: true });
   }
 }
 

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -24,6 +24,7 @@ import {
   wrapNativeError,
 } from "./errors";
 import type {
+  CheckpointOptions,
   ConnectOptions,
   ExecEvent,
   ExecOptions,
@@ -121,7 +122,7 @@ export interface Transport {
   share(): Promise<ShareLink>;
   /** Cloud only: revoke the machine's anonymous share link. */
   unshare(): Promise<void>;
-  checkpoint(output?: string): Promise<PortableCheckpointInfo>;
+  checkpoint(output?: string, options?: CheckpointOptions): Promise<PortableCheckpointInfo>;
   checkpoints(): Promise<PortableCheckpointInfo[]>;
   fork(name: string, options?: PortSpec[] | ForkOptions): Promise<Transport>;
   forkBatch(opts: ForkBatchOptions): Promise<Transport[]>;
@@ -535,19 +536,24 @@ class LocalTransport implements Transport {
     );
   }
 
-  async checkpoint(output?: string): Promise<PortableCheckpointInfo> {
+  async checkpoint(
+    output?: string,
+    options: CheckpointOptions = {},
+  ): Promise<PortableCheckpointInfo> {
     if (!output) {
       throw new InvalidConfigError(
         "local checkpoint capture requires an output .smolcheckpoint path.",
       );
     }
     const path = resolvePath(output);
-    const result = await this.inner.checkpoint(path);
+    const store = options.store ? resolvePath(options.store) : undefined;
+    const result = await this.inner.checkpoint(path, store);
     return {
       id: path,
       machineId: this.name,
       status: "available",
       sizeBytes: result.sizeBytes,
+      reusedBytes: result.reusedBytes,
       arch: process.arch,
       createdAt: new Date().toISOString(),
       downloadUrl: "",
@@ -1171,7 +1177,15 @@ class CloudTransport implements Transport {
     );
   }
 
-  async checkpoint(output?: string): Promise<PortableCheckpointInfo> {
+  async checkpoint(
+    output?: string,
+    options: CheckpointOptions = {},
+  ): Promise<PortableCheckpointInfo> {
+    if (options.store) {
+      throw new InvalidConfigError(
+        "checkpoint stores are local-only; cloud checkpoints are managed by Smol Cloud.",
+      );
+    }
     if (output) {
       throw new InvalidConfigError(
         "cloud checkpoint capture returns durable metadata; use its downloadUrl to save an artifact.",

--- a/sdk/node/types.ts
+++ b/sdk/node/types.ts
@@ -98,6 +98,13 @@ export interface BranchBatchOptions {
 /** Backwards-compatible name for {@link BranchBatchOptions}. */
 export type ForkBatchOptions = BranchBatchOptions;
 
+/** Options for a local checkpoint capture. A store reuses unchanged chunks
+ * across periodic captures; cloud checkpoints are deduplicated server-side. */
+export interface CheckpointOptions {
+  /** Local content-addressed checkpoint store directory. */
+  store?: string;
+}
+
 /** Options for assigning an RL episode — fork + provision one clone of a forkable
  *  golden under an idempotent lease. Cloud target only. */
 export interface AssignOptions {
@@ -298,6 +305,8 @@ export interface PortableCheckpointInfo {
   machineId: string;
   status: string;
   sizeBytes: number;
+  /** Logical bytes reused from prior captures in the local store. */
+  reusedBytes?: number;
   arch: string;
   createdAt: string;
   downloadUrl: string;

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "async-stream",
  "axum",
@@ -2432,11 +2432,12 @@ dependencies = [
  "utoipa-swagger-ui",
  "windows-sys 0.60.2",
  "zeroize",
+ "zstd",
 ]
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
@@ -2445,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2458,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2477,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "base64",
  "serde",
@@ -2487,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.13.1"
+version = "1.14.6"
 dependencies = [
  "bytes",
  "dirs",

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "smolfile"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "base64",
  "serde",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.14.6"
+version = "1.15.1"
 dependencies = [
  "bytes",
  "dirs",

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -28,6 +28,13 @@ with Machine.create(MachineConfig(resources=ResourceSpec(cpus=2, memory_mb=1024,
 source = Machine.create(MachineConfig(image="alpine", network=True, branchable=True))
 branch = source.branch("b1")
 
+# Periodic local rollback points reuse unchanged RAM and disk chunks.
+first = source.checkpoint("./points/1.smolcheckpoint", store="./points/store")
+second = source.checkpoint("./points/2.smolcheckpoint", store="./points/store")
+restored = Machine.restore_checkpoint("./points/2.smolcheckpoint", "restored")
+Machine.export_checkpoint("./points/2.smolcheckpoint", "./point-2.smolcheckpoint")
+Machine.prune_checkpoint_store("./points/store")
+
 # smol cloud — create() waits until it is ready for work.
 from smol import ConnectOptions
 m = Machine.create(

--- a/sdk/python/python/smol/async_machine.py
+++ b/sdk/python/python/smol/async_machine.py
@@ -103,6 +103,16 @@ class AsyncMachine:
         """Restore a local artifact or cloud checkpoint; alias of ``restore_checkpoint``."""
         return await cls.restore_checkpoint(checkpoint_id, name, conn)
 
+    @staticmethod
+    async def export_checkpoint(source: str, output: str) -> int:
+        """Export a local stored checkpoint directory as one portable file."""
+        return await asyncio.to_thread(Machine.export_checkpoint, source, output)
+
+    @staticmethod
+    async def prune_checkpoint_store(store: str) -> int:
+        """Remove objects unreferenced by retained checkpoints in a local store."""
+        return await asyncio.to_thread(Machine.prune_checkpoint_store, store)
+
     @property
     def name(self) -> str:
         """The machine's name / identifier."""
@@ -232,9 +242,11 @@ class AsyncMachine:
         """Revoke this machine's anonymous share link (cloud target)."""
         await asyncio.to_thread(self._m.unshare)
 
-    async def checkpoint(self, output: Optional[str] = None) -> PortableCheckpointInfo:
-        """Capture this machine; local capture requires a `.smolcheckpoint` path."""
-        return await asyncio.to_thread(self._m.checkpoint, output)
+    async def checkpoint(
+        self, output: Optional[str] = None, *, store: Optional[str] = None
+    ) -> PortableCheckpointInfo:
+        """Capture this machine, optionally reusing a local checkpoint store."""
+        return await asyncio.to_thread(self._m.checkpoint, output, store=store)
 
     async def checkpoints(self) -> "list[PortableCheckpointInfo]":
         """List durable portable checkpoints captured from this machine."""

--- a/sdk/python/python/smol/machine.py
+++ b/sdk/python/python/smol/machine.py
@@ -12,15 +12,18 @@ Mirrors the Node SDK's ``machine.ts`` (sync, since the embedded engine blocks)::
 
 from __future__ import annotations
 
+import os
 import uuid
 from typing import Any, Optional
 
 from .transport import (
     Transport,
+    _load_native,
     connect_transport,
     make_transport,
     restore_checkpoint_transport,
 )
+from .errors import wrap_native_error
 from .types import (
     ConnectOptions,
     ExecOptions,
@@ -102,6 +105,31 @@ class Machine:
                 conn,
             )
         )
+
+    @staticmethod
+    def export_checkpoint(source: str, output: str) -> int:
+        """Export a local stored checkpoint directory as one portable file."""
+        try:
+            return int(
+                _load_native().Machine.export_checkpoint(
+                    os.path.abspath(source),
+                    os.path.abspath(output),
+                )
+            )
+        except Exception as error:  # noqa: BLE001
+            raise wrap_native_error(error) from error
+
+    @staticmethod
+    def prune_checkpoint_store(store: str) -> int:
+        """Remove objects unreferenced by retained checkpoints in a local store."""
+        try:
+            return int(
+                _load_native().Machine.prune_checkpoint_store(
+                    os.path.abspath(store)
+                )
+            )
+        except Exception as error:  # noqa: BLE001
+            raise wrap_native_error(error) from error
 
     @classmethod
     def restore(
@@ -259,9 +287,11 @@ class Machine:
         existing URL immediately stops granting access."""
         self._t.unshare()
 
-    def checkpoint(self, output: Optional[str] = None) -> PortableCheckpointInfo:
-        """Capture this machine; local capture requires a `.smolcheckpoint` path."""
-        return self._t.checkpoint(output)
+    def checkpoint(
+        self, output: Optional[str] = None, *, store: Optional[str] = None
+    ) -> PortableCheckpointInfo:
+        """Capture this machine, optionally reusing a local checkpoint store."""
+        return self._t.checkpoint(output, store=store)
 
     def checkpoints(self) -> "list[PortableCheckpointInfo]":
         """List durable portable checkpoints captured from this machine."""

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -85,6 +85,9 @@ def _checkpoint_from(r: dict[str, Any]) -> PortableCheckpointInfo:
         machine_id=str(r.get("machineId", "")),
         status=str(r.get("status", "")),
         size_bytes=int(r.get("sizeBytes", 0)),
+        reused_bytes=(
+            int(r["reusedBytes"]) if r.get("reusedBytes") is not None else None
+        ),
         arch=str(r.get("arch", "")),
         created_at=str(r.get("createdAt", "")),
         download_url=str(r.get("downloadUrl", "")),
@@ -125,7 +128,9 @@ class Transport(Protocol):
     def usage(self) -> MachineUsageReport: ...
     def share(self) -> ShareLink: ...
     def unshare(self) -> None: ...
-    def checkpoint(self, output: Optional[str] = None) -> PortableCheckpointInfo: ...
+    def checkpoint(
+        self, output: Optional[str] = None, *, store: Optional[str] = None
+    ) -> PortableCheckpointInfo: ...
     def checkpoints(self) -> "list[PortableCheckpointInfo]": ...
     def fork(
         self,
@@ -500,14 +505,17 @@ class LocalTransport:
             "unshare() is cloud-only; a local machine has no share link to revoke."
         )
 
-    def checkpoint(self, output: Optional[str] = None) -> PortableCheckpointInfo:
+    def checkpoint(
+        self, output: Optional[str] = None, *, store: Optional[str] = None
+    ) -> PortableCheckpointInfo:
         if not output:
             raise InvalidConfigError(
                 "local checkpoint capture requires an output .smolcheckpoint path."
             )
         path = os.path.abspath(os.fspath(output))
         try:
-            result = self._inner.checkpoint(path)
+            store_path = os.path.abspath(os.fspath(store)) if store else None
+            result = self._inner.checkpoint(path, store_path)
         except Exception as e:  # noqa: BLE001
             raise wrap_native_error(e) from e
         return PortableCheckpointInfo(
@@ -515,6 +523,7 @@ class LocalTransport:
             machine_id=self.name,
             status="available",
             size_bytes=int(result.size_bytes),
+            reused_bytes=int(result.reused_bytes),
             arch=platform.machine(),
             created_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             download_url="",
@@ -890,7 +899,13 @@ class CloudTransport:
     def unshare(self) -> None:
         _cloud_fetch(self._base, self._key, "DELETE", f"/v1/machines/{self._id}/share")
 
-    def checkpoint(self, output: Optional[str] = None) -> PortableCheckpointInfo:
+    def checkpoint(
+        self, output: Optional[str] = None, *, store: Optional[str] = None
+    ) -> PortableCheckpointInfo:
+        if store:
+            raise InvalidConfigError(
+                "checkpoint stores are local-only; cloud checkpoints are managed by Smol Cloud."
+            )
         if output:
             raise InvalidConfigError(
                 "cloud checkpoint capture returns durable metadata; use its download_url to save an artifact."

--- a/sdk/python/python/smol/types.py
+++ b/sdk/python/python/smol/types.py
@@ -258,6 +258,7 @@ class PortableCheckpointInfo:
     arch: str
     created_at: str
     download_url: str
+    reused_bytes: Optional[int] = None
     path: Optional[str] = None
     source_pause_ms: Optional[float] = None
     elapsed_ms: Optional[float] = None

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -133,6 +133,8 @@ struct LocalCheckpointResult {
     #[pyo3(get)]
     size_bytes: u64,
     #[pyo3(get)]
+    reused_bytes: u64,
+    #[pyo3(get)]
     source_pause_ms: f64,
     #[pyo3(get)]
     elapsed_ms: f64,
@@ -475,6 +477,23 @@ impl Machine {
         Ok(Self { name })
     }
 
+    /// Export a stored checkpoint directory as one portable checkpoint file.
+    #[staticmethod]
+    fn export_checkpoint(source: String, output: String) -> PyResult<u64> {
+        smolvm::checkpoint_store::export(
+            std::path::Path::new(&source),
+            std::path::Path::new(&output),
+        )
+        .map_err(|error| PyRuntimeError::new_err(format!("export checkpoint: {error}")))
+    }
+
+    /// Remove objects that no retained checkpoint in a local store references.
+    #[staticmethod]
+    fn prune_checkpoint_store(store: String) -> PyResult<u64> {
+        smolvm::checkpoint_store::prune(std::path::Path::new(&store))
+            .map_err(|error| PyRuntimeError::new_err(format!("prune checkpoint store: {error}")))
+    }
+
     #[getter]
     fn name(&self) -> String {
         self.name.clone()
@@ -512,23 +531,27 @@ impl Machine {
     }
 
     /// Capture this running checkpointable machine to local disk.
-    fn checkpoint(&self, py: Python<'_>, output: String) -> PyResult<LocalCheckpointResult> {
+    #[pyo3(signature = (output, store=None))]
+    fn checkpoint(
+        &self,
+        py: Python<'_>,
+        output: String,
+        store: Option<String>,
+    ) -> PyResult<LocalCheckpointResult> {
         let runtime = runtime().map_err(err)?;
         let result = py
             .allow_threads(|| {
                 let options = smolvm::portable_checkpoint::CaptureOptions {
+                    store_dir: store.map(std::path::PathBuf::from),
                     rootfs_dir: Some(smolvm::agent::AgentManager::default_rootfs_path()?),
                     ..Default::default()
                 };
-                runtime.checkpoint_machine(
-                    &self.name,
-                    std::path::Path::new(&output),
-                    &options,
-                )
+                runtime.checkpoint_machine(&self.name, std::path::Path::new(&output), &options)
             })
             .map_err(err)?;
         Ok(LocalCheckpointResult {
             size_bytes: result.size_bytes,
+            reused_bytes: result.reused_bytes,
             source_pause_ms: result.source_pause.as_secs_f64() * 1000.0,
             elapsed_ms: result.elapsed.as_secs_f64() * 1000.0,
         })

--- a/sdk/python/tests/test_checkpoint_store_e2e.py
+++ b/sdk/python/tests/test_checkpoint_store_e2e.py
@@ -1,0 +1,60 @@
+"""Real periodic-checkpoint lifecycle through the public Python SDK."""
+
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+from smol import Machine, MachineConfig, ResourceSpec
+
+
+def main() -> None:
+    suffix = f"{time.time_ns()}"
+    root = Path(tempfile.mkdtemp(prefix="smol-python-checkpoint-"))
+    store = root / "store"
+    first = root / "first.smolcheckpoint"
+    second = root / "second.smolcheckpoint"
+    portable = root / "second-portable.smolcheckpoint"
+    source = None
+    restored = None
+    try:
+        source = Machine.create(
+            MachineConfig(
+                name=f"python-checkpoint-source-{suffix}",
+                persistent=True,
+                branchable=True,
+                resources=ResourceSpec(cpus=2, memory_mb=1024),
+            )
+        )
+        source.write_file("/dev/shm/ram-marker", b"RAM-1")
+        source.write_file("/workspace/disk-marker", b"DISK-1")
+        initial = source.checkpoint(str(first), store=str(store))
+        assert initial.size_bytes > 0
+
+        source.write_file("/dev/shm/ram-marker", b"RAM-2")
+        source.write_file("/workspace/disk-marker", b"DISK-2")
+        incremental = source.checkpoint(str(second), store=str(store))
+        assert incremental.reused_bytes and incremental.reused_bytes > 0
+
+        shutil.rmtree(first)
+        assert Machine.prune_checkpoint_store(str(store)) > 0
+        assert Machine.export_checkpoint(str(second), str(portable)) > 0
+        assert portable.is_file()
+
+        restored = Machine.restore_checkpoint(
+            str(second), f"python-checkpoint-restored-{suffix}"
+        )
+        assert restored.read_file("/dev/shm/ram-marker") == b"RAM-2"
+        assert restored.read_file("/workspace/disk-marker") == b"DISK-2"
+        assert source.exec(["echo", "SOURCE-ALIVE"]).stdout.strip() == "SOURCE-ALIVE"
+        print("checkpoint-store-e2e: passed")
+    finally:
+        if restored is not None:
+            restored.delete()
+        if source is not None:
+            source.delete()
+        shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/tests/test_unit.py
+++ b/sdk/python/tests/test_unit.py
@@ -4,14 +4,21 @@ import json
 import os
 import sys
 import tempfile
+from types import SimpleNamespace
 from pathlib import Path
 from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
 
-from smol.errors import ExecutionError, SmolError, wrap_native_error  # noqa: E402
+from smol.errors import (  # noqa: E402
+    ExecutionError,
+    InvalidConfigError,
+    SmolError,
+    wrap_native_error,
+)
 from smol.rollout import RolloutClient, RolloutError, adapter_sha256  # noqa: E402
 from smol import transport as transport_module  # noqa: E402
+from smol import machine as machine_module  # noqa: E402
 from smol.transport import (  # noqa: E402
     _cli_config_api_key,
     _encode_path,
@@ -226,6 +233,70 @@ def test_connect_preserves_frozen_checkpoint_without_readiness_wait():
             "checkpoint", ConnectOptions(target="local")
         )
     assert connected.state() == "frozen"
+
+
+def test_local_checkpoint_forwards_store_and_reports_reuse():
+    calls = []
+
+    class Inner:
+        name = "source"
+
+        @staticmethod
+        def checkpoint(output, store):
+            calls.append((output, store))
+            return SimpleNamespace(
+                size_bytes=123,
+                reused_bytes=456,
+                source_pause_ms=7.0,
+                elapsed_ms=8.0,
+            )
+
+    with tempfile.TemporaryDirectory() as root:
+        transport = transport_module.LocalTransport(Inner(), cleanup_on_exit=False)
+        output = str(Path(root) / "point")
+        store = str(Path(root) / "store")
+        checkpoint = transport.checkpoint(output, store=store)
+        assert calls == [(os.path.abspath(output), os.path.abspath(store))]
+        assert checkpoint.size_bytes == 123
+        assert checkpoint.reused_bytes == 456
+
+
+def test_cloud_checkpoint_rejects_local_store_without_network_call():
+    transport = transport_module.CloudTransport("https://x", "smk_k", "mID", "name")
+    try:
+        transport.checkpoint(store="./store")
+        raise AssertionError("cloud capture accepted a local checkpoint store")
+    except InvalidConfigError:
+        pass
+
+
+def test_checkpoint_store_management_uses_native_engine():
+    calls = []
+
+    class NativeMachine:
+        @staticmethod
+        def export_checkpoint(source, output):
+            calls.append(("export", source, output))
+            return 100
+
+        @staticmethod
+        def prune_checkpoint_store(store):
+            calls.append(("prune", store))
+            return 25
+
+    with tempfile.TemporaryDirectory() as root:
+        source = str(Path(root) / "source")
+        output = str(Path(root) / "point.smolcheckpoint")
+        store = str(Path(root) / "store")
+        with mock.patch.object(
+            machine_module, "_load_native", return_value=SimpleNamespace(Machine=NativeMachine)
+        ):
+            assert machine_module.Machine.export_checkpoint(source, output) == 100
+            assert machine_module.Machine.prune_checkpoint_store(store) == 25
+    assert calls == [
+        ("export", os.path.abspath(source), os.path.abspath(output)),
+        ("prune", os.path.abspath(store)),
+    ]
 
 
 def test_native_config_forwards_image_workload_env_and_workdir():

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -8,10 +8,23 @@ use tokio::io::AsyncWriteExt;
 #[derive(Args, Debug)]
 pub struct CheckpointCmd {
     /// Running checkpointable machine (name, `local/name`, or `cloud/name`).
-    #[arg(short = 'n', long = "name")]
-    pub machine: String,
+    #[arg(
+        short = 'n',
+        long = "name",
+        required_unless_present = "export_from",
+        conflicts_with = "export_from"
+    )]
+    pub machine: Option<String>,
 
-    /// Destination `.smolcheckpoint` file.
+    /// Export a stored checkpoint directory as one portable file.
+    #[arg(long, value_name = "CHECKPOINT", conflicts_with_all = ["store", "cloud"])]
+    pub export_from: Option<PathBuf>,
+
+    /// Reuse unchanged chunks here; output becomes a self-contained directory.
+    #[arg(long, value_name = "DIR", conflicts_with = "cloud")]
+    pub store: Option<PathBuf>,
+
+    /// Destination `.smolcheckpoint` file or stored checkpoint directory.
     #[arg(short, long, value_name = "PATH")]
     pub output: PathBuf,
 
@@ -31,39 +44,62 @@ impl CheckpointCmd {
         if self.output.exists() {
             anyhow::bail!("refusing to overwrite {}", self.output.display());
         }
-        let (location, handle) = resolve::route(
-            Some(&self.machine),
-            Target::from_flags(self.local, self.cloud)?,
-        )?;
-        self.machine = handle;
+        if let Some(source) = self.export_from.as_deref() {
+            let bytes = smolvm::checkpoint_store::export(source, &self.output)?;
+            println!(
+                "Exported checkpoint to {} ({:.1} MiB)",
+                self.output.display(),
+                bytes as f64 / (1024.0 * 1024.0),
+            );
+            return Ok(());
+        }
+        let machine = self
+            .machine
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("--name is required"))?;
+        let (location, handle) =
+            resolve::route(Some(machine), Target::from_flags(self.local, self.cloud)?)?;
+        self.machine = Some(handle);
         match location {
             Location::Local => self.run_local(),
+            Location::Cloud if self.store.is_some() => {
+                anyhow::bail!("--store is available only for local checkpoints")
+            }
             Location::Cloud => self.run_cloud(),
         }
     }
 
     fn run_local(self) -> anyhow::Result<()> {
+        let machine = self.machine.expect("machine was resolved");
         let runtime = smolvm::embedded::EmbeddedRuntime::new()?;
         let options = smolvm::portable_checkpoint::CaptureOptions {
+            store_dir: self.store.clone(),
             rootfs_dir: Some(smolvm::agent::AgentManager::default_rootfs_path()?),
             ..Default::default()
         };
-        let result = runtime.checkpoint_machine(&self.machine, &self.output, &options)?;
+        let result = runtime.checkpoint_machine(&machine, &self.output, &options)?;
         println!(
-            "Checkpointed '{}' to {} ({:.1} MiB, {:.1} ms pause, {:.1} ms total)",
-            self.machine,
+            "Checkpointed '{}' to {} ({:.1} MiB written, {:.1} ms pause, {:.1} ms total)",
+            machine,
             self.output.display(),
             result.size_bytes as f64 / (1024.0 * 1024.0),
             result.source_pause.as_secs_f64() * 1000.0,
             result.elapsed.as_secs_f64() * 1000.0,
         );
+        if self.store.is_some() {
+            println!(
+                "Reused {:.1} MiB from existing checkpoint objects",
+                result.reused_bytes as f64 / (1024.0 * 1024.0),
+            );
+        }
         Ok(())
     }
 
     fn run_cloud(self) -> anyhow::Result<()> {
+        let machine = self.machine.expect("machine was resolved");
         let output = self.output;
         super::cloud::run_cloud_command(
-            Some(self.machine),
+            Some(machine),
             move |http, endpoint, machine_id| async move {
                 let response = http
                     .post(format!("{endpoint}/v1/machines/{machine_id}/checkpoints"))
@@ -110,6 +146,25 @@ impl CheckpointCmd {
                 Ok(())
             },
         )
+    }
+}
+
+/// Remove objects that no retained checkpoint in a local store references.
+#[derive(Args, Debug)]
+pub struct CheckpointPruneCmd {
+    /// Store used by `machine checkpoint --store`.
+    #[arg(long, value_name = "DIR")]
+    pub store: PathBuf,
+}
+
+impl CheckpointPruneCmd {
+    pub fn run(self) -> anyhow::Result<()> {
+        let bytes = smolvm::checkpoint_store::prune(&self.store)?;
+        println!(
+            "Reclaimed {:.1} MiB of unreferenced checkpoint objects",
+            bytes as f64 / (1024.0 * 1024.0),
+        );
+        Ok(())
     }
 }
 

--- a/src/commands/machine.rs
+++ b/src/commands/machine.rs
@@ -79,6 +79,10 @@ pub enum MachineSubcommand {
     /// Persist a live machine as a portable rollback point
     Checkpoint(crate::commands::checkpoint::CheckpointCmd),
 
+    /// Remove unused objects from a local incremental checkpoint store
+    #[command(name = "checkpoint-prune")]
+    CheckpointPrune(crate::commands::checkpoint::CheckpointPruneCmd),
+
     /// Restore a portable rollback point as a running fork source
     Restore(crate::commands::restore::RestoreCmd),
 
@@ -133,6 +137,7 @@ impl MachineCmd {
             MachineSubcommand::Branch(cmd) => cmd.run(),
             MachineSubcommand::BranchBatch(cmd) => cmd.run(),
             MachineSubcommand::Checkpoint(cmd) => cmd.run(),
+            MachineSubcommand::CheckpointPrune(cmd) => cmd.run(),
             MachineSubcommand::Restore(cmd) => cmd.run(),
             // maintenance
             MachineSubcommand::Images(cmd) => cmd.run(),
@@ -210,6 +215,51 @@ mod tests {
             assert_eq!(batch.golden, "source");
             assert_eq!(batch.count, Some(2));
         }
+    }
+
+    #[test]
+    fn checkpoint_supports_incremental_capture_export_and_prune() {
+        let parsed = TestCli::parse_from([
+            "smol",
+            "checkpoint",
+            "--name",
+            "source",
+            "--store",
+            "/tmp/store",
+            "--output",
+            "/tmp/point.smolcheckpoint",
+        ]);
+        let MachineSubcommand::Checkpoint(checkpoint) = parsed.command else {
+            panic!("expected checkpoint command");
+        };
+        assert_eq!(checkpoint.machine.as_deref(), Some("source"));
+        assert_eq!(
+            checkpoint.store.as_deref(),
+            Some(std::path::Path::new("/tmp/store"))
+        );
+
+        let parsed = TestCli::parse_from([
+            "smol",
+            "checkpoint",
+            "--export-from",
+            "/tmp/point.smolcheckpoint",
+            "--output",
+            "/tmp/point-portable.smolcheckpoint",
+        ]);
+        let MachineSubcommand::Checkpoint(checkpoint) = parsed.command else {
+            panic!("expected checkpoint export");
+        };
+        assert!(checkpoint.machine.is_none());
+        assert_eq!(
+            checkpoint.export_from.as_deref(),
+            Some(std::path::Path::new("/tmp/point.smolcheckpoint"))
+        );
+
+        let parsed = TestCli::parse_from(["smol", "checkpoint-prune", "--store", "/tmp/store"]);
+        let MachineSubcommand::CheckpointPrune(prune) = parsed.command else {
+            panic!("expected checkpoint prune");
+        };
+        assert_eq!(prune.store, std::path::PathBuf::from("/tmp/store"));
     }
 
     #[test]


### PR DESCRIPTION
Expose periodic incremental checkpoints, standalone export, and store pruning through the smol CLI and Node and Python SDKs after smol-machines/smolvm#1232 lands.