### PR TITLE
Allow long-running cloud machine starts

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -150,6 +150,8 @@ jobs:
         run: python tests/test_cloud_mock.py
       - name: Cloud start-failure surfacing (mock /v1 server; pure Python)
         run: python tests/test_cloud_start_error.py
+      - name: Cloud start timeout (pure Python)
+        run: python tests/test_cloud_start_timeout.py
       - name: Cloud no-port readiness probe (mock /v1 server; pure Python)
         run: python tests/test_cloud_ready_no_ports.py
       - name: Async-transport tests (AsyncMachine vs mock /v1; pure Python)

--- a/sdk/node/transport.ts
+++ b/sdk/node/transport.ts
@@ -654,6 +654,10 @@ const DEFAULT_CLOUD_URL = "https://api.smolmachines.com";
 
 /** Default per-request timeout for cloud calls (ms). Override via opts.timeoutMs. */
 const CLOUD_TIMEOUT_MS = 30_000;
+// Starting can include a cold image pull. Keep ordinary API calls short, but
+// give this explicitly long-running operation the same bounded window already
+// used by checkpoint restore.
+const CLOUD_START_TIMEOUT_MS = 30 * 60 * 1_000;
 // Grace before falling back to the guest-agent probe for a machine with no
 // published port: give `ready` time to flip first, so the probe stays a last
 // resort and never preempts a machine legitimately about to become ready.
@@ -1125,7 +1129,9 @@ class CloudTransport implements Transport {
 
   async start(): Promise<void> {
     // Resume a stopped machine, then wait for its agent so the handle is usable.
-    await cloudFetch(this.conn, "POST", `/v1/machines/${this.id}/start`);
+    await cloudFetch(this.conn, "POST", `/v1/machines/${this.id}/start`, {
+      timeoutMs: CLOUD_START_TIMEOUT_MS,
+    });
     await waitForReady(this.conn, this.id);
   }
 
@@ -1540,7 +1546,9 @@ export async function makeTransport(
       // be forked with Machine.fork (live-RAM CoW, RL rollouts).
       const startPath = `/v1/machines/${id}/start${resolveBranchable(config) ? "?forkable=true" : ""}`;
       try {
-        await cloudFetch(cloudConn, "POST", startPath);
+        await cloudFetch(cloudConn, "POST", startPath, {
+          timeoutMs: CLOUD_START_TIMEOUT_MS,
+        });
       } catch (e) {
         // waitForReady decides readiness; remember why start failed so a
         // subsequent readiness failure can surface it (the machine record

--- a/sdk/python/python/smol/transport.py
+++ b/sdk/python/python/smol/transport.py
@@ -42,6 +42,10 @@ from .types import (
 
 DEFAULT_CLOUD_URL = "https://api.smolmachines.com"
 CLOUD_TIMEOUT_S = 30.0
+# Starting can include a cold image pull. Keep ordinary API calls short, but
+# give this explicitly long-running operation the same bounded window already
+# used by checkpoint restore.
+CLOUD_START_TIMEOUT_S = 30 * 60.0
 # Grace before falling back to the guest-agent probe for a machine with no
 # published port: give the `ready` flag time to flip first, so the probe stays a
 # last resort and never preempts a machine that is legitimately about to become
@@ -859,7 +863,13 @@ class CloudTransport:
     def start(self) -> None:
         # Resume a stopped machine, then wait for its agent so the returned handle
         # is usable (the control plane returns as soon as it's `started`).
-        _cloud_fetch(self._base, self._key, "POST", f"/v1/machines/{self._id}/start")
+        _cloud_fetch(
+            self._base,
+            self._key,
+            "POST",
+            f"/v1/machines/{self._id}/start",
+            timeout=CLOUD_START_TIMEOUT_S,
+        )
         _wait_for_ready(self._base, self._key, self._id)
 
     def delete(self) -> None:
@@ -1461,7 +1471,13 @@ def make_transport(config: MachineConfig, conn: Optional[ConnectOptions] = None)
         start_error: Optional[str] = None
         try:
             try:
-                _cloud_fetch(base_url, api_key, "POST", start_path)
+                _cloud_fetch(
+                    base_url,
+                    api_key,
+                    "POST",
+                    start_path,
+                    timeout=CLOUD_START_TIMEOUT_S,
+                )
             except SmolError as e:
                 # Best-effort; _wait_for_ready is the gate. Remember the reason so
                 # a subsequent readiness failure can surface WHY start failed — the

--- a/sdk/python/tests/test_cloud_start_timeout.py
+++ b/sdk/python/tests/test_cloud_start_timeout.py
@@ -1,0 +1,78 @@
+"""Cloud starts get a long request deadline without relaxing other API calls."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+from smol import ConnectOptions, Machine, MachineConfig, transport  # noqa: E402
+
+
+def test_create_uses_long_timeout_for_cloud_start() -> None:
+    for forkable in (False, True):
+        starts: list[tuple[str, float]] = []
+
+        def fetch(base_url, api_key, method, path, **kwargs):
+            if method == "POST" and path == "/v1/machines":
+                return {"id": "mach-large", "name": "large-image"}
+            if method == "POST" and path.startswith("/v1/machines/mach-large/start"):
+                starts.append((path, kwargs.get("timeout", transport.CLOUD_TIMEOUT_S)))
+                return {"id": "mach-large", "state": "started"}
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+        with (
+            patch.object(transport, "_cloud_fetch", fetch),
+            patch.object(transport, "_wait_for_ready", lambda *args, **kwargs: None),
+        ):
+            machine = Machine.create(
+                MachineConfig(
+                    image="example.invalid/large:latest",
+                    forkable=forkable,
+                    ready_timeout_seconds=5,
+                ),
+                ConnectOptions(
+                    target="cloud", api_key="smk_test", base_url="http://cloud"
+                ),
+            )
+
+        assert machine.name == "large-image"
+        assert starts == [
+            (
+                "/v1/machines/mach-large/start"
+                + ("?forkable=true" if forkable else ""),
+                transport.CLOUD_START_TIMEOUT_S,
+            )
+        ]
+
+
+def test_resume_uses_long_timeout_for_cloud_start() -> None:
+    starts: list[float] = []
+
+    def fetch(base_url, api_key, method, path, **kwargs):
+        assert method == "POST"
+        assert path == "/v1/machines/mach-large/start"
+        starts.append(kwargs.get("timeout", transport.CLOUD_TIMEOUT_S))
+        return {"id": "mach-large", "state": "started"}
+
+    with (
+        patch.object(transport, "_cloud_fetch", fetch),
+        patch.object(transport, "_wait_for_ready", lambda *args, **kwargs: None),
+    ):
+        cloud = transport.CloudTransport(
+            "http://cloud", "smk_test", "mach-large", "large-image"
+        )
+        cloud.start()
+
+    assert starts == [transport.CLOUD_START_TIMEOUT_S]
+
+
+def main() -> int:
+    test_create_uses_long_timeout_for_cloud_start()
+    test_resume_uses_long_timeout_for_cloud_start()
+    print("RESULT=PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -954,6 +954,9 @@ fn checkpoint(args: CloudCheckpointArgs) -> Result<()> {
                     .await?;
                 let response = http
                     .post(format!("{endpoint}/v1/machines/{}/start", machine.id))
+                    .timeout(std::time::Duration::from_secs(
+                        super::common::HTTP_LONG_OPERATION_TIMEOUT_SECS,
+                    ))
                     .send()
                     .await?;
                 check_response(response, "start restored machine").await?;

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -12,6 +12,10 @@ pub const HTTP_CONNECT_TIMEOUT_SECS: u64 = 10;
 /// surfaces as an error instead of an indefinite hang.
 pub const HTTP_REQUEST_TIMEOUT_SECS: u64 = 30;
 
+/// Overall deadline for operations that may legitimately pull and unpack a
+/// large image before responding.
+pub const HTTP_LONG_OPERATION_TIMEOUT_SECS: u64 = 30 * 60;
+
 /// Build a reqwest client preconfigured with connect + request timeouts.
 /// All cloud- and auth-facing HTTP should go through this so no call can
 /// hang indefinitely. The returned builder lets callers add headers before

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -294,6 +294,9 @@ impl DeployCmd {
 
         let start_resp = http
             .post(format!("{}/v1/machines/{}/start", endpoint, machine.id))
+            .timeout(std::time::Duration::from_secs(
+                super::common::HTTP_LONG_OPERATION_TIMEOUT_SECS,
+            ))
             .send()
             .await?;
 

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -55,6 +55,9 @@ impl RestoreCmd {
             let response = http
                 .post(format!("{endpoint}/v1/machines/{}/start", machine.id))
                 .query(&[("wait_ready", "true")])
+                .timeout(std::time::Duration::from_secs(
+                    super::common::HTTP_LONG_OPERATION_TIMEOUT_SECS,
+                ))
                 .send()
                 .await?;
             super::cloud::check_response(response, "start restored machine").await?;

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -256,6 +256,9 @@ impl StartCmd {
         super::cloud::run_cloud_command(self.name, move |http, endpoint, id| async move {
             eprintln!("Starting {}...", id);
             let mut req = http.post(format!("{}/v1/machines/{}/start", endpoint, id));
+            req = req.timeout(std::time::Duration::from_secs(
+                super::common::HTTP_LONG_OPERATION_TIMEOUT_SECS,
+            ));
             if forkable {
                 // Start with cloneable live RAM so it can be branched later.
                 req = req.query(&[("forkable", "true")]);


### PR DESCRIPTION
Give cloud start operations a bounded 30-minute deadline so large image pulls can complete without relaxing timeouts for ordinary API calls.